### PR TITLE
Fix a template typo in t/data_migration_pipeline

### DIFF
--- a/t/data_migration_pipeline/spec.yaml
+++ b/t/data_migration_pipeline/spec.yaml
@@ -22,7 +22,8 @@ steps:
     action: 'include'
     params:
       paths: ['.']
-  - action: 'print'
+  - desc: 'Print user instructions'
+    action: 'print'
     params:
       message:
         'Please go to the main.go and replace the the data model (hint text: "Your data model goes here.") and the data processing logic (hint text: "Your data parsing logic goes here.")'


### PR DESCRIPTION
error reading template spec file: invalid config near line 25 column 5: field "desc" is required