### PR TITLE
Add CI workflow to rest_server example

### DIFF
--- a/t/rest_server/.github/workflows/ci.yaml
+++ b/t/rest_server/.github/workflows/ci.yaml
@@ -1,0 +1,43 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: 'ci'
+
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+    branches:
+      - 'main'
+  workflow_dispatch:
+  workflow_call:
+
+concurrency:
+  group: '${{ github.workflow }}-${{ github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
+jobs:
+  go_lint:
+    uses: 'abcxyz/pkg/.github/workflows/go-lint.yml@main'
+    with:
+      go_version: '1.20'
+
+  go_test:
+    uses: 'abcxyz/pkg/.github/workflows/go-test.yml@main'
+    with:
+      go_version: '1.20'
+
+  yaml_lint:
+    uses: 'abcxyz/pkg/.github/workflows/yaml-lint.yml@main' # ratchet:exclude

--- a/t/rest_server/main_test.go
+++ b/t/rest_server/main_test.go
@@ -30,6 +30,7 @@ import (
 )
 
 func TestRealMain(t *testing.T) {
+	t.Parallel()
 	ctx := logging.WithLogger(context.Background(), logging.TestLogger(t))
 	ctx, done := context.WithCancel(ctx)
 	defer done()
@@ -41,8 +42,8 @@ func TestRealMain(t *testing.T) {
 		realMainErr = realMain(ctx)
 	}()
 
-	time.Sleep(100 * time.Millisecond) // wait for server startup
-	resp, err := http.Get(fmt.Sprintf("http://localhost:%s/", *port))
+	time.Sleep(100 * time.Millisecond)                                // wait for server startup
+	resp, err := http.Get(fmt.Sprintf("http://localhost:%s/", *port)) //nolint:noctx
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Taken from https://github.com/abcxyz/bet-in-a-box/blob/main/.github/workflows/ci.yml, includes go lint, go test, yaml lint