### PR TITLE
Use filepath.FromSlash instead of our own impln

### DIFF
--- a/templates/commands/render.go
+++ b/templates/commands/render.go
@@ -28,7 +28,6 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"runtime"
 	"sort"
 	"strings"
 
@@ -551,14 +550,4 @@ func destOK(fs fs.StatFS, dest string) error {
 	}
 
 	return nil
-}
-
-// toPlatformPath takes a path-like string (e.g. "/foo/bar/file.txt") and
-// converts it to the platform-appropriate string for the file separator. On
-// unix systems, the path separator is "/". On windows, it's "\".
-func toPlatformPath(pth string) string {
-	if runtime.GOOS == "windows" {
-		return strings.ReplaceAll(pth, "/", "\\")
-	}
-	return strings.ReplaceAll(pth, "\\", "/")
 }

--- a/templates/commands/render_test.go
+++ b/templates/commands/render_test.go
@@ -562,9 +562,10 @@ func TestSafeRelPath(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := safeRelPath(nil, toPlatformPath(tc.in))
+			got, err := safeRelPath(nil, filepath.FromSlash(tc.in))
 
-			if got, want := got, toPlatformPath(tc.want); got != want {
+			want := filepath.FromSlash(tc.want)
+			if got != want {
 				t.Errorf("safeRelPath(%s): expected %q to be %q", tc.in, got, want)
 			}
 			if diff := testutil.DiffErrString(err, tc.wantErr); diff != "" {
@@ -764,8 +765,8 @@ func writeAll(root string, files map[string]modeAndContents) error {
 func convertKeysToPlatformPaths[T any](maps ...map[string]T) {
 	for _, m := range maps {
 		for k, v := range m {
-			if diff := toPlatformPath(k); diff != k {
-				m[diff] = v
+			if newKey := filepath.FromSlash(k); newKey != k {
+				m[newKey] = v
 				delete(m, k)
 			}
 		}


### PR DESCRIPTION
It turns out that the standard library already provides this function, so we don't need our own.

Also rename `diff` -> `newKey` because the value isn't semantically a diff, it's just a different string.