### PR TITLE
Add more action types

### DIFF
--- a/templates/model/primitive.go
+++ b/templates/model/primitive.go
@@ -25,6 +25,9 @@ type String = valWithPos[string]
 // Bool represents a boolean field in a model, together with its location in the input file.
 type Bool = valWithPos[bool]
 
+// Bool represents an integer field in a model, together with its location in the input file.
+type Int = valWithPos[int]
+
 // valWithPos unmarshals a type T from YAML, and adds on the location in the YAML doc that it came
 // from. This allows helpful error messages.
 type valWithPos[T any] struct {

--- a/templates/model/primitive.go
+++ b/templates/model/primitive.go
@@ -25,7 +25,7 @@ type String = valWithPos[string]
 // Bool represents a boolean field in a model, together with its location in the input file.
 type Bool = valWithPos[bool]
 
-// Bool represents an integer field in a model, together with its location in the input file.
+// Int represents an integer field in a model, together with its location in the input file.
 type Int = valWithPos[int]
 
 // valWithPos unmarshals a type T from YAML, and adds on the location in the YAML doc that it came

--- a/templates/model/spec_test.go
+++ b/templates/model/spec_test.go
@@ -322,6 +322,92 @@ params:
   nonexistent: 'foo'`,
 			wantUnmarshalErr: `invalid config near line 4 column 3: unknown field name "nonexistent"`,
 		},
+		{
+			name: "regex_replace_success",
+			in: `desc: 'mydesc'
+action: 'regex_replace'
+params:
+  regex: 'my_regex'
+  subgroup: 1
+  with: 'some_template'`,
+			want: &Step{
+				Desc:   String{Val: "mydesc"},
+				Action: String{Val: "regex_replace"},
+				RegexReplace: &RegexReplace{
+					Regex:    String{Val: "my_regex"},
+					Subgroup: Int{Val: 1},
+					With:     String{Val: "some_template"},
+				},
+			},
+		},
+		{
+			name: "regex_negative_subgroup_should_fail",
+			in: `desc: 'mydesc'
+action: 'regex_replace'
+params:
+  regex: 'my_regex'
+  subgroup: -1
+  with: 'some_template'`,
+			wantValidateErr: `field "subgroup" must not be negative`,
+		},
+		{
+			name: "regex_missing_fields_should_fail",
+			in: `desc: 'mydesc'
+action: 'regex_replace'
+params:
+  subgroup: 1`,
+			wantValidateErr: `invalid config near line 4 column 3: field "regex" is required
+invalid config near line 4 column 3: field "with" is required`,
+		},
+		{
+			name: "string_replace_success",
+			in: `desc: 'mydesc'
+action: 'string_replace'
+params:
+  to_replace: 'abc'
+  with: 'def'`,
+			want: &Step{
+				Desc:   String{Val: "mydesc"},
+				Action: String{Val: "string_replace"},
+				StringReplace: &StringReplace{
+					ToReplace: String{Val: "abc"},
+					With:      String{Val: "def"},
+				},
+			},
+		},
+		{
+			name: "string_replace_missing_field_should_fail",
+			in: `desc: 'mydesc'
+action: 'string_replace'
+params:
+  with: 'def'`,
+			wantValidateErr: `invalid config near line 4 column 3: field "to_replace" is required`,
+		},
+		{
+			name: "go_template_success",
+			in: `desc: 'mydesc'
+action: 'go_template'
+params:
+  paths: ['my/path/1', 'my/path/2']`,
+			want: &Step{
+				Desc:   String{Val: "mydesc"},
+				Action: String{Val: "go_template"},
+				GoTemplate: &GoTemplate{
+					Paths: []String{
+						{Val: "my/path/1"},
+						{Val: "my/path/2"},
+					},
+				},
+			},
+		},
+		{
+			name: "go_template_missing_paths_should_fail",
+			in: `desc: 'mydesc'
+action: 'go_template'
+params:
+  paths: []`,
+			wantValidateErr: `invalid config near line 4 column 3: field "paths" is required`,
+		},
 	}
 
 	for _, tc := range cases {

--- a/templates/model/validate.go
+++ b/templates/model/validate.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"reflect"
 
+	"golang.org/x/exp/constraints"
 	"golang.org/x/exp/slices"
 	"gopkg.in/yaml.v3"
 )
@@ -34,6 +35,14 @@ func notZero[T comparable](pos *ConfigPos, x valWithPos[T], fieldName string) er
 func nonEmptySlice[T any](pos *ConfigPos, s []T, fieldName string) error {
 	if len(s) == 0 {
 		return pos.AnnotateErr(fmt.Errorf("field %q is required", fieldName))
+	}
+	return nil
+}
+
+func nonNegative[T constraints.Ordered](x valWithPos[T], fieldName string) error {
+	var zero T
+	if x.Val < zero {
+		return x.Pos.AnnotateErr(fmt.Errorf("field %q must not be negative", fieldName))
 	}
 	return nil
 }


### PR DESCRIPTION
This PR adds the remaining action types from the design doc: `regex_replace`, `string_replace`, and `go_template`. 