### PR TITLE
Implement the "include" and "print" actions

### DIFF
--- a/templates/commands/render.go
+++ b/templates/commands/render.go
@@ -42,6 +42,9 @@ const (
 	// make them identifiable.
 	templateDirNamePart = "template-copy"
 	scratchDirNamePart  = "scratch"
+
+	// Permission bits: rwx------
+	mkdirPerms = 0o700
 )
 
 type Render struct {
@@ -287,7 +290,7 @@ func (r *Render) realRun(ctx context.Context, rp *runParams) (outErr error) {
 	if err != nil {
 		return err
 	}
-	if err := rp.fs.MkdirAll(scratchDir, 0o700); err != nil {
+	if err := rp.fs.MkdirAll(scratchDir, mkdirPerms); err != nil {
 		return fmt.Errorf("failed to create scratch directory: MkdirAll(): %w", err)
 	}
 

--- a/templates/commands/render.go
+++ b/templates/commands/render.go
@@ -12,8 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package render implements the "templates render" subcommand for installing a template.
+// Package commands implements the template-related subcommands.
 package commands
+
+// This file implements the "templates render" subcommand for installing a template.
 
 import (
 	"context"

--- a/templates/commands/render.go
+++ b/templates/commands/render.go
@@ -411,18 +411,6 @@ func copyRecursive(pos *model.ConfigPos, from, to string, rfs renderFS) error {
 	})
 }
 
-func actionRegexReplace(ctx context.Context, p *model.RegexReplace, sp *stepParams) error {
-	return fmt.Errorf("not implemented")
-}
-
-func actionStringReplace(ctx context.Context, p *model.StringReplace, sp *stepParams) error {
-	return fmt.Errorf("not implemented")
-}
-
-func actionGoTemplate(ctx context.Context, p *model.GoTemplate, sp *stepParams) error {
-	return fmt.Errorf("not implemented")
-}
-
 func loadSpecFile(fs renderFS, templateDir, flagSpec string) (*model.Spec, error) {
 	f, err := fs.Open(filepath.Join(templateDir, flagSpec))
 	if err != nil {

--- a/templates/commands/render.go
+++ b/templates/commands/render.go
@@ -398,9 +398,6 @@ func copyRecursive(pos *model.ConfigPos, from, to string, rfs renderFS) error {
 			return fmt.Errorf("Stat(): %w", err)
 		}
 
-		// TODO: this arguable should be an atomic write so we don't end up with
-		// half-written files on error.
-		//
 		// The permission bits on the output file are copied from the input file;
 		// this preserves the execute bit on executable files.
 		if err := rfs.WriteFile(dst, buf, info.Mode().Perm()); err != nil {

--- a/templates/commands/render.go
+++ b/templates/commands/render.go
@@ -345,12 +345,12 @@ func parseGoTmpl(tpl string) (*template.Template, error) {
 func parseAndExecuteGoTmpl(m model.String, inputs map[string]string) (string, error) {
 	goTmpl, err := parseGoTmpl(m.Val)
 	if err != nil {
-		return "", model.ErrWithPos(m.Pos, `error compiling as go-template: %w`, err)
+		return "", model.ErrWithPos(m.Pos, `error compiling as go-template: %w`, err) //nolint:wrapcheck
 	}
 
-	sb := strings.Builder{}
+	var sb strings.Builder
 	if err := goTmpl.Execute(&sb, inputs); err != nil {
-		return "", model.ErrWithPos(m.Pos, "template.Execute() failed: %w", err)
+		return "", model.ErrWithPos(m.Pos, "template.Execute() failed: %w", err) //nolint:wrapcheck
 	}
 
 	return sb.String(), nil
@@ -368,7 +368,7 @@ func copyRecursive(pos *model.ConfigPos, from, to string, rfs renderFS) error {
 
 		relToSrc, err := filepath.Rel(from, path)
 		if err != nil {
-			return model.ErrWithPos(pos, "filepath.Rel(%s,%s): %w", from, path, err)
+			return model.ErrWithPos(pos, "filepath.Rel(%s,%s): %w", from, path, err) //nolint:wrapcheck
 		}
 
 		dst := filepath.Join(to, relToSrc)
@@ -382,7 +382,7 @@ func copyRecursive(pos *model.ConfigPos, from, to string, rfs renderFS) error {
 			dirToCreate = filepath.Dir(dst)
 		}
 		if err := rfs.MkdirAll(dirToCreate, 0o700); err != nil {
-			return model.ErrWithPos(pos, "MkdirAll(): %w", err)
+			return model.ErrWithPos(pos, "MkdirAll(): %w", err) //nolint:wrapcheck
 		}
 		if d.IsDir() {
 			return nil
@@ -390,7 +390,7 @@ func copyRecursive(pos *model.ConfigPos, from, to string, rfs renderFS) error {
 
 		buf, err := rfs.ReadFile(path)
 		if err != nil {
-			return model.ErrWithPos(pos, "ReadFile(): %w", err)
+			return model.ErrWithPos(pos, "ReadFile(): %w", err) //nolint:wrapcheck
 		}
 
 		info, err := rfs.Stat(path)

--- a/templates/commands/render.go
+++ b/templates/commands/render.go
@@ -43,7 +43,7 @@ const (
 	templateDirNamePart = "template-copy"
 	scratchDirNamePart  = "scratch"
 
-	// Permission bits: rwx------
+	// Permission bits: rwx------ .
 	mkdirPerms = 0o700
 )
 

--- a/templates/commands/render_action_gotemplate.go
+++ b/templates/commands/render_action_gotemplate.go
@@ -1,0 +1,12 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/abcxyz/abc/templates/model"
+)
+
+func actionGoTemplate(ctx context.Context, p *model.GoTemplate, sp *stepParams) error {
+	return fmt.Errorf("not implemented")
+}

--- a/templates/commands/render_action_gotemplate.go
+++ b/templates/commands/render_action_gotemplate.go
@@ -1,3 +1,17 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package commands
 
 import (

--- a/templates/commands/render_action_include.go
+++ b/templates/commands/render_action_include.go
@@ -1,0 +1,54 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commands
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/abcxyz/abc/templates/model"
+)
+
+func actionInclude(ctx context.Context, i *model.Include, sp *stepParams) error {
+	for _, p := range i.Paths {
+		// Paths may contain template expressions, so render them first.
+		walkRelPath, err := parseAndExecuteGoTmpl(p, sp.inputs)
+		if err != nil {
+			return model.ErrWithPos(p.Pos, `error compiling go-template: %w`, err)
+		}
+
+		if err := safeRelPath(p.Val); err != nil {
+			return model.ErrWithPos(p.Pos, "invalid path: %w", err)
+		}
+
+		absSrc := filepath.Join(sp.templateDir, walkRelPath)
+		absDst := filepath.Join(sp.scratchDir, walkRelPath)
+
+		if _, err := sp.fs.Stat(absSrc); err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				return model.ErrWithPos(p.Pos, "include path doesn't exist: %q", walkRelPath)
+			}
+			return fmt.Errorf("Stat(): %w", err)
+		}
+
+		if err := copyRecursive(p.Pos, absSrc, absDst, sp.fs); err != nil {
+			return model.ErrWithPos(p.Pos, "copying failed: %w", err)
+		}
+	}
+	return nil
+}

--- a/templates/commands/render_action_include.go
+++ b/templates/commands/render_action_include.go
@@ -29,11 +29,11 @@ func actionInclude(ctx context.Context, i *model.Include, sp *stepParams) error 
 		// Paths may contain template expressions, so render them first.
 		walkRelPath, err := parseAndExecuteGoTmpl(p, sp.inputs)
 		if err != nil {
-			return model.ErrWithPos(p.Pos, `error compiling go-template: %w`, err)
+			return model.ErrWithPos(p.Pos, `error compiling go-template: %w`, err) //nolint:wrapcheck
 		}
 
 		if err := safeRelPath(p.Val); err != nil {
-			return model.ErrWithPos(p.Pos, "invalid path: %w", err)
+			return model.ErrWithPos(p.Pos, "invalid path: %w", err) //nolint:wrapcheck
 		}
 
 		absSrc := filepath.Join(sp.templateDir, walkRelPath)
@@ -41,13 +41,13 @@ func actionInclude(ctx context.Context, i *model.Include, sp *stepParams) error 
 
 		if _, err := sp.fs.Stat(absSrc); err != nil {
 			if errors.Is(err, os.ErrNotExist) {
-				return model.ErrWithPos(p.Pos, "include path doesn't exist: %q", walkRelPath)
+				return model.ErrWithPos(p.Pos, "include path doesn't exist: %q", walkRelPath) //nolint:wrapcheck
 			}
 			return fmt.Errorf("Stat(): %w", err)
 		}
 
 		if err := copyRecursive(p.Pos, absSrc, absDst, sp.fs); err != nil {
-			return model.ErrWithPos(p.Pos, "copying failed: %w", err)
+			return model.ErrWithPos(p.Pos, "copying failed: %w", err) //nolint:wrapcheck
 		}
 	}
 	return nil

--- a/templates/commands/render_action_include_test.go
+++ b/templates/commands/render_action_include_test.go
@@ -1,0 +1,145 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commands
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/abcxyz/abc/templates/model"
+	"github.com/abcxyz/pkg/logging"
+	"github.com/abcxyz/pkg/testutil"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestActionInclude(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name                string
+		paths               []string
+		templateContents    map[string]modeAndContents
+		inputs              map[string]string
+		wantScratchContents map[string]modeAndContents
+		statErr             error
+		wantErr             string
+	}{
+		{
+			name:  "simple_success",
+			paths: []string{"myfile.txt"},
+			templateContents: map[string]modeAndContents{
+				"myfile.txt": {0o600, "my file contents"},
+			},
+			wantScratchContents: map[string]modeAndContents{
+				"myfile.txt": {0o600, "my file contents"},
+			},
+		},
+		{
+			name:    "reject_dot_dot",
+			paths:   []string{"../file.txt"},
+			wantErr: `path must not contain ".."`,
+		},
+		{
+			name:  "templated_filename_success",
+			paths: []string{"{{.my_dir}}/{{.my_file}}"},
+			templateContents: map[string]modeAndContents{
+				"foo/bar.txt": {0o600, "file contents"},
+			},
+			inputs: map[string]string{
+				"my_dir":  "foo",
+				"my_file": "bar.txt",
+			},
+			wantScratchContents: map[string]modeAndContents{
+				"foo/bar.txt": {0o600, "file contents"},
+			},
+		},
+		{
+			name:  "templated_filename_nonexistent_input_var_should_fail",
+			paths: []string{"{{.filename}}"},
+			templateContents: map[string]modeAndContents{
+				"myfile.txt": {0o600, "file contents"},
+			},
+			inputs:  map[string]string{},
+			wantErr: `no entry for key "filename"`,
+		},
+		{
+			name:  "nonexistent_source_should_fail",
+			paths: []string{"nonexistent"},
+			templateContents: map[string]modeAndContents{
+				"myfile.txt": {0o600, "file contents"},
+			},
+			wantErr: `include path doesn't exist: "nonexistent"`,
+		},
+		{
+			// Note: we don't exhaustively test every possible FS error here. That's
+			// already done in the tests for the underlying copyRecursive function.
+			name:  "filesystem_error_should_be_returned",
+			paths: []string{"myfile.txt"},
+			templateContents: map[string]modeAndContents{
+				"myfile.txt": {0o600, "my file contents"},
+			},
+			statErr: fmt.Errorf("fake error"),
+			wantErr: "fake error",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := logging.WithLogger(context.Background(), logging.TestLogger(t))
+
+			tempDir := t.TempDir()
+			templateDir := filepath.Join(tempDir, templateDirNamePart)
+			scratchDir := filepath.Join(tempDir, scratchDirNamePart)
+
+			if err := writeAll(templateDir, tc.templateContents); err != nil {
+				t.Fatal(err)
+			}
+
+			include := &model.Include{
+				Pos:   &model.ConfigPos{},
+				Paths: modelStrings(tc.paths),
+			}
+			sp := &stepParams{
+				fs: &errorFS{
+					renderFS: &realFS{},
+					statErr:  tc.statErr,
+				},
+				scratchDir:  scratchDir,
+				templateDir: templateDir,
+				inputs:      tc.inputs,
+			}
+			err := actionInclude(ctx, include, sp)
+			if diff := testutil.DiffErrString(err, tc.wantErr); diff != "" {
+				t.Error(diff)
+			}
+
+			gotTemplateContents := loadDirContents(t, filepath.Join(tempDir, templateDirNamePart))
+			if diff := cmp.Diff(gotTemplateContents, tc.templateContents); diff != "" {
+				t.Errorf("template directory should not have been touched (-got,+want): %s", diff)
+			}
+
+			gotScratchContents := loadDirContents(t, filepath.Join(tempDir, scratchDirNamePart))
+			if diff := cmp.Diff(gotScratchContents, tc.wantScratchContents); diff != "" {
+				t.Errorf("scratch directory contents were not as expected (-got,+want): %s", diff)
+			}
+		})
+	}
+}

--- a/templates/commands/render_action_print.go
+++ b/templates/commands/render_action_print.go
@@ -1,0 +1,41 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commands
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/abcxyz/abc/templates/model"
+)
+
+func actionPrint(ctx context.Context, p *model.Print, sp *stepParams) error {
+	msg, err := parseAndExecuteGoTmpl(p.Message, sp.inputs)
+	if err != nil {
+		return err
+	}
+	if !strings.HasSuffix(msg, "\n") {
+		msg += "\n"
+	}
+
+	// We can ignore the int returned from Write() because the docs promise that
+	// short writes always return error.
+	if _, err := sp.stdout.Write([]byte(msg)); err != nil {
+		return fmt.Errorf("error writing to stdout: %w", err)
+	}
+
+	return nil
+}

--- a/templates/commands/render_action_print_test.go
+++ b/templates/commands/render_action_print_test.go
@@ -1,0 +1,86 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commands
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/abcxyz/abc/templates/model"
+	"github.com/abcxyz/pkg/logging"
+	"github.com/abcxyz/pkg/testutil"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestActionPrint(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		in      string
+		inputs  map[string]string
+		want    string
+		wantErr string
+	}{
+		{
+			name: "simple_success",
+			in:   "hello 🐕",
+			want: "hello 🐕\n",
+		},
+		{
+			name: "simple_templating",
+			in:   "hello {{.name}}",
+			inputs: map[string]string{
+				"name": "🐕",
+			},
+			want: "hello 🐕\n",
+		},
+		{
+			name:    "template_missing_input",
+			in:      "hello {{.name}}",
+			inputs:  map[string]string{},
+			wantErr: `map has no entry for key "name"`,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := logging.WithLogger(context.Background(), logging.TestLogger(t))
+			var outBuf bytes.Buffer
+			sp := &stepParams{
+				stdout: &outBuf,
+				inputs: tc.inputs,
+			}
+			pr := &model.Print{
+				Message: model.String{
+					Val: tc.in,
+					Pos: &model.ConfigPos{},
+				},
+			}
+			err := actionPrint(ctx, pr, sp)
+			if diff := testutil.DiffErrString(err, tc.wantErr); diff != "" {
+				t.Error(diff)
+			}
+
+			if diff := cmp.Diff(outBuf.String(), tc.want); diff != "" {
+				t.Errorf("got different output than wanted (-got,+want): %s", diff)
+			}
+		})
+	}
+}

--- a/templates/commands/render_action_regexreplace.go
+++ b/templates/commands/render_action_regexreplace.go
@@ -1,3 +1,17 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package commands
 
 import (

--- a/templates/commands/render_action_regexreplace.go
+++ b/templates/commands/render_action_regexreplace.go
@@ -1,0 +1,12 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/abcxyz/abc/templates/model"
+)
+
+func actionRegexReplace(ctx context.Context, p *model.RegexReplace, sp *stepParams) error {
+	return fmt.Errorf("not implemented")
+}

--- a/templates/commands/render_action_stringreplace.go
+++ b/templates/commands/render_action_stringreplace.go
@@ -1,3 +1,17 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package commands
 
 import (

--- a/templates/commands/render_action_stringreplace.go
+++ b/templates/commands/render_action_stringreplace.go
@@ -1,0 +1,12 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/abcxyz/abc/templates/model"
+)
+
+func actionStringReplace(ctx context.Context, p *model.StringReplace, sp *stepParams) error {
+	return fmt.Errorf("not implemented")
+}

--- a/templates/model/pos.go
+++ b/templates/model/pos.go
@@ -55,3 +55,22 @@ func (c *ConfigPos) AnnotateErr(err error) error {
 
 	return fmt.Errorf("invalid config near %s: %w", pos, err)
 }
+
+// ErrWithPos includes information about the given config line with a given
+// error. One good way to use this is with %w, like:
+//
+//	ErrWithPos(pos, "Foo(): %w", err)
+//
+// Calling this function with a zero or nil ConfigPos is valid. The resulting
+// error will just say that the position is unknown.
+func ErrWithPos(pos *ConfigPos, fmtStr string, args ...any) error {
+	err := fmt.Errorf(fmtStr, args...)
+	var lineStr string
+	if pos == nil || *pos == (ConfigPos{}) {
+		lineStr = "(unknown line number)"
+	} else {
+		lineStr = fmt.Sprintf("line %d", pos.Line)
+	}
+
+	return fmt.Errorf("failed executing template spec file at %s: %w", lineStr, err)
+}


### PR DESCRIPTION
The "include" action copies files from the template into the scratch directory. This is analogous to a docker "COPY".

The "print" command just prints to stdout.

In both of these actions, template variable substitution is allowed.

This PR is big, but it's mostly tests.

Coming next: implementing more action types and committing the scratch dir to the output directory.