### PR TITLE
Run tests on linux and mac (2nd PR attempt)

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -16,14 +16,18 @@ concurrency:
 
 jobs:
   go_lint:
-    uses: 'abcxyz/pkg/.github/workflows/go-lint.yml@main'  # ratchet:exclude
+    uses: 'abcxyz/pkg/.github/workflows/go-lint.yml@main' # ratchet:exclude
     with:
       go_version: '1.20'
 
   go_test:
-    uses: 'abcxyz/pkg/.github/workflows/go-test.yml@main'  # ratchet:exclude
+    uses: 'abcxyz/pkg/.github/workflows/go-test.yml@main' # ratchet:exclude
+    strategy:
+      matrix:
+        os: ['ubuntu-latest', 'macos-latest'] # TODO: add 'windows-latest' once it's known to work (issue #70)
     with:
       go_version: '1.20'
+      os: '${{ matrix.os }}'
 
   yaml_lint:
-    uses: 'abcxyz/pkg/.github/workflows/yaml-lint.yml@main'  # ratchet:exclude
+    uses: 'abcxyz/pkg/.github/workflows/yaml-lint.yml@main' # ratchet:exclude

--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ Example:
 - action: 'print'
   params:
     message:
-      'Please go to the GCP console for project {{.project_id}} and click on the
+      'Please go to the GCP console for project {{.project_id}} and click the
       thing'
 ```
 


### PR DESCRIPTION
Windows isn't yet in the test matrix because test currently don't pass on Windows (which is issue #70).(https://github.com/abcxyz/abc/pull/71).

This is a recreation of PR #71 which got into a stuck workflow state during a GitHub outage.