### PR TITLE
Fix broken example and autoformat

### DIFF
--- a/examples/templates/render/hello_jupiter/spec.yaml
+++ b/examples/templates/render/hello_jupiter/spec.yaml
@@ -12,21 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: "cli.abcxyz.dev/v1alpha1"
-kind: "Template"
+apiVersion: 'cli.abcxyz.dev/v1alpha1'
+kind: 'Template'
 
 desc:
   'An example template that changes a "hello world" program to a "hello jupiter"
   program'
 steps:
-  - desc: "Include some files and directories"
-    action: "include"
+  - desc: 'Include some files and directories'
+    action: 'include'
     params:
-      paths: ["main.go"]
+      paths: ['main.go']
   - desc: 'Replace "world" with "jupiter"'
-    action: "string_replace"
+    action: 'string_replace'
     params:
-      paths: ["main.go"]
+      paths: ['main.go']
       replacements:
-        - to_replace: "world"
-          with: "jupiter"
+        - to_replace: 'world'
+          with: 'jupiter'

--- a/examples/templates/render/hello_jupiter/spec.yaml
+++ b/examples/templates/render/hello_jupiter/spec.yaml
@@ -12,19 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: 'abcxyz.dev/cli/v1alpha1'
-kind: 'Template'
+apiVersion: "cli.abcxyz.dev/v1alpha1"
+kind: "Template"
 
-desc: 'An example template that changes a "hello world" program to a "hello jupiter" program'
+desc:
+  'An example template that changes a "hello world" program to a "hello jupiter"
+  program'
 steps:
-  - desc: 'Include some files and directories'
-    action: 'include'
+  - desc: "Include some files and directories"
+    action: "include"
     params:
-    paths: ['main.go']
+      paths: ["main.go"]
   - desc: 'Replace "world" with "jupiter"'
-    action: 'string_replace'
+    action: "string_replace"
     params:
-      paths: ['main.go']
+      paths: ["main.go"]
       replacements:
-        - to_replace: 'world'
-          with: 'jupiter'
+        - to_replace: "world"
+          with: "jupiter"


### PR DESCRIPTION
- Update apiVersion to the new format, the old format is now rejected
- Fix bad indentation that prevented the example from rendering
- Autoformat the whole file with `prettier` (hopefully yamllint is OK with this)