### PR TITLE
Refactor copyRecursive to add callback

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.20
 
 require (
 	github.com/abcxyz/pkg v0.0.0-20230627122505-f65777eea99c
+	github.com/benbjohnson/clock v1.3.0
 	github.com/google/go-cmp v0.5.9
 	github.com/hashicorp/go-getter/v2 v2.2.1
 	github.com/posener/complete/v2 v2.0.1-alpha.13
@@ -12,7 +13,6 @@ require (
 )
 
 require (
-	github.com/benbjohnson/clock v1.3.0 // indirect
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect

--- a/templates/commands/render.go
+++ b/templates/commands/render.go
@@ -338,6 +338,11 @@ func (r *Render) realRun(ctx context.Context, rp *runParams) (outErr error) {
 			rfs:       rp.fs,
 			overwrite: r.flagForceOverwrite,
 			dryRun:    dryRun,
+			visitor: func(relPath string, _ fs.DirEntry) (copyHint, error) {
+				return copyHint{
+					overwrite: r.flagForceOverwrite,
+				}, nil
+			},
 		}
 		if err := copyRecursive(ctx, nil, params); err != nil {
 			return fmt.Errorf("failed writing to --dest directory: %w", err)

--- a/templates/commands/render_action.go
+++ b/templates/commands/render_action.go
@@ -210,9 +210,6 @@ type copyParams struct {
 	// dryRun skips actually copy anything, just checks whether the copy would
 	// be likely to succeed.
 	dryRun bool
-	// skip is a set of paths not to be copied. These paths are relative to
-	// srcRoot. This lets certain special files be excluded from the output.
-	skip []string
 	// visitor is an optional function that will be called for each file in the
 	// source, to allow customization of the copy operation on a per-file basis.
 	visitor copyVisitor

--- a/templates/commands/render_test.go
+++ b/templates/commands/render_test.go
@@ -205,6 +205,13 @@ steps:
   action: 'include'
   params:
     paths: ['file1.txt', 'dir1', 'dir2/file2.txt']
+- desc: 'Replace "blue" with "red"'
+  action: 'string_replace'
+  params:
+    paths: ['.']
+    replacements:
+    - to_replace: 'blue'
+      with: 'red'
 `
 
 	cases := []struct {
@@ -235,13 +242,13 @@ steps:
 			templateContents: map[string]string{
 				"myfile.txt":           "Some random stuff",
 				"spec.yaml":            specContents,
-				"file1.txt":            "file1 contents",
+				"file1.txt":            "my favorite color is blue",
 				"dir1/file_in_dir.txt": "file_in_dir contents",
 				"dir2/file2.txt":       "file2 contents",
 			},
 			wantStdout: "Hello, Bob🐈\n",
 			wantDestContents: map[string]string{
-				"file1.txt":            "file1 contents",
+				"file1.txt":            "my favorite color is red",
 				"dir1/file_in_dir.txt": "file_in_dir contents",
 				"dir2/file2.txt":       "file2 contents",
 			},
@@ -257,24 +264,24 @@ steps:
 			flagSpec:         "spec.yaml",
 			templateContents: map[string]string{
 				"spec.yaml":            specContents,
-				"file1.txt":            "file1 contents",
+				"file1.txt":            "my favorite color is blue",
 				"dir1/file_in_dir.txt": "file_in_dir contents",
 				"dir2/file2.txt":       "file2 contents",
 			},
 			wantStdout: "Hello, Bob🐈\n",
 			wantScratchContents: map[string]string{
-				"file1.txt":            "file1 contents",
+				"file1.txt":            "my favorite color is red",
 				"dir1/file_in_dir.txt": "file_in_dir contents",
 				"dir2/file2.txt":       "file2 contents",
 			},
 			wantTemplateContents: map[string]string{
 				"spec.yaml":            specContents,
-				"file1.txt":            "file1 contents",
+				"file1.txt":            "my favorite color is blue",
 				"dir1/file_in_dir.txt": "file_in_dir contents",
 				"dir2/file2.txt":       "file2 contents",
 			},
 			wantDestContents: map[string]string{
-				"file1.txt":            "file1 contents",
+				"file1.txt":            "my favorite color is red",
 				"dir1/file_in_dir.txt": "file_in_dir contents",
 				"dir2/file2.txt":       "file2 contents",
 			},


### PR DESCRIPTION
This PR lays the groundwork for the "destination includes" feature coming in a following PR.

We add a callback to the copyRecursive function that lets the handling of each file be specified as it's crawled (overwrite or skip). In the following PR we'll add a new option to back up each file if it's being overwritten. It also informs the caller of the names of each crawled file.

Also, fix a bug found while testing this change: add the `O_TRUNC` option when overwriting a file. When overwriting a longer file with a shorter file, we were leaving some of the old file contents at the end of the file.

Also some misc cleanups:

 - rename `from`->`src` and `to`->`dst` in render_action_test.go. We agreed on this renaming but missed some spots.

 - factor out `copyFile()` from the anonymous function inside copyRecursive(). It was getting too big, and we'll need it in the next PR when we want to copy files one at a time.

 - Add a `string_replacement` step to the spec file in TestRealRun to make the test more realistic.