### PR TITLE
More detailed logic for when overwriting is OK

### DIFF
--- a/templates/commands/render.go
+++ b/templates/commands/render.go
@@ -390,10 +390,10 @@ func copyRecursive(pos *model.ConfigPos, from, to string, rfs renderFS, overwrit
 		dirInfo, err := rfs.Stat(dirToCreate)
 		if err != nil {
 			if !os.IsNotExist(err) {
-				return model.ErrWithPos(pos, "Stat(): %w", err)
+				return model.ErrWithPos(pos, "Stat(): %w", err) //nolint:wrapcheck
 			}
 		} else if !dirInfo.Mode().IsDir() {
-			return model.ErrWithPos(pos, "cannot overwrite a file with a directory of the same name, %q", path)
+			return model.ErrWithPos(pos, "cannot overwrite a file with a directory of the same name, %q", path) //nolint:wrapcheck
 		}
 		if err := rfs.MkdirAll(dirToCreate, 0o700); err != nil {
 			return model.ErrWithPos(pos, "MkdirAll(): %w", err) //nolint:wrapcheck
@@ -410,13 +410,13 @@ func copyRecursive(pos *model.ConfigPos, from, to string, rfs renderFS, overwrit
 		dstInfo, err := rfs.Stat(dst)
 		if err == nil {
 			if dstInfo.IsDir() {
-				return model.ErrWithPos(pos, "cannot overwrite a directory with a file of the same name, %q", path)
+				return model.ErrWithPos(pos, "cannot overwrite a directory with a file of the same name, %q", path) //nolint:wrapcheck
 			}
 			if !overwrite {
-				return model.ErrWithPos(pos, "destination file %s already exists and overwriting was not enabled", path)
+				return model.ErrWithPos(pos, "destination file %s already exists and overwriting was not enabled", path) //nolint:wrapcheck
 			}
 		} else if !os.IsNotExist(err) {
-			return model.ErrWithPos(pos, "Stat(%s): %w", dst, err)
+			return model.ErrWithPos(pos, "Stat(%s): %w", dst, err) //nolint:wrapcheck
 		}
 
 		info, err := rfs.Stat(path)

--- a/templates/commands/render_action_include.go
+++ b/templates/commands/render_action_include.go
@@ -46,7 +46,12 @@ func actionInclude(ctx context.Context, i *model.Include, sp *stepParams) error 
 			return fmt.Errorf("Stat(): %w", err)
 		}
 
-		if err := copyRecursive(p.Pos, absSrc, absDst, sp.fs); err != nil {
+		// Allow later includes to replace earlier includes in the scratch
+		// directory. This doesn't affect whether files in the final destination
+		// directory will be overwritten; that comes later.
+		const overwrite = true
+
+		if err := copyRecursive(p.Pos, absSrc, absDst, sp.fs, overwrite); err != nil {
 			return model.ErrWithPos(p.Pos, "copying failed: %w", err) //nolint:wrapcheck
 		}
 	}


### PR DESCRIPTION
The logic in this PR is to use `overwrite=true` when writing to the scratch directory. This allows multiple include actions to touch the same set of files, if the template author wishes.

This PR also improves error messages in some edge cases.

This PR also forbids overwriting files with directories and vice versa, because that would be confusing for both template developers and abc code maintainers.

In an upcoming PR, we will set `overwrite=$(value_of_--force_overwrite_flag)` when writing to the final output directory.