### PR TITLE
Add VS Code debug configuration

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Render hello_jupiter example",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            "program": "cmd/abc/abc.go",
+            "args": [
+                "templates",
+                "render",
+                "${workspaceFolder}/examples/templates/render/hello_jupiter"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This allows VS Code users to debug the full CLI command, rather than just debugging a _test.go file.