### PR TITLE
Add flags to go-template context for print action

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,17 @@ Params:
 - `message`: the message to show. May use template expressions (e.g.
   `{{.my_input}}`).
 
+  The print action has special access to an extra template variable named
+  `flags` containing the values of some of the command line flags. This can be
+  useful to print a message like
+  `Template rendering is done, now please to go the {{.flags.dest}} directory and run a certain command.`
+  The available values are:
+
+  - `{{.flags.dest}}`: the value of the the `--dest` flag, e.g. `.`
+  - `{{.flags.source}}`: the template location that's being rendered, e.g.
+    `github.com/abcxyz/abc.git//t/my_template`
+  - `{{.flags.spec}}`: the value of the `--spec` flag, e.g. `spec.yaml`
+
 Example:
 
 ```yaml

--- a/templates/commands/render_action.go
+++ b/templates/commands/render_action.go
@@ -142,7 +142,7 @@ var templateKeyErrRegex = regexp.MustCompile(`map has no entry for key "([^"]*)"
 // there's no reason to print out spec file location in an error message. If
 // template execution fails because of a missing input variable, the error will
 // be wrapped in a unknownTemplateKeyError.
-func parseAndExecuteGoTmpl(pos *model.ConfigPos, tmpl string, inputs map[string]string) (string, error) {
+func parseAndExecuteGoTmpl[T any](pos *model.ConfigPos, tmpl string, inputs map[string]T) (string, error) {
 	parsedTmpl, err := parseGoTmpl(tmpl)
 	if err != nil {
 		return "", model.ErrWithPos(pos, `error compiling as go-template: %w`, err) //nolint:wrapcheck

--- a/templates/commands/render_action_include.go
+++ b/templates/commands/render_action_include.go
@@ -86,7 +86,7 @@ func actionInclude(ctx context.Context, inc *model.Include, sp *stepParams) erro
 			// If we're copying the template root directory, automatically skip
 			// the spec.yaml file, because it's very unlikely that the user actually
 			// wants the spec file in the template output.
-			skipNow[sp.flagSpec] = struct{}{}
+			skipNow[sp.flags.spec] = struct{}{}
 		}
 
 		if _, err := sp.fs.Stat(absSrc); err != nil {

--- a/templates/commands/render_action_include_test.go
+++ b/templates/commands/render_action_include_test.go
@@ -272,7 +272,7 @@ func TestActionInclude(t *testing.T) {
 			}
 
 			sp := &stepParams{
-				flagSpec: tc.flagSpec,
+				flags: &renderFlags{spec: tc.flagSpec},
 				fs: &errorFS{
 					renderFS: &realFS{},
 					statErr:  tc.statErr,

--- a/templates/commands/render_action_print.go
+++ b/templates/commands/render_action_print.go
@@ -23,7 +23,12 @@ import (
 )
 
 func actionPrint(ctx context.Context, p *model.Print, sp *stepParams) error {
-	msg, err := parseAndExecuteGoTmpl(p.Message.Pos, p.Message.Val, sp.inputs)
+	inputsAndFlags := map[string]any{}
+	for k, v := range sp.inputs {
+		inputsAndFlags[k] = v
+	}
+	inputsAndFlags["flags"] = sp.flags.forTemplate()
+	msg, err := parseAndExecuteGoTmpl(p.Message.Pos, p.Message.Val, inputsAndFlags)
 	if err != nil {
 		return err
 	}

--- a/templates/commands/render_action_print_test.go
+++ b/templates/commands/render_action_print_test.go
@@ -32,6 +32,7 @@ func TestActionPrint(t *testing.T) {
 		name    string
 		in      string
 		inputs  map[string]string
+		flags   renderFlags
 		want    string
 		wantErr string
 	}{
@@ -54,6 +55,20 @@ func TestActionPrint(t *testing.T) {
 			inputs:  map[string]string{},
 			wantErr: `template referenced a nonexistent input variable name "name"`,
 		},
+		{
+			name: "flags_in_message",
+			in:   "{{.flags.dest}} {{.flags.source}} {{.flags.spec}}",
+			flags: renderFlags{
+				source:         "mysource",
+				dest:           "mydest",
+				gitProtocol:    "mygitprotocol",
+				logLevel:       "myloglevel",
+				forceOverwrite: true,
+				keepTempDirs:   true,
+				spec:           "myspec",
+			},
+			want: "mydest mysource myspec\n",
+		},
 	}
 
 	for _, tc := range cases {
@@ -66,6 +81,7 @@ func TestActionPrint(t *testing.T) {
 			sp := &stepParams{
 				stdout: &outBuf,
 				inputs: tc.inputs,
+				flags:  &tc.flags,
 			}
 			pr := &model.Print{
 				Message: model.String{

--- a/templates/commands/render_test.go
+++ b/templates/commands/render_test.go
@@ -80,14 +80,16 @@ func TestParseFlags(t *testing.T) {
 				"helloworld@v1",
 			},
 			want: &Render{
-				source:             "helloworld@v1",
-				flagSpec:           "my_spec.yaml",
-				flagDest:           "my_dir",
-				flagGitProtocol:    "https",
-				flagInputs:         map[string]string{"x": "y"},
-				flagLogLevel:       "info",
-				flagForceOverwrite: true,
-				flagKeepTempDirs:   true,
+				flags: renderFlags{
+					source:         "helloworld@v1",
+					spec:           "my_spec.yaml",
+					dest:           "my_dir",
+					gitProtocol:    "https",
+					inputs:         map[string]string{"x": "y"},
+					logLevel:       "info",
+					forceOverwrite: true,
+					keepTempDirs:   true,
+				},
 			},
 		},
 		{
@@ -96,14 +98,16 @@ func TestParseFlags(t *testing.T) {
 				"helloworld@v1",
 			},
 			want: &Render{
-				source:             "helloworld@v1",
-				flagSpec:           "./spec.yaml",
-				flagDest:           ".",
-				flagGitProtocol:    "https",
-				flagInputs:         map[string]string{},
-				flagLogLevel:       "warn",
-				flagForceOverwrite: false,
-				flagKeepTempDirs:   false,
+				flags: renderFlags{
+					source:         "helloworld@v1",
+					spec:           "./spec.yaml",
+					dest:           ".",
+					gitProtocol:    "https",
+					inputs:         map[string]string{},
+					logLevel:       "warn",
+					forceOverwrite: false,
+					keepTempDirs:   false,
+				},
 			},
 		},
 		{
@@ -127,6 +131,7 @@ func TestParseFlags(t *testing.T) {
 			}
 			opts := []cmp.Option{
 				cmp.AllowUnexported(Render{}),
+				cmp.AllowUnexported(renderFlags{}),
 				cmpopts.IgnoreFields(Render{}, "BaseCommand"),
 			}
 			if diff := cmp.Diff(r, tc.want, opts...); diff != "" {
@@ -456,12 +461,14 @@ steps:
 				tempDirNamer: tempDirNamer,
 			}
 			r := &Render{
-				flagDest:           dest,
-				flagForceOverwrite: tc.flagForceOverwrite,
-				flagInputs:         tc.flagInputs,
-				flagKeepTempDirs:   tc.flagKeepTempDirs,
-				flagSpec:           "spec.yaml",
-				source:             "github.com/myorg/myrepo",
+				flags: renderFlags{
+					dest:           dest,
+					forceOverwrite: tc.flagForceOverwrite,
+					inputs:         tc.flagInputs,
+					keepTempDirs:   tc.flagKeepTempDirs,
+					spec:           "spec.yaml",
+					source:         "github.com/myorg/myrepo",
+				},
 			}
 
 			ctx := logging.WithLogger(context.Background(), logging.TestLogger(t))
@@ -470,12 +477,12 @@ steps:
 				t.Error(diff)
 			}
 
-			if fg.gotSource != r.source {
-				t.Errorf("fake getter got template source %s but wanted %s", fg.gotSource, r.source)
+			if fg.gotSource != r.flags.source {
+				t.Errorf("fake getter got template source %s but wanted %s", fg.gotSource, r.flags.source)
 			}
 
 			if tc.wantFlagInputs != nil {
-				if diff := cmp.Diff(r.flagInputs, tc.wantFlagInputs); diff != "" {
+				if diff := cmp.Diff(r.flags.inputs, tc.wantFlagInputs); diff != "" {
 					t.Errorf("flagInputs was not as expected; (-got,+want): %s", diff)
 				}
 			}

--- a/templates/model/spec.go
+++ b/templates/model/spec.go
@@ -50,6 +50,7 @@ import (
 	"fmt"
 	"io"
 
+	"golang.org/x/exp/slices"
 	"gopkg.in/yaml.v3"
 )
 
@@ -151,9 +152,18 @@ func (i *Input) UnmarshalYAML(n *yaml.Node) error {
 
 // Validate implements Validator.
 func (i *Input) Validate() error {
+	var reservedNameErr error
+	// Reasons for reserved input names:
+	//  - "flags" is used as expose the CLI flags to the print action. If it was also
+	//    an input name, there would be a collision when trying to do {{.flags.foo}}
+	if slices.Contains([]string{"flags"}, i.Name.Val) {
+		reservedNameErr = i.Name.Pos.AnnotateErr(fmt.Errorf("input name %q is reserved, please pick a different name", i.Name.Val))
+	}
+
 	return errors.Join(
 		notZero(i.Pos, i.Name, "name"),
 		notZero(i.Pos, i.Desc, "desc"),
+		reservedNameErr,
 	)
 }
 

--- a/templates/model/spec_test.go
+++ b/templates/model/spec_test.go
@@ -187,6 +187,12 @@ desc: 'b'
 nonexistent_field: 'oops'`,
 			wantUnmarshalErr: `invalid config near line 3 column 1: unknown field name "nonexistent_field"`,
 		},
+		{
+			name: "reserved_input_name",
+			in: `desc: 'foo'
+name: 'flags'`,
+			wantValidateErr: "is reserved",
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Fixes #85.

To be able to pass the entire set of flags around, I factored them out of the Render struct into a new dedicated struct, `renderFlags`.

Q: Why only expose some flags? Why expose `--dest` but not `--force-overwrite`?

A: API parsimony. We should limit the things we expose to just the things which we know are useful, since we'll have to support this in the future. We can always expose more flags later.

Q: Why only expose these flags to the print action?

A: We want to avoid the temptation for template authors to be inappropriately clever. We think we've provided a single correct way to do things, and we don't want people macking weird hacks unnecessarily. We want template rendering to be deterministic, and not change in surprising ways depending on flag values.

Since we're adding a new `{{.flags}}` namespace, we now forbid a template from declaring an input named `flags`, to avoid collisions.