### PR TITLE
Add tests for abc.go

### DIFF
--- a/cmd/abc/abc.go
+++ b/cmd/abc/abc.go
@@ -17,7 +17,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"io"
 	"os"
 	"os/signal"
 	"syscall"
@@ -52,17 +51,13 @@ func main() {
 		syscall.SIGINT, syscall.SIGTERM)
 	defer done()
 
-	if err := realMain(ctx, os.Args[1:], os.Stdout, os.Stderr); err != nil {
+	if err := realMain(ctx); err != nil {
 		done()
 		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(1)
 	}
 }
 
-// argsTrimmed should be os.Args[1:], or the equivalent for testing.
-func realMain(ctx context.Context, argsTrimmed []string, stdout, stderr io.Writer) error {
-	cmd := rootCmd()
-	cmd.SetStdout(stdout)
-	cmd.SetStderr(stderr)
-	return cmd.Run(ctx, argsTrimmed) //nolint:wrapcheck
+func realMain(ctx context.Context) error {
+	return rootCmd().Run(ctx, os.Args[1:]) //nolint:wrapcheck
 }

--- a/cmd/abc/abc.go
+++ b/cmd/abc/abc.go
@@ -17,6 +17,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"os/signal"
 	"syscall"
@@ -51,13 +52,17 @@ func main() {
 		syscall.SIGINT, syscall.SIGTERM)
 	defer done()
 
-	if err := realMain(ctx); err != nil {
+	if err := realMain(ctx, os.Args[1:], os.Stdout, os.Stderr); err != nil {
 		done()
 		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(1)
 	}
 }
 
-func realMain(ctx context.Context) error {
-	return rootCmd().Run(ctx, os.Args[1:]) //nolint:wrapcheck
+// argsTrimmed should be os.Args[1:], or the equivalent for testing.
+func realMain(ctx context.Context, argsTrimmed []string, stdout, stderr io.Writer) error {
+	cmd := rootCmd()
+	cmd.SetStdout(stdout)
+	cmd.SetStderr(stderr)
+	return cmd.Run(ctx, argsTrimmed) //nolint:wrapcheck
 }

--- a/cmd/abc/abc_test.go
+++ b/cmd/abc/abc_test.go
@@ -15,7 +15,6 @@
 package main
 
 import (
-	"bytes"
 	"context"
 	"runtime"
 	"strings"
@@ -26,7 +25,7 @@ import (
 	"golang.org/x/exp/slices"
 )
 
-func TestRealMain(t *testing.T) {
+func TestRootCmd(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
@@ -77,9 +76,9 @@ func TestRealMain(t *testing.T) {
 			}
 
 			ctx := context.Background()
-			stdout := &bytes.Buffer{}
-			stderr := &bytes.Buffer{}
-			err := realMain(ctx, tc.args, stdout, stderr)
+			rc := rootCmd()
+			_, stdout, stderr := rc.Pipe()
+			err := rc.Run(ctx, tc.args)
 			if diff := testutil.DiffErrString(err, tc.wantErr); diff != "" {
 				t.Error(diff)
 			}

--- a/examples/templates/render/print/spec.yaml
+++ b/examples/templates/render/print/spec.yaml
@@ -1,0 +1,29 @@
+# Copyright 2023 The Authors (see AUTHORS file)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: 'cli.abcxyz.dev/v1alpha1'
+kind: 'Template'
+
+desc: 'An example template that demonstrates the "print" action'
+
+inputs:
+  - name: 'person_name'
+    desc: 'the name of the person to greet'
+    default: 'Alice'
+
+steps:
+  - desc: 'Print a personalized message'
+    action: 'print'
+    params:
+      message: 'Hello, {{.person_name}}!'

--- a/templates/commands/render.go
+++ b/templates/commands/render.go
@@ -255,7 +255,7 @@ func (r *Render) Run(ctx context.Context, args []string) error {
 		cwd:          wd,
 		fs:           fSys,
 		getter:       gg,
-		stdout:       os.Stdout,
+		stdout:       r.Stdout(),
 		tempDirNamer: tempDirName,
 	})
 }


### PR DESCRIPTION
Also fix a place where os.Stdout was hardcoded into render.go. It should use the output stream provided by the cli package for testability.