### PR TITLE
Add the stringreplace action

### DIFF
--- a/templates/commands/render.go
+++ b/templates/commands/render.go
@@ -44,7 +44,7 @@ const (
 	scratchDirNamePart  = "scratch"
 
 	// Permission bits: rwx------ .
-	mkdirPerms = 0o700
+	ownerRWXPerms = 0o700
 )
 
 type Render struct {
@@ -73,7 +73,9 @@ type renderFS interface {
 	// These methods correspond to methods in the "os" package of the same name.
 	MkdirAll(string, os.FileMode) error
 	OpenFile(string, int, os.FileMode) (*os.File, error)
+	ReadFile(string) ([]byte, error)
 	RemoveAll(string) error
+	WriteFile(string, []byte, os.FileMode) error
 }
 
 // Allows the github.com/hashicorp/go-getter/Client to be faked.
@@ -178,7 +180,7 @@ func (r *Render) parseFlags(args []string) error {
 
 	r.source = parsedArgs[0]
 
-	if err := safeRelPath(r.flagSpec); err != nil {
+	if err := safeRelPath(nil, r.flagSpec); err != nil {
 		return fmt.Errorf("invalid --spec path %q: %w", r.flagSpec, err)
 	}
 
@@ -200,12 +202,20 @@ func (r *realFS) OpenFile(name string, flag int, perm os.FileMode) (*os.File, er
 	return os.OpenFile(name, flag, perm) //nolint:wrapcheck
 }
 
+func (r *realFS) ReadFile(name string) ([]byte, error) {
+	return os.ReadFile(name) //nolint:wrapcheck
+}
+
 func (r *realFS) RemoveAll(name string) error {
 	return os.RemoveAll(name) //nolint:wrapcheck
 }
 
 func (r *realFS) Stat(name string) (fs.FileInfo, error) {
 	return os.Stat(name) //nolint:wrapcheck
+}
+
+func (r *realFS) WriteFile(name string, data []byte, perm os.FileMode) error {
+	return os.WriteFile(name, data, perm) //nolint:wrapcheck
 }
 
 func (r *Render) Run(ctx context.Context, args []string) error {
@@ -284,7 +294,7 @@ func (r *Render) realRun(ctx context.Context, rp *runParams) (outErr error) {
 	if err != nil {
 		return err
 	}
-	if err := rp.fs.MkdirAll(scratchDir, mkdirPerms); err != nil {
+	if err := rp.fs.MkdirAll(scratchDir, ownerRWXPerms); err != nil {
 		return fmt.Errorf("failed to create scratch directory: MkdirAll(): %w", err)
 	}
 	tempDirs = append(tempDirs, scratchDir)
@@ -456,7 +466,7 @@ func mkdirAllChecked(pos *model.ConfigPos, rfs renderFS, path string, dryRun boo
 		return nil
 	}
 
-	if err := rfs.MkdirAll(path, mkdirPerms); err != nil {
+	if err := rfs.MkdirAll(path, ownerRWXPerms); err != nil {
 		return model.ErrWithPos(pos, "MkdirAll(): %w", err) //nolint:wrapcheck
 	}
 
@@ -563,12 +573,12 @@ func destOK(fs fs.StatFS, dest string) error {
 }
 
 // safeRelPath returns an error if the path is absolute or if it contains a ".." traversal.
-func safeRelPath(p string) error {
+func safeRelPath(pos *model.ConfigPos, p string) error {
 	if strings.Contains(p, "..") {
-		return fmt.Errorf(`path must not contain ".."`)
+		return model.ErrWithPos(pos, `path must not contain ".."`) //nolint:wrapcheck
 	}
 	if filepath.IsAbs(p) {
-		return fmt.Errorf(`path must be relative, not absolute`)
+		return model.ErrWithPos(pos, "path must be relative, not absolute") //nolint:wrapcheck
 	}
 	return nil
 }

--- a/templates/commands/render.go
+++ b/templates/commands/render.go
@@ -480,7 +480,12 @@ func loadSpecFile(fs renderFS, templateDir, flagSpec string) (*model.Spec, error
 	}
 	defer f.Close()
 
-	return model.DecodeSpec(f)
+	spec, err := model.DecodeSpec(f)
+	if err != nil {
+		return nil, fmt.Errorf("error reading template spec file: %w", err)
+	}
+
+	return spec, nil
 }
 
 // Downloads the template and returns the name of the temp directory where it

--- a/templates/commands/render.go
+++ b/templates/commands/render.go
@@ -480,12 +480,7 @@ func loadSpecFile(fs renderFS, templateDir, flagSpec string) (*model.Spec, error
 	}
 	defer f.Close()
 
-	decoder := model.NewDecoder(f)
-	var spec model.Spec
-	if err := decoder.Decode(&spec); err != nil {
-		return nil, fmt.Errorf("error parsing YAML spec file: %w", err)
-	}
-	return &spec, nil
+	return model.DecodeSpec(f)
 }
 
 // Downloads the template and returns the name of the temp directory where it

--- a/templates/commands/render_action.go
+++ b/templates/commands/render_action.go
@@ -42,7 +42,7 @@ func walkAndModify(pos *model.ConfigPos, rfs renderFS, scratchDir, relPath strin
 		return model.ErrWithPos(pos, "Stat(): %w", err) //nolint:wrapcheck
 	}
 
-	return filepath.WalkDir(walkFrom, func(path string, d fs.DirEntry, err error) error {
+	return filepath.WalkDir(walkFrom, func(path string, d fs.DirEntry, err error) error { //nolint:wrapcheck
 		if err != nil {
 			// There was some filesystem error. Give up.
 			return model.ErrWithPos(pos, "%w", err) //nolint:wrapcheck

--- a/templates/commands/render_action.go
+++ b/templates/commands/render_action.go
@@ -1,3 +1,17 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package commands
 
 import (

--- a/templates/commands/render_action.go
+++ b/templates/commands/render_action.go
@@ -1,0 +1,66 @@
+package commands
+
+import (
+	"bytes"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/abcxyz/abc/templates/model"
+)
+
+// Called with the contents of a file, and returns the new contents of the file
+// to be written.
+type walkAndModifyVisitor func([]byte) ([]byte, error)
+
+// Recursively traverses the directory or file scratchDir/relPath, calling the
+// given visitor for each file. If the visitor returns modified file contents
+// for a given file, that file will be overwritten with the new contents.
+func walkAndModify(pos *model.ConfigPos, rfs renderFS, scratchDir, relPath string, v walkAndModifyVisitor) error {
+	if err := safeRelPath(pos, relPath); err != nil {
+		return err
+	}
+	walkFrom := filepath.Join(scratchDir, relPath)
+	if _, err := rfs.Stat(walkFrom); err != nil {
+		if os.IsNotExist(err) {
+			return model.ErrWithPos(pos, `path %q doesn't exist in the scratch directory, did you forget to "include" it first?"`, relPath) //nolint:wrapcheck
+		}
+		return model.ErrWithPos(pos, "Stat(): %w", err) //nolint:wrapcheck
+	}
+
+	return filepath.WalkDir(walkFrom, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			// There was some filesystem error. Give up.
+			return model.ErrWithPos(pos, "%w", err) //nolint:wrapcheck
+		}
+		if d.IsDir() {
+			return nil
+		}
+
+		oldBuf, err := rfs.ReadFile(path)
+		if err != nil {
+			return model.ErrWithPos(pos, "Readfile(): %w", err) //nolint:wrapcheck
+		}
+
+		// We must clone oldBuf to guarantee that the callee won't change the
+		// underlying bytes. We rely on an unmodified oldBuf below in the call
+		// to bytes.Equal.
+		newBuf, err := v(bytes.Clone(oldBuf))
+		if err != nil {
+			return err
+		}
+
+		if bytes.Equal(oldBuf, newBuf) {
+			// If file contents are unchanged, there's no need to write.
+			return nil
+		}
+
+		// The permissions in the following WriteFile call will be ignored
+		// because the file already exists.
+		if err := rfs.WriteFile(path, newBuf, ownerRWXPerms); err != nil {
+			return model.ErrWithPos(pos, "Writefile(): %w", err) //nolint:wrapcheck
+		}
+
+		return nil
+	})
+}

--- a/templates/commands/render_action_include.go
+++ b/templates/commands/render_action_include.go
@@ -32,7 +32,7 @@ func actionInclude(ctx context.Context, i *model.Include, sp *stepParams) error 
 			return model.ErrWithPos(p.Pos, `error compiling go-template: %w`, err) //nolint:wrapcheck
 		}
 
-		if err := safeRelPath(p.Val); err != nil {
+		if err := safeRelPath(i.Pos, p.Val); err != nil {
 			return model.ErrWithPos(p.Pos, "invalid path: %w", err) //nolint:wrapcheck
 		}
 

--- a/templates/commands/render_action_stringreplace.go
+++ b/templates/commands/render_action_stringreplace.go
@@ -22,7 +22,7 @@ import (
 )
 
 func actionStringReplace(ctx context.Context, sr *model.StringReplace, sp *stepParams) error {
-	var replacerArgs []string
+	var replacerArgs []string //nolint:prealloc // strings.NewReplacer has a weird input slice, it's less confusing to append rather than preallocate.
 	for _, r := range sr.Replacements {
 		toReplace, err := parseAndExecuteGoTmpl(r.ToReplace, sp.inputs)
 		if err != nil {

--- a/templates/commands/render_action_stringreplace.go
+++ b/templates/commands/render_action_stringreplace.go
@@ -15,33 +15,35 @@
 package commands
 
 import (
-	"bytes"
 	"context"
+	"strings"
 
 	"github.com/abcxyz/abc/templates/model"
 )
 
 func actionStringReplace(ctx context.Context, sr *model.StringReplace, sp *stepParams) error {
-	replaceWith, err := parseAndExecuteGoTmpl(sr.With, sp.inputs)
-	if err != nil {
-		return err
-	}
-
-	toReplace, err := parseAndExecuteGoTmpl(sr.ToReplace, sp.inputs)
-	if err != nil {
-		return err
-	}
-
-	toReplaceBuf := []byte(toReplace)
-	replaceWithBuf := []byte(replaceWith)
-
-	for _, p := range sr.Paths {
-		relPath, err := parseAndExecuteGoTmpl(p, sp.inputs)
+	var replacerArgs []string
+	for _, r := range sr.Replacements {
+		toReplace, err := parseAndExecuteGoTmpl(r.ToReplace, sp.inputs)
 		if err != nil {
 			return err
 		}
-		if err := walkAndModify(p.Pos, sp.fs, sp.scratchDir, relPath, func(buf []byte) ([]byte, error) {
-			return bytes.ReplaceAll(buf, toReplaceBuf, replaceWithBuf), nil
+		replaceWith, err := parseAndExecuteGoTmpl(r.With, sp.inputs)
+		if err != nil {
+			return err
+		}
+		replacerArgs = append(replacerArgs, toReplace, replaceWith)
+	}
+	replacer := strings.NewReplacer(replacerArgs...)
+
+	for _, p := range sr.Paths {
+		path, err := parseAndExecuteGoTmpl(p, sp.inputs)
+		if err != nil {
+			return err
+		}
+
+		if err := walkAndModify(p.Pos, sp.fs, sp.scratchDir, path, func(buf []byte) ([]byte, error) {
+			return []byte(replacer.Replace(string(buf))), nil
 		}); err != nil {
 			return err
 		}

--- a/templates/commands/render_action_stringreplace_test.go
+++ b/templates/commands/render_action_stringreplace_test.go
@@ -1,3 +1,17 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package commands
 
 import (
@@ -89,7 +103,7 @@ func TestActionStringReplace(t *testing.T) {
 			},
 			inputs: map[string]string{
 				"filename_adjective": "cool",
-				"old_suffix":         "wich",
+				"old_suffix":         "wich", //nolint:misspell
 				"new_suffix":         "dog",
 			},
 			want: map[string]string{

--- a/templates/commands/render_action_stringreplace_test.go
+++ b/templates/commands/render_action_stringreplace_test.go
@@ -1,0 +1,193 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/abcxyz/abc/templates/model"
+	"github.com/abcxyz/pkg/testutil"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestActionStringReplace(t *testing.T) {
+	t.Parallel()
+
+	// These test cases are fairly minimal because all the heavy lifting is done
+	// in walkAndModify which has its own comprehensive test suite.
+	cases := []struct {
+		name      string
+		paths     []string
+		toReplace string
+		with      string
+		inputs    map[string]string
+
+		initialContents map[string]string
+		want            map[string]string
+		wantErr         string
+
+		readFileErr error // no need to test all errors here, see TestWalkAndModify
+	}{
+		{
+			name:      "simple_success",
+			paths:     []string{"my_file.txt"},
+			toReplace: "foo",
+			with:      "bar",
+			initialContents: map[string]string{
+				"my_file.txt": "abc foo def",
+			},
+			want: map[string]string{
+				"my_file.txt": "abc bar def",
+			},
+		},
+		{
+			name:      "multiple_files_should_work",
+			paths:     []string{""},
+			toReplace: "foo",
+			with:      "bar",
+			initialContents: map[string]string{
+				"my_file.txt":       "abc foo def",
+				"my_other_file.txt": "abc foo def",
+			},
+			want: map[string]string{
+				"my_file.txt":       "abc bar def",
+				"my_other_file.txt": "abc bar def",
+			},
+		},
+		{
+			name:      "no_replacement_needed_should_noop",
+			paths:     []string{""},
+			toReplace: "foo",
+			with:      "bar",
+			initialContents: map[string]string{
+				"my_file.txt": "abc def",
+			},
+			want: map[string]string{
+				"my_file.txt": "abc def",
+			},
+		},
+		{
+			name:      "empty_file_should_noop",
+			paths:     []string{""},
+			toReplace: "foo",
+			with:      "bar",
+			initialContents: map[string]string{
+				"my_file.txt": "",
+			},
+			want: map[string]string{
+				"my_file.txt": "",
+			},
+		},
+		{
+			name:      "templated_replacement_should_succeed",
+			paths:     []string{"my_{{.filename_adjective}}_file.txt"},
+			toReplace: "sand{{.old_suffix}}",
+			with:      "hot{{.new_suffix}}",
+			initialContents: map[string]string{
+				"my_cool_file.txt":  "sandwich",
+				"ignored_filed.txt": "ignored",
+			},
+			inputs: map[string]string{
+				"filename_adjective": "cool",
+				"old_suffix":         "wich",
+				"new_suffix":         "dog",
+			},
+			want: map[string]string{
+				"my_cool_file.txt":  "hotdog",
+				"ignored_filed.txt": "ignored",
+			},
+		},
+		{
+			name:      "templated_filename_missing_input_should_fail",
+			paths:     []string{"{{.myinput}}"},
+			toReplace: "foo",
+			with:      "bar",
+			initialContents: map[string]string{
+				"my_file.txt": "foo",
+			},
+			inputs: map[string]string{},
+			want: map[string]string{
+				"my_file.txt": "foo",
+			},
+			wantErr: `no entry for key "myinput"`,
+		},
+		{
+			name:      "templated_toreplace_missing_input_should_fail",
+			paths:     []string{""},
+			toReplace: "{{.myinput}}",
+			with:      "bar",
+			initialContents: map[string]string{
+				"my_file.txt": "foo",
+			},
+			inputs: map[string]string{},
+			want: map[string]string{
+				"my_file.txt": "foo",
+			},
+			wantErr: `no entry for key "myinput"`,
+		},
+		{
+			name:      "templated_with_missing_input_should_fail",
+			paths:     []string{""},
+			toReplace: "foo",
+			with:      "{{.myinput}}",
+			initialContents: map[string]string{
+				"my_file.txt": "foo",
+			},
+			inputs: map[string]string{},
+			want: map[string]string{
+				"my_file.txt": "foo",
+			},
+			wantErr: `no entry for key "myinput"`,
+		},
+		{
+			name:      "fs_errors_should_be_returned",
+			paths:     []string{"my_file.txt"},
+			toReplace: "foo",
+			with:      "bar",
+			initialContents: map[string]string{
+				"my_file.txt": "abc foo def",
+			},
+			want: map[string]string{
+				"my_file.txt": "abc foo def",
+			},
+			readFileErr: fmt.Errorf("fake error for testing"),
+			wantErr:     "fake error for testing",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			scratchDir := t.TempDir()
+			if err := writeAllDefaultMode(scratchDir, tc.initialContents); err != nil {
+				t.Fatal(err)
+			}
+
+			sr := &model.StringReplace{
+				Paths:     modelStrings(tc.paths),
+				ToReplace: model.String{Val: tc.toReplace},
+				With:      model.String{Val: tc.with},
+			}
+			sp := &stepParams{
+				fs: &errorFS{
+					renderFS:    &realFS{},
+					readFileErr: tc.readFileErr,
+				},
+				scratchDir: scratchDir,
+				inputs:     tc.inputs,
+			}
+			err := actionStringReplace(context.Background(), sr, sp)
+			if diff := testutil.DiffErrString(err, tc.wantErr); diff != "" {
+				t.Error(diff)
+			}
+
+			got := loadDirWithoutMode(t, scratchDir)
+			if diff := cmp.Diff(got, tc.want); diff != "" {
+				t.Errorf("scratch directory contents were not as expected (-got,+want): %v", diff)
+			}
+		})
+	}
+}

--- a/templates/commands/render_action_test.go
+++ b/templates/commands/render_action_test.go
@@ -1,3 +1,17 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package commands
 
 import (
@@ -40,8 +54,8 @@ func TestWalkAndModify(t *testing.T) {
 			name:            "multiple_replacements_should_work",
 			visitor:         fooToBarVisitor,
 			relPath:         "my_file.txt",
-			initialContents: map[string]string{"my_file.txt": "foo foo"},
-			want:            map[string]string{"my_file.txt": "bar bar"},
+			initialContents: map[string]string{"my_file.txt": "foo foo"}, //nolint:dupword
+			want:            map[string]string{"my_file.txt": "bar bar"}, //nolint:dupword
 		},
 		{
 			name:            "dot_dir_should_work",

--- a/templates/commands/render_action_test.go
+++ b/templates/commands/render_action_test.go
@@ -1,0 +1,197 @@
+package commands
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/abcxyz/pkg/testutil"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestWalkAndModify(t *testing.T) {
+	t.Parallel()
+
+	fooToBarVisitor := func(buf []byte) ([]byte, error) {
+		return bytes.ReplaceAll(buf, []byte("foo"), []byte("bar")), nil
+	}
+
+	cases := []struct {
+		name            string
+		visitor         walkAndModifyVisitor
+		relPath         string
+		initialContents map[string]string
+		want            map[string]string
+		wantErr         string
+
+		// fakeable errors
+		readFileErr  error
+		statErr      error
+		writeFileErr error
+	}{
+		{
+			name:            "simple_single_file_replacement_should_work",
+			visitor:         fooToBarVisitor,
+			relPath:         "my_file.txt",
+			initialContents: map[string]string{"my_file.txt": "abc foo def"},
+			want:            map[string]string{"my_file.txt": "abc bar def"},
+		},
+		{
+			name:            "multiple_replacements_should_work",
+			visitor:         fooToBarVisitor,
+			relPath:         "my_file.txt",
+			initialContents: map[string]string{"my_file.txt": "foo foo"},
+			want:            map[string]string{"my_file.txt": "bar bar"},
+		},
+		{
+			name:            "dot_dir_should_work",
+			visitor:         fooToBarVisitor,
+			relPath:         ".",
+			initialContents: map[string]string{"my_file.txt": "abc foo def"},
+			want:            map[string]string{"my_file.txt": "abc bar def"},
+		},
+		{
+			name:            "empty_path_means_root_should_work",
+			visitor:         fooToBarVisitor,
+			relPath:         ".",
+			initialContents: map[string]string{"my_file.txt": "abc foo def"},
+			want:            map[string]string{"my_file.txt": "abc bar def"},
+		},
+		{
+			name:            "dot_dir_with_trailing_slash_should_work",
+			visitor:         fooToBarVisitor,
+			relPath:         "./",
+			initialContents: map[string]string{"my_file.txt": "abc foo def"},
+			want:            map[string]string{"my_file.txt": "abc bar def"},
+		},
+		{
+			name:            "single_subdir_should_work",
+			visitor:         fooToBarVisitor,
+			relPath:         "./dir",
+			initialContents: map[string]string{"dir/my_file.txt": "abc foo def"},
+			want:            map[string]string{"dir/my_file.txt": "abc bar def"},
+		},
+		{
+			name:            "named_file_in_subdir_should_work",
+			visitor:         fooToBarVisitor,
+			relPath:         "dir/my_file.txt",
+			initialContents: map[string]string{"dir/my_file.txt": "abc foo def"},
+			want:            map[string]string{"dir/my_file.txt": "abc bar def"},
+		},
+		{
+			name:            "deeply_nested_dirs_should_work",
+			visitor:         fooToBarVisitor,
+			relPath:         "dir1",
+			initialContents: map[string]string{"dir1/dir2/dir3/dir4/my_file.txt": "abc foo def"},
+			want:            map[string]string{"dir1/dir2/dir3/dir4/my_file.txt": "abc bar def"},
+		},
+		{
+			name:    "one_included_dir_one_excluded",
+			visitor: fooToBarVisitor,
+			relPath: "dir1",
+			initialContents: map[string]string{
+				"dir1/should_change.txt":     "abc foo def",
+				"dir2/should_not_change.txt": "ghi foo jkl",
+			},
+			want: map[string]string{
+				"dir1/should_change.txt":     "abc bar def",
+				"dir2/should_not_change.txt": "ghi foo jkl",
+			},
+		},
+		{
+			name:            "nonexistent_path_should_fail",
+			visitor:         fooToBarVisitor,
+			relPath:         "nonexistent",
+			initialContents: map[string]string{"my_file.txt": "abc foo def"},
+			want:            map[string]string{"my_file.txt": "abc foo def"},
+			wantErr:         "doesn't exist in the scratch directory",
+		},
+		{
+			name:            "dot_dot_traversal_should_fail",
+			visitor:         fooToBarVisitor,
+			relPath:         "abc/..",
+			initialContents: map[string]string{"my_file.txt": "abc foo def"},
+			want:            map[string]string{"my_file.txt": "abc foo def"},
+			wantErr:         `path must not contain ".."`,
+		},
+		{
+			name:            "absolute_path_should_be_rejected",
+			visitor:         fooToBarVisitor,
+			relPath:         "/etc/passwd",
+			initialContents: map[string]string{"my_file.txt": "abc foo def"},
+			want:            map[string]string{"my_file.txt": "abc foo def"},
+			wantErr:         "path must be relative",
+		},
+		{
+			name:            "empty_file_should_be_ignored",
+			visitor:         fooToBarVisitor,
+			relPath:         ".",
+			initialContents: map[string]string{"my_file.txt": ""},
+			want:            map[string]string{"my_file.txt": ""},
+		},
+		{
+			name:            "writefile_should_not_be_called_if_contents_unchanged",
+			visitor:         fooToBarVisitor,
+			relPath:         ".",
+			initialContents: map[string]string{"my_file.txt": "abc"},
+			want:            map[string]string{"my_file.txt": "abc"},
+			writeFileErr:    fmt.Errorf("WriteFile should not have been called"),
+		},
+		{
+			name:            "stat_error_should_be_returned",
+			visitor:         fooToBarVisitor,
+			relPath:         ".",
+			initialContents: map[string]string{"my_file.txt": "foo"},
+			want:            map[string]string{"my_file.txt": "foo"},
+			statErr:         fmt.Errorf("fake error for testing"),
+			wantErr:         "fake error for testing",
+		},
+		{
+			name:            "readfile_error_should_be_returned",
+			visitor:         fooToBarVisitor,
+			relPath:         ".",
+			initialContents: map[string]string{"my_file.txt": "foo"},
+			want:            map[string]string{"my_file.txt": "foo"},
+			readFileErr:     fmt.Errorf("fake error for testing"),
+			wantErr:         "fake error for testing",
+		},
+		{
+			name:            "writefile_error_should_be_returned",
+			visitor:         fooToBarVisitor,
+			relPath:         ".",
+			initialContents: map[string]string{"my_file.txt": "foo"},
+			want:            map[string]string{"my_file.txt": "foo"},
+			writeFileErr:    fmt.Errorf("fake error for testing"),
+			wantErr:         "fake error for testing",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			scratchDir := t.TempDir()
+			if err := writeAllDefaultMode(scratchDir, tc.initialContents); err != nil {
+				t.Fatal(err)
+			}
+
+			fs := &errorFS{
+				renderFS: &realFS{},
+
+				readFileErr:  tc.readFileErr,
+				statErr:      tc.statErr,
+				writeFileErr: tc.writeFileErr,
+			}
+			err := walkAndModify(nil, fs, scratchDir, tc.relPath, tc.visitor)
+			if diff := testutil.DiffErrString(err, tc.wantErr); diff != "" {
+				t.Error(diff)
+			}
+
+			got := loadDirWithoutMode(t, scratchDir)
+			if diff := cmp.Diff(got, tc.want); diff != "" {
+				t.Errorf("scratch directory contents were not as expected (-got,+want): %v", diff)
+			}
+		})
+	}
+}

--- a/templates/commands/render_test.go
+++ b/templates/commands/render_test.go
@@ -702,7 +702,7 @@ func TestSafeRelPath(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := safeRelPath(tc.in)
+			got := safeRelPath(nil, tc.in)
 
 			if testutil.DiffErrString(got, tc.wantErr) != "" {
 				t.Errorf("safeRelPath(%s)=%s, want %s", tc.in, got, tc.wantErr)
@@ -786,8 +786,10 @@ type errorFS struct {
 	mkdirAllErr  error
 	openErr      error
 	openFileErr  error
+	readFileErr  error
 	removeAllErr error
 	statErr      error
+	writeFileErr error
 }
 
 func (e *errorFS) MkdirAll(name string, mode fs.FileMode) error {
@@ -811,6 +813,13 @@ func (e *errorFS) OpenFile(name string, flag int, mode os.FileMode) (*os.File, e
 	return e.renderFS.OpenFile(name, flag, mode)
 }
 
+func (e *errorFS) ReadFile(name string) ([]byte, error) {
+	if e.readFileErr != nil {
+		return nil, e.readFileErr
+	}
+	return e.renderFS.ReadFile(name)
+}
+
 func (e *errorFS) RemoveAll(name string) error {
 	if e.removeAllErr != nil {
 		return e.removeAllErr
@@ -823,6 +832,13 @@ func (e *errorFS) Stat(name string) (fs.FileInfo, error) {
 		return nil, e.statErr
 	}
 	return e.renderFS.Stat(name)
+}
+
+func (e *errorFS) WriteFile(name string, data []byte, perm os.FileMode) error {
+	if e.writeFileErr != nil {
+		return e.writeFileErr
+	}
+	return e.renderFS.WriteFile(name, data, perm)
 }
 
 type fakeGetter struct {

--- a/templates/commands/render_test.go
+++ b/templates/commands/render_test.go
@@ -172,6 +172,7 @@ kind: 'Template'
 desc: 'A template for the ages'
 inputs:
 - name: 'name_to_greet'
+  desc: 'A name to include in the message'
   required: true
 steps:
 - desc: 'Print a message'

--- a/templates/model/spec.go
+++ b/templates/model/spec.go
@@ -304,9 +304,10 @@ type RegexReplace struct {
 	// Pos is the YAML file location where this object started.
 	Pos *ConfigPos `yaml:"-"`
 
-	Regex    String `yaml:"regex"`
-	Subgroup Int    `yaml:"subgroup"`
-	With     String `yaml:"with"`
+	Paths    []String `yaml:"paths"`
+	Regex    String   `yaml:"regex"`
+	Subgroup Int      `yaml:"subgroup"`
+	With     String   `yaml:"with"`
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler.
@@ -345,8 +346,9 @@ type StringReplace struct {
 	// Pos is the YAML file location where this object started.
 	Pos *ConfigPos `yaml:"-"`
 
-	ToReplace String `yaml:"to_replace"`
-	With      String `yaml:"with"`
+	Paths     []String `yaml:"paths"`
+	ToReplace String   `yaml:"to_replace"`
+	With      String   `yaml:"with"`
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler.

--- a/templates/model/spec.go
+++ b/templates/model/spec.go
@@ -53,8 +53,23 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// NewDecoder returns a yaml Decoder with the desired options.
-func NewDecoder(r io.Reader) *yaml.Decoder {
+// DecodeSpec unmarshals the YAML Spec from r. This function exists so we can
+// validate the Spec model before providing it to the caller; we don't want the
+// caller to forget, and thereby introduce bugs.
+//
+// If the Spec parses successfully but then fails validation, the spec will be
+// returned along with the parse error.
+func DecodeSpec(r io.Reader) (*Spec, error) {
+	dec := newDecoder(r)
+	var spec Spec
+	if err := dec.Decode(&spec); err != nil {
+		return nil, fmt.Errorf("error parsing YAML spec file: %w", err)
+	}
+	return &spec, spec.Validate()
+}
+
+// newDecoder returns a yaml Decoder with the desired options.
+func newDecoder(r io.Reader) *yaml.Decoder {
 	dec := yaml.NewDecoder(r)
 	dec.KnownFields(true) // Fail if any unexpected fields are seen. Often doesn't work: https://github.com/go-yaml/yaml/issues/460
 	return dec
@@ -304,15 +319,13 @@ type RegexReplace struct {
 	// Pos is the YAML file location where this object started.
 	Pos *ConfigPos `yaml:"-"`
 
-	Paths    []String `yaml:"paths"`
-	Regex    String   `yaml:"regex"`
-	Subgroup Int      `yaml:"subgroup"`
-	With     String   `yaml:"with"`
+	Paths        []String            `yaml:"paths"`
+	Replacements []*RegexReplacement `yaml:"replacements"`
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler.
 func (r *RegexReplace) UnmarshalYAML(n *yaml.Node) error {
-	knownYAMLFields := []string{"regex", "subgroup", "with"}
+	knownYAMLFields := []string{"paths", "replacements"}
 	if err := extraFields(n, knownYAMLFields); err != nil {
 		return err
 	}
@@ -330,15 +343,49 @@ func (r *RegexReplace) UnmarshalYAML(n *yaml.Node) error {
 
 // Validate implements Validator.
 func (r *RegexReplace) Validate() error {
+	return errors.Join(
+		nonEmptySlice(r.Pos, r.Paths, "paths"),
+		nonEmptySlice(r.Pos, r.Replacements, "replacements"),
+		validateEach(r.Replacements),
+	)
+}
+
+// RegexReplacement is one of potentially many regex replacements to be applied.
+type RegexReplacement struct {
+	Pos      *ConfigPos `yaml:"-"`
+	Regex    String     `yaml:"regex"`
+	Subgroup Int        `yaml:"subgroup"`
+	With     String     `yaml:"with"`
+}
+
+// Validate implements Validator.
+func (r *RegexReplacement) Validate() error {
 	// Some validation happens later during execution:
 	//  - Compiling the regular expression
 	//  - Compiling the "with" template
 	//  - Validating that the subgroup number is actually a valid subgroup in the regex
 	return errors.Join(
 		notZero(r.Pos, r.Regex, "regex"),
-		notZero(r.Pos, r.With, "with"),
 		nonNegative(r.Subgroup, "subgroup"),
+		notZero(r.Pos, r.With, "with"),
 	)
+}
+
+func (r *RegexReplacement) UnmarshalYAML(n *yaml.Node) error {
+	knownYAMLFields := []string{"regex", "subgroup", "with"}
+	if err := extraFields(n, knownYAMLFields); err != nil {
+		return err
+	}
+	type shadowType RegexReplacement
+	shadow := &shadowType{} // see "Q2" in file comment above
+
+	if err := n.Decode(shadow); err != nil {
+		return err
+	}
+	*r = RegexReplacement(*shadow)
+	r.Pos = yamlPos(n)
+
+	return nil
 }
 
 // StringReplace is an action that replaces a string with a template expression.
@@ -346,14 +393,13 @@ type StringReplace struct {
 	// Pos is the YAML file location where this object started.
 	Pos *ConfigPos `yaml:"-"`
 
-	Paths     []String `yaml:"paths"`
-	ToReplace String   `yaml:"to_replace"`
-	With      String   `yaml:"with"`
+	Paths        []String             `yaml:"paths"`
+	Replacements []*StringReplacement `yaml:"replacements"`
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler.
 func (s *StringReplace) UnmarshalYAML(n *yaml.Node) error {
-	knownYAMLFields := []string{"to_replace", "with"}
+	knownYAMLFields := []string{"paths", "replacements", "params"}
 	if err := extraFields(n, knownYAMLFields); err != nil {
 		return err
 	}
@@ -377,9 +423,41 @@ func (s *StringReplace) Validate() error {
 	//  - Validating that the subgroup number is actually a valid subgroup in
 	//    the regex
 	return errors.Join(
+		nonEmptySlice(s.Pos, s.Paths, "paths"),
+		nonEmptySlice(s.Pos, s.Replacements, "replacements"),
+		validateEach(s.Replacements),
+	)
+}
+
+type StringReplacement struct {
+	Pos *ConfigPos `yaml:"-"`
+
+	ToReplace String `yaml:"to_replace"`
+	With      String `yaml:"with"`
+}
+
+func (s *StringReplacement) Validate() error {
+	return errors.Join(
 		notZero(s.Pos, s.ToReplace, "to_replace"),
 		notZero(s.Pos, s.With, "with"),
 	)
+}
+
+func (s *StringReplacement) UnmarshalYAML(n *yaml.Node) error {
+	knownYAMLFields := []string{"to_replace", "with"}
+	if err := extraFields(n, knownYAMLFields); err != nil {
+		return err
+	}
+	type shadowType StringReplacement
+	shadow := &shadowType{} // see "Q2" in file comment above
+
+	if err := n.Decode(shadow); err != nil {
+		return err
+	}
+	*s = StringReplacement(*shadow)
+	s.Pos = yamlPos(n)
+
+	return nil
 }
 
 // GoTemplate is an action that executes one more files as a Go template,


### PR DESCRIPTION
This is an action that performs a straightforward string replacement on a list of paths (either directories or files). Template variables can be used when specifying any of the parameters:

- paths in which to replace
- strings to be replaced
- strings to be used as replacements.

Most of the logic is in the walkAndModify() function, and the string replacement logic is a thin wrapper around it. This lays the foundation for actionRegexReplace() and actionGoTemplate() to also use walkAndModify().