### PR TITLE
Copy the scratch dir contents to the dest dir

### DIFF
--- a/templates/commands/render.go
+++ b/templates/commands/render.go
@@ -71,11 +71,9 @@ type renderFS interface {
 	fs.StatFS
 
 	// These methods correspond to methods in the "os" package of the same name.
-	Mkdir(name string, perm os.FileMode) error
 	MkdirAll(string, os.FileMode) error
-	ReadFile(string) ([]byte, error)
+	OpenFile(string, int, os.FileMode) (*os.File, error)
 	RemoveAll(string) error
-	WriteFile(string, []byte, os.FileMode) error
 }
 
 // Allows the github.com/hashicorp/go-getter/Client to be faked.
@@ -190,10 +188,6 @@ func (r *Render) parseFlags(args []string) error {
 // This is the non-test implementation of the filesystem interface.
 type realFS struct{}
 
-func (r *realFS) Mkdir(name string, perm os.FileMode) error {
-	return os.Mkdir(name, perm) //nolint:wrapcheck
-}
-
 func (r *realFS) MkdirAll(name string, perm os.FileMode) error {
 	return os.MkdirAll(name, perm) //nolint:wrapcheck
 }
@@ -202,8 +196,8 @@ func (r *realFS) Open(name string) (fs.File, error) {
 	return os.Open(name) //nolint:wrapcheck
 }
 
-func (r *realFS) ReadFile(name string) ([]byte, error) {
-	return os.ReadFile(name) //nolint:wrapcheck
+func (r *realFS) OpenFile(name string, flag int, perm os.FileMode) (*os.File, error) {
+	return os.OpenFile(name, flag, perm) //nolint:wrapcheck
 }
 
 func (r *realFS) RemoveAll(name string) error {
@@ -212,10 +206,6 @@ func (r *realFS) RemoveAll(name string) error {
 
 func (r *realFS) Stat(name string) (fs.FileInfo, error) {
 	return os.Stat(name) //nolint:wrapcheck
-}
-
-func (r *realFS) WriteFile(name string, data []byte, perm os.FileMode) error {
-	return os.WriteFile(name, data, perm) //nolint:wrapcheck
 }
 
 func (r *Render) Run(ctx context.Context, args []string) error {
@@ -309,6 +299,15 @@ func (r *Render) realRun(ctx context.Context, rp *runParams) (outErr error) {
 		return err
 	}
 
+	// Commit the contents of the scratch directory to the output directory. We
+	// first do a dry-run to check that the copy will fully succeed, so we don't
+	// leave a half-done mess in the user's dest directory.
+	for _, dryRun := range []bool{true, false} {
+		if err := copyRecursive(nil, scratchDir, r.flagDest, rp.fs, r.flagForceOverwrite, dryRun); err != nil {
+			return fmt.Errorf("failed writing to --dest directory: %w", err)
+		}
+	}
+
 	return nil
 }
 
@@ -367,7 +366,7 @@ func parseAndExecuteGoTmpl(m model.String, inputs map[string]string) (string, er
 }
 
 // "from" may be a file or directory. "pos" is only used for error messages.
-func copyRecursive(pos *model.ConfigPos, from, to string, rfs renderFS, overwrite bool) error {
+func copyRecursive(pos *model.ConfigPos, from, to string, rfs renderFS, overwrite, dryRun bool) (outErr error) {
 	return fs.WalkDir(rfs, from, func(path string, d fs.DirEntry, err error) error { //nolint:wrapcheck
 		if err != nil {
 			return err // There was some filesystem error. Give up.
@@ -397,19 +396,14 @@ func copyRecursive(pos *model.ConfigPos, from, to string, rfs renderFS, overwrit
 			if !os.IsNotExist(err) {
 				return model.ErrWithPos(pos, "Stat(): %w", err) //nolint:wrapcheck
 			}
+			if err := rfs.MkdirAll(dirToCreate, mkdirPerms); err != nil {
+				return model.ErrWithPos(pos, "MkdirAll(): %w", err) //nolint:wrapcheck
+			}
 		} else if !dirInfo.Mode().IsDir() {
 			return model.ErrWithPos(pos, "cannot overwrite a file with a directory of the same name, %q", path) //nolint:wrapcheck
 		}
-		if err := rfs.MkdirAll(dirToCreate, 0o700); err != nil {
-			return model.ErrWithPos(pos, "MkdirAll(): %w", err) //nolint:wrapcheck
-		}
 		if d.IsDir() {
 			return nil
-		}
-
-		buf, err := rfs.ReadFile(path)
-		if err != nil {
-			return model.ErrWithPos(pos, "ReadFile(): %w", err) //nolint:wrapcheck
 		}
 
 		dstInfo, err := rfs.Stat(dst)
@@ -429,10 +423,26 @@ func copyRecursive(pos *model.ConfigPos, from, to string, rfs renderFS, overwrit
 			return fmt.Errorf("Stat(): %w", err)
 		}
 
+		rf, err := rfs.Open(path)
+		if err != nil {
+			return model.ErrWithPos(pos, "Open(): %w", err) //nolint:wrapcheck
+		}
+		defer func() { outErr = errors.Join(outErr, rf.Close()) }()
+
+		if dryRun {
+			return nil
+		}
+
 		// The permission bits on the output file are copied from the input file;
 		// this preserves the execute bit on executable files.
-		if err := rfs.WriteFile(dst, buf, info.Mode().Perm()); err != nil {
-			return fmt.Errorf("failed writing to scratch file: WriteFile(): %w", err)
+		wf, err := rfs.OpenFile(dst, os.O_CREATE|os.O_WRONLY, info.Mode().Perm())
+		if err != nil {
+			return model.ErrWithPos(pos, "OpenFile(): %w", err) //nolint:wrapcheck
+		}
+		defer func() { outErr = errors.Join(outErr, wf.Close()) }()
+
+		if _, err := io.Copy(wf, rf); err != nil {
+			return fmt.Errorf("Copy(): %w", err)
 		}
 
 		return nil

--- a/templates/commands/render_action_include.go
+++ b/templates/commands/render_action_include.go
@@ -51,7 +51,7 @@ func actionInclude(ctx context.Context, i *model.Include, sp *stepParams) error 
 		// directory will be overwritten; that comes later.
 		const overwrite = true
 
-		if err := copyRecursive(p.Pos, absSrc, absDst, sp.fs, overwrite); err != nil {
+		if err := copyRecursive(p.Pos, absSrc, absDst, sp.fs, overwrite, false); err != nil {
 			return model.ErrWithPos(p.Pos, "copying failed: %w", err) //nolint:wrapcheck
 		}
 	}

--- a/templates/commands/render_test.go
+++ b/templates/commands/render_test.go
@@ -427,6 +427,8 @@ func TestCopyRecursive(t *testing.T) {
 				"file1.txt":      {0o600, "file1 contents"},
 				"dir1/file2.txt": {0o600, "file2 contents"},
 			},
+			openFileErr: fmt.Errorf("OpenFile shouldn't be called in dry run mode"),
+			mkdirAllErr: fmt.Errorf("MkdirAll shouldn't be called in dry run mode"),
 		},
 		{
 			name:   "dry_run_without_overwrite_should_detect_conflicting_files",
@@ -441,7 +443,9 @@ func TestCopyRecursive(t *testing.T) {
 			want: map[string]modeAndContents{
 				"file1.txt": {0o600, "old contents"},
 			},
-			wantErr: "already exists and overwriting was not enabled",
+			openFileErr: fmt.Errorf("OpenFile shouldn't be called in dry run mode"),
+			mkdirAllErr: fmt.Errorf("MkdirAll shouldn't be called in dry run mode"),
+			wantErr:     "already exists and overwriting was not enabled",
 		},
 		{
 			name: "owner_execute_bit_should_be_preserved",

--- a/templates/model/pos.go
+++ b/templates/model/pos.go
@@ -62,15 +62,11 @@ func (c *ConfigPos) AnnotateErr(err error) error {
 //	ErrWithPos(pos, "Foo(): %w", err)
 //
 // Calling this function with a zero or nil ConfigPos is valid. The resulting
-// error will just say that the position is unknown.
+// error will just omit information about config location.
 func ErrWithPos(pos *ConfigPos, fmtStr string, args ...any) error {
 	err := fmt.Errorf(fmtStr, args...)
-	var lineStr string
 	if pos == nil || *pos == (ConfigPos{}) {
-		lineStr = "(unknown line number)"
-	} else {
-		lineStr = fmt.Sprintf("line %d", pos.Line)
+		return err // No location info is available.
 	}
-
-	return fmt.Errorf("failed executing template spec file at %s: %w", lineStr, err)
+	return fmt.Errorf("failed executing template spec file at line %d: %w", pos.Line, err)
 }

--- a/templates/model/pos_test.go
+++ b/templates/model/pos_test.go
@@ -1,3 +1,17 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package model
 
 import (

--- a/templates/model/pos_test.go
+++ b/templates/model/pos_test.go
@@ -1,0 +1,62 @@
+package model
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestErrWithPos(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		pos     *ConfigPos
+		fmtStr  string
+		args    []any
+		wantErr string // comparison is exact
+	}{
+		{
+			name:    "happy_path",
+			pos:     &ConfigPos{10, 11},
+			fmtStr:  "Oh no! some number %d: %w",
+			args:    []any{345, fmt.Errorf("wrapped error")},
+			wantErr: "failed executing template spec file at line 10: Oh no! some number 345: wrapped error",
+		},
+		{
+			name:    "nil_position",
+			pos:     nil,
+			fmtStr:  "foo(): %w",
+			args:    []any{fmt.Errorf("wrapped error")},
+			wantErr: "foo(): wrapped error",
+		},
+		{
+			name:    "zero_position",
+			pos:     &ConfigPos{},
+			fmtStr:  "foo(): %w",
+			args:    []any{fmt.Errorf("wrapped error")},
+			wantErr: "foo(): wrapped error",
+		},
+		{
+			name:    "no_args",
+			pos:     &ConfigPos{10, 11},
+			fmtStr:  "abc def",
+			args:    nil,
+			wantErr: "failed executing template spec file at line 10: abc def",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := ErrWithPos(tc.pos, tc.fmtStr, tc.args...)
+			if diff := cmp.Diff(got.Error(), tc.wantErr); diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This is the final phase of the the rendering process: taking each file and directory in the scratch dir and copying it into the destination.

We want to make this as atomic as possible. If there are any errors, we want to leave the destination directory untouched. We don't want half of the output files to succeed and half of them to be missing; this would be annoying for users to clean up. To achieve this atomicity, we first do a "dry run" copy that checks whether the copy *would* succeed, then we do a real copy. This could be made more efficient in the future, but it's good enough for now.

In this PR we also switch from ReadFile+WriteFile to io.Copy; it seemed silly to read a buffer then just write it again.