### PR TITLE
Create dest dir if nonexistent, rather than failing

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ Examples of template locations:
 - `--spec <path_to_spec_yaml>`: the path of the spec yaml file, relative to the
   template root. Defaults to `spec.yaml`.
 - `--dest <output_dir>`: the directory on the local filesystem to write output
-  to. Defaults to the current directory.
+  to. Defaults to the current directory. If it doesn't exist, it will be
+  created.
 - `--input=key=val`: provide an input parameter to the template. `key` must be
   one of the inputs declared by the template in its `spec.yaml`. May be repeated
   to provide multiple inputs, like

--- a/templates/commands/render.go
+++ b/templates/commands/render.go
@@ -328,7 +328,7 @@ func (r *Render) realRun(ctx context.Context, rp *runParams) (outErr error) {
 	}
 
 	// Commit the contents of the scratch directory to the output directory. We
-	// first do a dry-run to check that the copy is likely to  succeed, so we
+	// first do a dry-run to check that the copy is likely to succeed, so we
 	// don't leave a half-done mess in the user's dest directory.
 	for _, dryRun := range []bool{true, false} {
 		params := &copyParams{
@@ -540,13 +540,13 @@ func destOK(fs fs.StatFS, dest string) error {
 	fi, err := fs.Stat(dest)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return fmt.Errorf("the destination directory doesn't exist: %q", dest)
+			return nil
 		}
 		return fmt.Errorf("os.Stat(%s): %w", dest, err)
 	}
 
 	if !fi.IsDir() {
-		return fmt.Errorf("the destination %q is not a directory", dest)
+		return fmt.Errorf("the destination %q exists but isn't a directory", dest)
 	}
 
 	return nil

--- a/templates/commands/render_test.go
+++ b/templates/commands/render_test.go
@@ -134,13 +134,7 @@ func TestDestOK(t *testing.T) {
 			fs: fstest.MapFS{
 				"my/file": {},
 			},
-			wantErr: "is not a directory",
-		},
-		{
-			name:    "dest_doesnt_exist_should_fail",
-			dest:    "my/dir",
-			fs:      fstest.MapFS{},
-			wantErr: "doesn't exist",
+			wantErr: "exists but isn't a directory",
 		},
 		{
 			name:    "stat_returns_error",


### PR DESCRIPTION
There are no new calls to mkdir in this PR because we already have code that creates directories as needed. We just needed to remove a validation check.

Previously, we enforced that the destination dir already exists. This was intended to support the user journey where we're installing into the root of a git repo. However, a new user journey has emerged where we're installing a new directory into an existing git repo. In this case it's annoying to pre-create the directory and/or hackily precede every path in the spec file with a subdirectory name.