### PR TITLE
Use named subgroups exclusively

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,9 +291,9 @@ Params:
     readability. Use a non-capturing group (like `(?:abc)|(?:abc)`) if you need
     grouping without capturing.
 
-  - `with`: a string to that will replace regex matches (or, if the `subgroup`
-    field is set, will replace only that subgroup). May use template expressions
-    and may use
+  - `with`: a string to that will replace regex matches (or, if the
+    `subgroup_to_replace` field is set, will replace only that subgroup). May
+    use template expressions and may use
     [Regexp.Expand() syntax](https://pkg.go.dev/regexp#Regexp.Expand) (e.g.
     `${mysubgroup}`).
 
@@ -326,7 +326,7 @@ Examples:
       paths: ['main.go']
       replacements:
         - regex: 'gcp_project_id=(?P<proj_id>[a-z0-9-]+)'
-          subgroup: 'proj_id'
+          subgroup_to_replace: 'proj_id'
           with: '{{.project_id}}'
   ```
 
@@ -339,7 +339,7 @@ Examples:
       paths: ['main.go']
       replacements:
         - regex: 'gcp_(?P<input_name>[a-z_]+)=(?P<value>[a-z0-9-]+)'
-          subgroup: 'value'
+          subgroup_to_replace: 'value'
           with: '{{ .${input_name} }}'
   ```
 

--- a/templates/commands/render_action_regexreplace.go
+++ b/templates/commands/render_action_regexreplace.go
@@ -53,7 +53,7 @@ func actionRegexReplace(ctx context.Context, rr *model.RegexReplace, sp *stepPar
 				continue
 			}
 			if name == "" {
-				return model.ErrWithPos(rp.Regex.Pos, "all capturing groups in regexes must be named, like (?P<myname>re) . The %d'th capturing group in regex %s is an unnamed group, like (re) . Please use either a named capturing group or an non-capturing group like (?:re)", subexpIdx, rp.Regex.Val)
+				return model.ErrWithPos(rp.Regex.Pos, "all capturing groups in regexes must be named, like (?P<myname>re) . The %d'th capturing group in regex %s is an unnamed group, like (re) . Please use either a named capturing group or an non-capturing group like (?:re)", subexpIdx, rp.Regex.Val) //nolint:wrapcheck
 			}
 		}
 	}
@@ -145,7 +145,7 @@ func rejectNumberedSubgroupExpand(with model.String) error {
 			continue
 		}
 
-		return model.ErrWithPos(with.Pos, "regex expansions must reference the subgroup by name, like ${mygroup}, rather than by number, like ${1}; we saw %s", oneMatch[0])
+		return model.ErrWithPos(with.Pos, "regex expansions must reference the subgroup by name, like ${mygroup}, rather than by number, like ${1}; we saw %s", oneMatch[0]) //nolint:wrapcheck
 	}
 	return nil
 }

--- a/templates/commands/render_action_regexreplace.go
+++ b/templates/commands/render_action_regexreplace.go
@@ -16,19 +16,17 @@ package commands
 
 import (
 	"context"
-	"fmt"
 	"regexp"
-	"strconv"
 
 	"github.com/abcxyz/abc/templates/model"
 )
 
 // The regex_replace action replaces a regex match (or a subgroup thereof) with
-// a given string. The replacement string can use subgroup references like $1 or
+// a given string. The replacement string can use subgroup references like
 // ${groupname}, and can also use Go template expressions. An example is:
 //
 //   - regex: '([a-zA-Z]+), (?P<adjective>[a-zA-Z]+) world!'
-//     subgroup: 1
+//     subgroup_to_replace: 'adjective'
 //     with: 'fresh'
 //
 // This would transform a file containing "Hello, cool world!" to "Hello, fresh
@@ -43,14 +41,28 @@ func actionRegexReplace(ctx context.Context, rr *model.RegexReplace, sp *stepPar
 		return err
 	}
 
+	// For the sake of readable spec files, we require that all regex capturing
+	// groups be named.
 	for i, rp := range rr.Replacements {
-		subexps := compiledRegexes[i].NumSubexp()
-		if max := maxSubgroup([]byte(rp.With.Val)); max > subexps {
-			// Note to maintainers: subgroups are 1-indexed, and index i
-			// corresponds to subgroup i because subgroup 0 is just the whole
-			// regex match. Therefore we use ">" in the check above, and
-			// NumSubexp() is the index of the final subgroup.
-			return model.ErrWithPos(rp.With.Pos, "subgroup $%d is out of range; the largest subgroup in this regex is %d", max, subexps) //nolint:wrapcheck
+		compiled := compiledRegexes[i]
+		for subexpIdx, name := range compiled.SubexpNames() {
+			if subexpIdx == 0 {
+				// Subexp 0 is "the whole regex match", and not a subexp, so
+				// it's never named. Therefore we skip the name check for subexp
+				// 0.
+				continue
+			}
+			if name == "" {
+				return model.ErrWithPos(rp.Regex.Pos, "all capturing groups in regexes must be named, like (?P<myname>re) . The %d'th capturing group in regex %s is an unnamed group, like (re) . Please use either a named capturing group or an non-capturing group like (?:re)", subexpIdx, rp.Regex.Val)
+			}
+		}
+	}
+
+	// For the sake of readable spec files, we require that all regex expansions reference
+	// the subgroup by name (like ${mygroup}) rather than number (like ${1}).
+	for _, rp := range rr.Replacements {
+		if err := rejectNumberedSubgroupExpand(rp.With); err != nil {
+			return err
 		}
 	}
 
@@ -82,23 +94,29 @@ func replaceWithTemplate(allMatches [][]int, b []byte, rr *model.RegexReplaceEnt
 	// matches indices.
 	for allMatchesIdx := len(allMatches) - 1; allMatchesIdx >= 0; allMatchesIdx-- {
 		oneMatch := allMatches[allMatchesIdx]
-		// Expand transforms "$1" and "${mygroup}" from "With" into the corresponding matched subgroups from oneMatch.
+		// Expand transforms "${mygroup}" from "With" into the
+		// corresponding matched subgroups from oneMatch.
 		replacementRegexExpanded := re.Expand(nil, []byte(rr.With.Val), b, oneMatch)
 		// Why do regex expansion first before go-template execution? So we can
 		// use regex subgroups to reference template variables to support people
-		// trying to be super clever with their templates.
+		// trying to be super clever with their templates. Like:
+		// {{.${mysubgroup}}}
 		replacementTemplateExpanded, err := parseAndExecuteGoTmpl(rr.With.Pos, string(replacementRegexExpanded), inputs)
 		if err != nil {
 			return nil, err
 		}
 
-		// Subgroup 0 means "the whole string matched by the regex, not just a
-		// subgroup". This is a neat coincidence because the default Subgroup
-		// number in the config is 0 if not specified by the user. So this gives
-		// us the desired behavior of "if user doesn't specify a subgroup to
-		// replace, then replace the whole matched string."
-		replaceAtStartIdx := oneMatch[rr.Subgroup.Val*2] // bounds have already been checked in the caller
-		replaceAtEndIdx := oneMatch[rr.Subgroup.Val*2+1]
+		subgroupNum := 0
+		// If the user didn't specify a subgroup to replace, then replace
+		// subgroup 0, which is the entire string matched by the regex.
+		if rr.SubgroupToReplace.Val != "" {
+			subgroupNum = re.SubexpIndex(rr.SubgroupToReplace.Val)
+			if subgroupNum < 0 {
+				return nil, model.ErrWithPos(rr.SubgroupToReplace.Pos, "subgroup name %q is not a named subgroup in the regex %s", rr.SubgroupToReplace.Val, re.String()) //nolint:wrapcheck
+			}
+		}
+		replaceAtStartIdx := oneMatch[subgroupNum*2] // bounds have already been checked in the caller
+		replaceAtEndIdx := oneMatch[subgroupNum+1]
 		b = append(b[:replaceAtStartIdx],
 			append([]byte(replacementTemplateExpanded),
 				b[replaceAtEndIdx:]...)...)
@@ -108,53 +126,26 @@ func replaceWithTemplate(allMatches [][]int, b []byte, rr *model.RegexReplaceEnt
 
 // A regular expression that matches regex subgroup references like "$5" or
 // "${5}" in a string that will be passed to Regexp.Expand().
-var subGroupExtractRegex = regexp.MustCompile(`\$+` + // some number of dollar signs
+var subGroupExtractRegex = regexp.MustCompile(`(?P<dollars>\$+)` + // some number of dollar signs
 	`[{]?` + // then optionally has a brace character
-	`([0-9]+)`) // and then has some number of decimal digits (as a capturing group)
+	`[0-9]+`) // and then has some number of decimal digits (as a capturing group)
 
-// Given a string that will be passed to Regexp.Expand(), try to find the
-// highest-numbered subgroup reference. This lets us show a friendly error
-// message instead of failing weirdly. If Regexp.Expand() sees a subgroup
-// reference for a nonexistent subgroup, it will just expand it to the empty
-// string. This is likely to be quite confusing for users; they'll get bad
-// output without knowing why.
-//
-// This could be problematic if we find false positive or false negative
-// matches, because the parser in Expand() might have a slightly different idea
-// of what a subgroup reference looks like. We must accept this risk in exchange
-// for the ability to detect problems and provide a decent error message to the
-// user.
-//
-// Returns 0 when no subgroups were found. This makes sense because subgroup 0
-// means the entire string matched by the regex, and therefore subgroup 0 will
-// always be a valid "subgroup".
-func maxSubgroup(in []byte) int {
-	var maxSoFar int
-	matches := subGroupExtractRegex.FindAllSubmatchIndex(in, -1)
+// Given a string that will be passed to Regexp.Expand(), make sure it that it
+// doesn't use any numbered subgroup expansions (like ${1}). Named subgroup
+// expansions are allowed (like ${mygroup}). This is a policy decision because
+// we consider the numbered form to be harder to read.
+func rejectNumberedSubgroupExpand(with model.String) error {
+	matches := subGroupExtractRegex.FindAllStringSubmatch(with.Val, -1)
 	for _, oneMatch := range matches {
-		// Count leading '$' bytes
-		numDollars := 0
-		for ; in[oneMatch[0]+numDollars] == '$'; numDollars++ {
-		}
-
-		if numDollars%2 == 0 {
+		dollars := oneMatch[subGroupExtractRegex.SubexpIndex("dollars")]
+		if len(dollars)%2 == 0 {
 			// This is a literal dollar sign ("$$" expands to "$") and not a
 			// subgroup reference. It could any even number of dollar signs,
 			// like "$$$$$$" expands to "$$$" and is not a subgroup reference.
 			continue
 		}
 
-		numberStartIdx, numberEndIdx := oneMatch[2*1], oneMatch[2*1+1]
-
-		groupNum, err := strconv.Atoi(string(in[numberStartIdx:numberEndIdx]))
-		if err != nil {
-			// We're guaranteed that subgroup 1 is just decimal digits because
-			// of the regex definition. An Atoi failure is not possible.
-			panic(fmt.Errorf("impossible error: numeric subgroup couldn't be parsed as int: %w", err))
-		}
-		if groupNum > maxSoFar {
-			maxSoFar = groupNum
-		}
+		return model.ErrWithPos(with.Pos, "regex expansions must reference the subgroup by name, like ${mygroup}, rather than by number, like ${1}; we saw %s", oneMatch[0])
 	}
-	return maxSoFar
+	return nil
 }

--- a/templates/commands/render_action_regexreplace_test.go
+++ b/templates/commands/render_action_regexreplace_test.go
@@ -43,9 +43,8 @@ func TestActionRegexReplace(t *testing.T) {
 				Paths: modelStrings([]string{"."}),
 				Replacements: []*model.RegexReplaceEntry{
 					{
-						Regex:    model.String{Val: "foo"},
-						With:     model.String{Val: "bar"},
-						Subgroup: model.Int{Val: 0},
+						Regex: model.String{Val: "foo"},
+						With:  model.String{Val: "bar"},
 					},
 				},
 			},
@@ -62,9 +61,8 @@ func TestActionRegexReplace(t *testing.T) {
 				Paths: modelStrings([]string{"."}),
 				Replacements: []*model.RegexReplaceEntry{
 					{
-						Regex:    model.String{Val: "foo"},
-						With:     model.String{Val: "bar"},
-						Subgroup: model.Int{Val: 0},
+						Regex: model.String{Val: "foo"},
+						With:  model.String{Val: "bar"},
 					},
 				},
 			},
@@ -82,9 +80,8 @@ func TestActionRegexReplace(t *testing.T) {
 				Paths: modelStrings([]string{"."}),
 				Replacements: []*model.RegexReplaceEntry{
 					{
-						Regex:    model.String{Val: `\b(?P<my_first_input>b...) (?P<my_second_input>g....)`},
-						Subgroup: model.Int{Val: 0},
-						With:     model.String{Val: "${my_second_input} ${my_first_input}"},
+						Regex: model.String{Val: `\b(?P<my_first_input>b...) (?P<my_second_input>g....)`},
+						With:  model.String{Val: "${my_second_input} ${my_first_input}"},
 					},
 				},
 			},
@@ -93,7 +90,7 @@ func TestActionRegexReplace(t *testing.T) {
 			},
 		},
 		{
-			name: "numbered_subgroup_as_template_variable_should_work",
+			name: "numbered_subgroup_as_template_variable_should_fail",
 			initContents: map[string]string{
 				"a.txt": "alpha template_foo beta",
 			},
@@ -104,15 +101,15 @@ func TestActionRegexReplace(t *testing.T) {
 				Paths: modelStrings([]string{"."}),
 				Replacements: []*model.RegexReplaceEntry{
 					{
-						Regex:    model.String{Val: "template_([a-z]+)"},
-						Subgroup: model.Int{Val: 0},
-						With:     model.String{Val: "{{.$1}}"},
+						Regex: model.String{Val: "template_(?P<mygroup>[a-z]+)"},
+						With:  model.String{Val: "{{.$1}}"},
 					},
 				},
 			},
 			want: map[string]string{
-				"a.txt": "alpha bar beta",
+				"a.txt": "alpha template_foo beta",
 			},
+			wantErr: "regex expansions must reference the subgroup by name",
 		},
 		{
 			name: "named_subgroup_template_variable_should_work",
@@ -126,9 +123,8 @@ func TestActionRegexReplace(t *testing.T) {
 				Paths: modelStrings([]string{"."}),
 				Replacements: []*model.RegexReplaceEntry{
 					{
-						Regex:    model.String{Val: "template_(?P<mysubgroup>[a-z]+)"},
-						Subgroup: model.Int{Val: 0},
-						With:     model.String{Val: "{{.${mysubgroup}}}"},
+						Regex: model.String{Val: "template_(?P<mysubgroup>[a-z]+)"},
+						With:  model.String{Val: "{{.${mysubgroup}}}"},
 					},
 				},
 			},
@@ -148,9 +144,8 @@ func TestActionRegexReplace(t *testing.T) {
 				Paths: modelStrings([]string{"."}),
 				Replacements: []*model.RegexReplaceEntry{
 					{
-						Regex:    model.String{Val: `\b(?P<mysubgroup>be..)\b`},
-						Subgroup: model.Int{Val: 0},
-						With:     model.String{Val: "{{.cool_${mysubgroup}}}"},
+						Regex: model.String{Val: `\b(?P<mysubgroup>be..)\b`},
+						With:  model.String{Val: "{{.cool_${mysubgroup}}}"},
 					},
 				},
 			},
@@ -159,7 +154,7 @@ func TestActionRegexReplace(t *testing.T) {
 			},
 		},
 		{
-			name: "template_lookup_using_numbered_regex_subgroup_should_work",
+			name: "template_lookup_using_numbered_regex_subgroup_should_not_work",
 			initContents: map[string]string{
 				"a.txt": "alpha beta gamma",
 			},
@@ -170,36 +165,15 @@ func TestActionRegexReplace(t *testing.T) {
 				Paths: modelStrings([]string{"."}),
 				Replacements: []*model.RegexReplaceEntry{
 					{
-						Regex:    model.String{Val: `\b(be..)\b`},
-						Subgroup: model.Int{Val: 0},
-						With:     model.String{Val: "{{.cool_${1}}}"},
-					},
-				},
-			},
-			want: map[string]string{
-				"a.txt": "alpha BETA gamma",
-			},
-		},
-		{
-			name: "numbered_subgroup_out_of_range_should_fail",
-			initContents: map[string]string{
-				"a.txt": "alpha beta gamma",
-			},
-			inputs: map[string]string{},
-			rr: &model.RegexReplace{
-				Paths: modelStrings([]string{"."}),
-				Replacements: []*model.RegexReplaceEntry{
-					{
-						Regex:    model.String{Val: `\b(b...)`},
-						Subgroup: model.Int{Val: 0},
-						With:     model.String{Val: "{{.$9}}"},
+						Regex: model.String{Val: `\b(?P<mygroup>be..)\b`},
+						With:  model.String{Val: "{{.cool_${1}}}"},
 					},
 				},
 			},
 			want: map[string]string{
 				"a.txt": "alpha beta gamma",
 			},
-			wantErr: "subgroup $9 is out of range; the largest subgroup in this regex is 1",
+			wantErr: "regex expansions must reference the subgroup by name",
 		},
 		{
 			name: "regex_with_template_reference_should_work",
@@ -214,9 +188,8 @@ func TestActionRegexReplace(t *testing.T) {
 				Paths: modelStrings([]string{"."}),
 				Replacements: []*model.RegexReplaceEntry{
 					{
-						Regex:    model.String{Val: `\b{{.to_replace}}`},
-						Subgroup: model.Int{Val: 0},
-						With:     model.String{Val: `{{.replace_with}}`},
+						Regex: model.String{Val: `\b{{.to_replace}}`},
+						With:  model.String{Val: `{{.replace_with}}`},
 					},
 				},
 			},
@@ -234,9 +207,8 @@ func TestActionRegexReplace(t *testing.T) {
 				Paths: modelStrings([]string{"."}),
 				Replacements: []*model.RegexReplaceEntry{
 					{
-						Regex:    model.String{Val: "foo"},
-						With:     model.String{Val: "bar"},
-						Subgroup: model.Int{Val: 0},
+						Regex: model.String{Val: "foo"},
+						With:  model.String{Val: "bar"},
 					},
 				},
 			},
@@ -277,44 +249,51 @@ func TestActionRegexReplace(t *testing.T) {
 	}
 }
 
-func TestMaxSubGroup(t *testing.T) {
+func TestRejectNumberedSubgroupExpand(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		name string
-		in   string
-		want int
+		name    string
+		in      string
+		wantErr string
 	}{
 		{
-			name: "simple_success",
-			in:   "abc $5 def",
-			want: 5,
+			name:    "reject_numbered",
+			in:      "abc $5 def",
+			wantErr: "failed executing template spec file at line 1: regex expansions must reference the subgroup by name, like ${mygroup}, rather than by number, like ${1}; we saw $5",
 		},
 		{
 			// Note: "$$" expands to "$", this is not a subgroup reference
 			name: "dollardollar_literal_should_not_be_considered",
 			in:   "abc $$5 def",
-			want: 0,
 		},
 		{
 			name: "dollardollardollardollar_literal_should_not_be_considered",
 			in:   "abc $$$$5 def",
-			want: 0,
 		},
 		{
-			name: "dollardollardollardollardollar_literal_should_be_considered",
-			in:   "abc $$$$$5 def",
-			want: 5,
+			name:    "dollardollardollardollardollar_literal_should_be_considered",
+			in:      "abc $$$$$5 def",
+			wantErr: "must reference the subgroup by name",
 		},
 		{
-			name: "braces_should_work",
-			in:   "abc ${5} def",
-			want: 5,
+			name:    "braces",
+			in:      "abc ${5} def",
+			wantErr: "must reference the subgroup by name",
 		},
 		{
-			name: "multiple_subgroup_should_work",
-			in:   "abc $3 def $5 ghi %4",
-			want: 5,
+			name:    "multiple_subgroups",
+			in:      "abc $3 def $5 ghi %4",
+			wantErr: "must reference the subgroup by name",
+		},
+		{
+			name: "named_subgroups",
+			in:   "abc ${mygroup} def",
+		},
+		{
+			name:    "mix_of_named_and_numbered_subgroups",
+			in:      "abc ${mygroup} $5 def",
+			wantErr: "we saw $5",
 		},
 	}
 
@@ -323,8 +302,15 @@ func TestMaxSubGroup(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			if got := maxSubgroup([]byte(tc.in)); got != tc.want {
-				t.Errorf("maxSubgroup(%s)=%d, want %d", tc.in, got, tc.want)
+			in := model.String{
+				Pos: &model.ConfigPos{
+					Line:   1,
+					Column: 1,
+				},
+				Val: tc.in,
+			}
+			if diff := testutil.DiffErrString(rejectNumberedSubgroupExpand(in), tc.wantErr); diff != "" {
+				t.Error(diff)
 			}
 		})
 	}

--- a/templates/model/spec.go
+++ b/templates/model/spec.go
@@ -358,10 +358,10 @@ func (r *RegexReplace) Validate() error {
 
 // RegexReplaceEntry is one of potentially many regex replacements to be applied.
 type RegexReplaceEntry struct {
-	Pos      *ConfigPos `yaml:"-"`
-	Regex    String     `yaml:"regex"`
-	Subgroup Int        `yaml:"subgroup"`
-	With     String     `yaml:"with"`
+	Pos               *ConfigPos `yaml:"-"`
+	Regex             String     `yaml:"regex"`
+	SubgroupToReplace String     `yaml:"subgroup_to_replace"`
+	With              String     `yaml:"with"`
 }
 
 // Validate implements Validator.
@@ -371,15 +371,20 @@ func (r *RegexReplaceEntry) Validate() error {
 	//  - Compiling the "with" template
 	//  - Validating that the subgroup number is actually a valid subgroup in the regex
 
+	var subgroupErr error
+	if r.SubgroupToReplace.Val != "" {
+		subgroupErr = isValidRegexGroupName(r.SubgroupToReplace, "subgroup")
+	}
+
 	return errors.Join(
 		notZero(r.Pos, r.Regex, "regex"),
-		nonNegative(r.Subgroup, "subgroup"),
 		notZero(r.Pos, r.With, "with"),
+		subgroupErr,
 	)
 }
 
 func (r *RegexReplaceEntry) UnmarshalYAML(n *yaml.Node) error {
-	knownYAMLFields := []string{"regex", "subgroup", "with"}
+	knownYAMLFields := []string{"regex", "subgroup_to_replace", "with"}
 	if err := extraFields(n, knownYAMLFields); err != nil {
 		return err
 	}

--- a/templates/model/spec_test.go
+++ b/templates/model/spec_test.go
@@ -329,8 +329,8 @@ action: 'regex_replace'
 params:
   paths: ['a.txt', 'b.txt']
   replacements:
-  - regex: 'my_regex'
-    subgroup: 1
+  - regex: 'my_(?P<groupname>regex)'
+    subgroup_to_replace: 'groupname'
     with: 'some_template'
   - regex: 'my_other_regex'
     with: 'whatever'`,
@@ -344,9 +344,9 @@ params:
 					},
 					Replacements: []*RegexReplaceEntry{
 						{
-							Regex:    String{Val: "my_regex"},
-							Subgroup: Int{Val: 1},
-							With:     String{Val: "some_template"},
+							Regex:             String{Val: "my_(?P<groupname>regex)"},
+							SubgroupToReplace: String{Val: "groupname"},
+							With:              String{Val: "some_template"},
 						},
 						{
 							Regex: String{Val: "my_other_regex"},
@@ -356,17 +356,18 @@ params:
 				},
 			},
 		},
+
 		{
-			name: "regex_replace_negative_subgroup_should_fail",
+			name: "regex_replace_invalid_subgroup_should_fail",
 			in: `desc: 'mydesc'
 action: 'regex_replace'
 params:
   paths: ['a.txt']
   replacements:
-  - regex: 'my_regex'
-    subgroup: -1
+  - regex: '(?p<x>y)'
+    subgroup_to_replace: 1
     with: 'some_template'`,
-			wantValidateErr: `field "subgroup" must not be negative`,
+			wantValidateErr: `invalid config near line 7 column 26: subgroup name must be a letter followed by zero or more alphanumerics`,
 		},
 		{
 			name: "regex_missing_fields_should_fail",
@@ -375,7 +376,31 @@ action: 'regex_replace'
 params:
   paths: ['a.txt']
   replacements:
-  - subgroup: 1`,
+  - subgroup_to_replace: xyz`,
+			wantValidateErr: `invalid config near line 6 column 5: field "regex" is required
+invalid config near line 6 column 5: field "with" is required`,
+		},
+
+		{
+			name: "regex_replace_negative_numbered_subgroup_should_fail",
+			in: `desc: 'mydesc'
+action: 'regex_replace'
+params:
+  paths: ['a.txt']
+  replacements:
+  - regex: 'my_regex'
+    subgroup_to_replace: -1
+    with: 'some_template'`,
+			wantValidateErr: `invalid config near line 7 column 26: subgroup name must be a letter followed by zero or more alphanumerics`,
+		},
+		{
+			name: "regex_missing_fields_should_fail",
+			in: `desc: 'mydesc'
+action: 'regex_replace'
+params:
+  paths: ['a.txt']
+  replacements:
+  - subgroup_to_replace: xyz`,
 			wantValidateErr: `invalid config near line 6 column 5: field "regex" is required
 invalid config near line 6 column 5: field "with" is required`,
 		},

--- a/templates/model/validate.go
+++ b/templates/model/validate.go
@@ -18,8 +18,8 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"regexp"
 
-	"golang.org/x/exp/constraints"
 	"golang.org/x/exp/slices"
 	"gopkg.in/yaml.v3"
 )
@@ -41,11 +41,13 @@ func nonEmptySlice[T any](pos *ConfigPos, s []T, fieldName string) error {
 	return nil
 }
 
-// Returns error if x.Val is <0.
-func nonNegative[T constraints.Ordered](x valWithPos[T], fieldName string) error {
-	var zero T
-	if x.Val < zero {
-		return x.Pos.AnnotateErr(fmt.Errorf("field %q must not be negative", fieldName))
+// In a regex, the groupname in (?P<groupname>re) must be a letter followed by zero
+// or more alphanumerics.
+var validRegexGroupName = regexp.MustCompile(`[a-zA-Z][a-zA-Z0-9]*`)
+
+func isValidRegexGroupName(s String, fieldName string) error {
+	if !validRegexGroupName.MatchString(s.Val) {
+		return s.Pos.AnnotateErr(fmt.Errorf("subgroup name must be a letter followed by zero or more alphanumerics"))
 	}
 	return nil
 }


### PR DESCRIPTION
To make sure our template spec files are maintainable, we force the use of named subgroups (eg `(?P<mygroup>re`) rather than numbered subgroups (eg `(re)`). Correspondingly we force the replacement strings to use named subgroup expansion (eg `${mygroup}`) rather than numbered (eg `${1}`).

Also rename the "subgroup" field to "subgroup_to_replace" to make it more obvious how it works.