### PR TITLE
Use version from build metadata vs hardcoded

### DIFF
--- a/cmd/abc/abc.go
+++ b/cmd/abc/abc.go
@@ -21,14 +21,15 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/abcxyz/abc/internal/version"
 	"github.com/abcxyz/abc/templates/commands"
 	"github.com/abcxyz/pkg/cli"
 )
 
 var rootCmd = func() *cli.RootCommand {
 	return &cli.RootCommand{
-		Name:    "abc",
-		Version: "0.0.1",
+		Name:    version.Name,
+		Version: version.HumanVersion,
 		Commands: map[string]cli.CommandFactory{
 			"templates": func() cli.Command {
 				return &cli.RootCommand{

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,48 @@
+// Copyright 2022 Lumberjack authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version
+
+import (
+	"runtime"
+	"runtime/debug"
+)
+
+var (
+	// Name is the name of the binary. This can be overridden by the build
+	// process.
+	Name = "abc"
+
+	// Version is the main package version. This can be overridden by the build
+	// process.
+	Version = "source"
+
+	// Commit is the git sha. This can be overridden by the build process.
+	Commit = func() string {
+		if info, ok := debug.ReadBuildInfo(); ok {
+			for _, setting := range info.Settings {
+				if setting.Key == "vcs.revision" {
+					return setting.Value
+				}
+			}
+		}
+		return "HEAD"
+	}()
+
+	// OSArch is the operating system and architecture combination.
+	OSArch = runtime.GOOS + "/" + runtime.GOARCH
+
+	// HumanVersion is the compiled version.
+	HumanVersion = Name + " " + Version + " (" + Commit + ", " + OSArch + ")"
+)

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Lumberjack authors (see AUTHORS file)
+// Copyright 2023 Lumberjack authors (see AUTHORS file)
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/templates/commands/render.go
+++ b/templates/commands/render.go
@@ -143,9 +143,9 @@ func (r *Render) Flags() *cli.FlagSet {
 	f.StringVar(&cli.StringVar{
 		Name:    "log-level",
 		Example: "info",
-		Default: "warning",
+		Default: defaultLogLevel,
 		Target:  &r.flagLogLevel,
-		Usage:   "How verbose to log; any of debug|info|warning|error.",
+		Usage:   "How verbose to log; any of debug|info|warn|error.",
 	})
 	f.BoolVar(&cli.BoolVar{
 		Name:    "force-overwrite",

--- a/templates/commands/render_test.go
+++ b/templates/commands/render_test.go
@@ -101,7 +101,7 @@ func TestParseFlags(t *testing.T) {
 				flagDest:           ".",
 				flagGitProtocol:    "https",
 				flagInputs:         map[string]string{},
-				flagLogLevel:       "warning",
+				flagLogLevel:       "warn",
 				flagForceOverwrite: false,
 				flagKeepTempDirs:   false,
 			},


### PR DESCRIPTION
This guarantees that `abc -version` won't get out of sync with the actual release.

Also fix a trivial unrelated problem where the default log level appeared redundantly in two places and used `warning` instead of the correct `warn`.

I tried logging the version number as a debug-level log message on abc startup, but the abcxyz cli package does not allow access to flags from main(), only from subcommand Run() functions.