### PR TITLE
feat: allow skipping specific input files/dirs

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,15 +213,93 @@ directory.
 Params:
 
 - `paths`: a list of files and/or directories to copy. These may use template
-  expressions (e.g. `{{.my_input}}`).
+  expressions (e.g. `{{.my_input}}`). By default, the output location of each
+  file is the same as its location in the template directory.
+- `as`: as list of output locations relative to the output directory. This can
+  be used to make the output location(s) different than the input locations. If
+  `as` is present, its length must be equal to the length of `paths`; that is,
+  each path must be given an output location.
 
-Example:
+  `as` may not be used with `strip_prefix` or `add_prefix`.
 
-```yaml
-- action: 'include'
-  params:
-    paths: ['main.go', '{{.user_requested_config}}/config.txt']
-```
+  These may use template expressions (e.g. `{{.my_input}}`).
+
+- `strip_prefix`: computes the output path by stripping off the beginning of the
+  input path. Useful for relocating files to a different location in the output
+  than their input location in the template.
+
+  If `strip_prefix` is not actually a prefix of every element of `paths`, that's
+  an error.
+
+  `strip_prefix` may be used with `add_prefix`. `strip_prefix` is executed
+  before `add_prefix` if both are present.
+
+  `strip_prefix` can't be used with `as`.
+
+  These may use template expressions (e.g. `{{.my_input}}`).
+
+- `add_prefix`: computes the output path by prepending to the beginning of the
+  input path. Useful for relocating files to a different location in the output
+  than their input location in the template.
+
+  `add_prefix` may be used with `strip_prefix`. `strip_prefix` is executed
+  before `add_prefix` if both are present.
+
+  `add_prefix` can't be used with `as`.
+
+  These may use template expressions (e.g. `{{.my_input}}`).
+
+- `skip`: omits some files or directories that might be present in the input
+  paths. For each path in `paths`, if `$path/$skip` exists, it won't be included
+  in the output. This supports use cases like "I want every thing in this
+  directory except this specific subdirectory and this specific file."
+
+  It's not an error if the path to skip wasn't found.
+
+  As a special case, the template spec file is automatically skipped and omitted
+  from the template output when the template has an `include` for the path `.`.
+  We assume that when template authors say "copy everything in the template into
+  the output," they mean "everything except the spec file."
+
+  These may use template expressions (e.g. `{{.my_input}}`).
+
+Examples:
+
+- A simple include, where each file keeps it location:
+
+  ```yaml
+  - action: 'include'
+    params:
+      paths: ['main.go', '{{.user_requested_config}}/config.txt']
+  ```
+
+- Using `as` to relocate files:
+
+  ```yaml
+  - action: 'include'
+    params:
+      paths: ['{{.dbname}}/db.go']
+      as: ['db.go']
+  ```
+
+- Using `strip_prefix` and `add_prefix` to relocate files:
+
+  ```yaml
+  - action: 'include'
+    params:
+      paths: ['my/config/files']
+      strip_prefix: 'my/config/files'
+      add_prefix: 'config_files'
+  ```
+
+- Using `skip` to omit certain sub-paths:
+
+  ```yaml
+  - action: 'include'
+    params:
+      paths: ['configs']
+      skip: ['unwanted_subdir', 'unwanted_file.txt']
+  ```
 
 ### Action: `print`
 

--- a/templates/commands/render.go
+++ b/templates/commands/render.go
@@ -302,6 +302,7 @@ func (r *Render) realRun(ctx context.Context, rp *runParams) (outErr error) {
 	tempDirs = append(tempDirs, scratchDir)
 
 	if err := executeSpec(ctx, spec, &stepParams{
+		flagSpec:    r.flagSpec,
 		inputs:      r.flagInputs,
 		fs:          rp.fs,
 		scratchDir:  scratchDir,
@@ -315,7 +316,14 @@ func (r *Render) realRun(ctx context.Context, rp *runParams) (outErr error) {
 	// first do a dry-run to check that the copy is likely to  succeed, so we
 	// don't leave a half-done mess in the user's dest directory.
 	for _, dryRun := range []bool{true, false} {
-		if err := copyRecursive(nil, scratchDir, r.flagDest, rp.fs, r.flagForceOverwrite, dryRun); err != nil {
+		params := &copyParams{
+			srcRoot:   scratchDir,
+			dstRoot:   r.flagDest,
+			rfs:       rp.fs,
+			overwrite: r.flagForceOverwrite,
+			dryRun:    dryRun,
+		}
+		if err := copyRecursive(ctx, nil, params); err != nil {
 			return fmt.Errorf("failed writing to --dest directory: %w", err)
 		}
 	}
@@ -334,6 +342,7 @@ func executeSpec(ctx context.Context, spec *model.Spec, sp *stepParams) error {
 
 type stepParams struct {
 	fs          renderFS
+	flagSpec    string
 	inputs      map[string]string
 	scratchDir  string
 	stdout      io.Writer
@@ -386,7 +395,8 @@ func mkdirAllChecked(pos *model.ConfigPos, rfs renderFS, path string, dryRun boo
 }
 
 func loadSpecFile(fs renderFS, templateDir, flagSpec string) (*model.Spec, error) {
-	f, err := fs.Open(filepath.Join(templateDir, flagSpec))
+	specPath := filepath.Join(templateDir, flagSpec)
+	f, err := fs.Open(specPath)
 	if err != nil {
 		return nil, fmt.Errorf("error opening template spec: ReadFile(): %w", err)
 	}

--- a/templates/commands/render_action.go
+++ b/templates/commands/render_action.go
@@ -16,6 +16,7 @@ package commands
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -28,7 +29,9 @@ import (
 	"text/template"
 
 	"github.com/abcxyz/abc/templates/model"
+	"github.com/abcxyz/pkg/logging"
 	"golang.org/x/exp/maps"
+	"golang.org/x/exp/slices"
 )
 
 // Called with the contents of a file, and returns the new contents of the file
@@ -190,65 +193,88 @@ func (n *unknownTemplateKeyError) Is(other error) bool {
 
 var templateKeyErrRegex = regexp.MustCompile(`map has no entry for key "([^"]*)"`)
 
-// "srcRoot" may be a file or directory. "pos" is only used for error messages.
-func copyRecursive(pos *model.ConfigPos, srcRoot, dstRoot string, rfs renderFS, overwrite, dryRun bool) (outErr error) {
-	return fs.WalkDir(rfs, srcRoot, func(path string, de fs.DirEntry, err error) error { //nolint:wrapcheck
+type copyParams struct {
+	// The file or directory from which to copy
+	srcRoot string
+	// The output directory
+	dstRoot string
+	// The filesytem to use
+	rfs renderFS
+	// Overwrite files if they already exists, rather than the default behavior
+	// of returning error.
+	overwrite bool
+	// Don't actually copy anything, just check whether the copy would be likely
+	// to succeed.
+	dryRun bool
+	// A set of paths not to be copied. These paths are relative to srcRoot.
+	skip []string
+}
+
+func copyRecursive(ctx context.Context, pos *model.ConfigPos, p *copyParams) (outErr error) {
+	return fs.WalkDir(p.rfs, p.srcRoot, func(path string, de fs.DirEntry, err error) error { //nolint:wrapcheck
+		logger := logging.FromContext(ctx)
+
 		if err != nil {
 			return err // There was some filesystem error. Give up.
+		}
+
+		// We don't have to worry about symlinks here because we passed
+		// DisableSymlinks=true to go-getter.
+
+		relToSrc, err := filepath.Rel(p.srcRoot, path)
+		if err != nil {
+			return model.ErrWithPos(pos, "filepath.Rel(%s,%s): %w", p.srcRoot, path, err) //nolint:wrapcheck
+		}
+		if slices.Contains(p.skip, relToSrc) {
+			logger.Debugf("copyRecursive: skipping file per configuration: %s", relToSrc)
+			return fs.SkipDir
 		}
 
 		if de.IsDir() {
 			return nil
 		}
 
-		// We don't have to worry about symlinks here because we passed
-		// DisableSymlinks=true to go-getter.
-
-		relToSrc, err := filepath.Rel(srcRoot, path)
-		if err != nil {
-			return model.ErrWithPos(pos, "filepath.Rel(%s,%s): %w", srcRoot, path, err) //nolint:wrapcheck
-		}
-		dst := filepath.Join(dstRoot, relToSrc)
+		dst := filepath.Join(p.dstRoot, relToSrc)
 
 		// The spec file may specify a file to copy that's deep in a
 		// directory tree, without naming its parent directory. We can't
 		// rely on WalkDir having traversed the parent directory of $path,
 		// so we must create the target directory if it doesn't exist.
 		inDir := filepath.Dir(dst)
-		if err := mkdirAllChecked(pos, rfs, inDir, dryRun); err != nil {
+		if err := mkdirAllChecked(pos, p.rfs, inDir, p.dryRun); err != nil {
 			return err
 		}
 
-		dstInfo, err := rfs.Stat(dst)
+		dstInfo, err := p.rfs.Stat(dst)
 		if err == nil {
 			if dstInfo.IsDir() {
 				return model.ErrWithPos(pos, "cannot overwrite a directory with a file of the same name, %q", relToSrc) //nolint:wrapcheck
 			}
-			if !overwrite {
+			if !p.overwrite {
 				return model.ErrWithPos(pos, "destination file %s already exists and overwriting was not enabled", relToSrc) //nolint:wrapcheck
 			}
 		} else if !os.IsNotExist(err) {
 			return model.ErrWithPos(pos, "Stat(): %w", err) //nolint:wrapcheck
 		}
 
-		srcInfo, err := rfs.Stat(path)
+		srcInfo, err := p.rfs.Stat(path)
 		if err != nil {
 			return fmt.Errorf("Stat(): %w", err)
 		}
 
-		rf, err := rfs.Open(path)
+		rf, err := p.rfs.Open(path)
 		if err != nil {
 			return model.ErrWithPos(pos, "Open(): %w", err) //nolint:wrapcheck
 		}
 		defer func() { outErr = errors.Join(outErr, rf.Close()) }()
 
-		if dryRun {
+		if p.dryRun {
 			return nil
 		}
 
 		// The permission bits on the output file are copied from the input file;
 		// this preserves the execute bit on executable files.
-		wf, err := rfs.OpenFile(dst, os.O_CREATE|os.O_WRONLY, srcInfo.Mode().Perm())
+		wf, err := p.rfs.OpenFile(dst, os.O_CREATE|os.O_WRONLY, srcInfo.Mode().Perm())
 		if err != nil {
 			return model.ErrWithPos(pos, "OpenFile(): %w", err) //nolint:wrapcheck
 		}

--- a/templates/model/spec.go
+++ b/templates/model/spec.go
@@ -58,7 +58,7 @@ import (
 // caller to forget, and thereby introduce bugs.
 //
 // If the Spec parses successfully but then fails validation, the spec will be
-// returned along with the parse error.
+// returned along with the validation error.
 func DecodeSpec(r io.Reader) (*Spec, error) {
 	dec := newDecoder(r)
 	var spec Spec
@@ -295,11 +295,12 @@ type Include struct {
 	As          []String `yaml:"as"`
 	StripPrefix String   `yaml:"strip_prefix"`
 	AddPrefix   String   `yaml:"add_prefix"`
+	Skip        []String `yaml:"skip"`
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler.
 func (i *Include) UnmarshalYAML(n *yaml.Node) error {
-	knownYAMLFields := []string{"paths", "as", "strip_prefix", "add_prefix"}
+	knownYAMLFields := []string{"paths", "as", "strip_prefix", "add_prefix", "skip"}
 	if err := extraFields(n, knownYAMLFields); err != nil {
 		return err
 	}

--- a/templates/model/spec_test.go
+++ b/templates/model/spec_test.go
@@ -348,6 +348,30 @@ params:
 			},
 		},
 		{
+			name: "include_with_skip",
+			in: `desc: 'mydesc'
+action: 'include'
+params:
+  paths: ['.']
+  skip: ['x/y']`,
+			want: &Step{
+				Desc:   String{Val: "mydesc"},
+				Action: String{Val: "include"},
+				Include: &Include{
+					Paths: []String{
+						{
+							Val: ".",
+						},
+					},
+					Skip: []String{
+						{
+							Val: "x/y",
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "wrong_number_of_as_paths",
 			in: `desc: 'mydesc'
 action: 'include'


### PR DESCRIPTION
This adds the `skip` field in the `include` action. The lets template developers say "include this list of directories, but omit these subdirectories/files thereunder."

The template spec YAML file is now automatically skipped. If user does `include "."`, what they really want is "include every file in the template in the output, *except for this spec.yaml*".

Also added docs, see README.md for more details on how this works. This also adds some docs that were previously missing for `as`,`strip_prefix`, and `add_prefix` options on the `include` action.

Also refactored `copyRecursive()`. It started having too many parameters, so there's now a `copyParams` struct to group them together.

Closes #55.
