### PR TITLE
Cleaner conversion of flags to go-template context

### DIFF
--- a/templates/commands/render.go
+++ b/templates/commands/render.go
@@ -73,16 +73,6 @@ type renderFlags struct {
 	spec           string
 }
 
-func (r *renderFlags) forTemplate() map[string]any {
-	// We only expose certain fields to go-templating; thse are the ones that we
-	// can imagine beneficial use cases for.
-	return map[string]any{
-		"dest":   r.dest,
-		"source": r.source,
-		"spec":   r.spec,
-	}
-}
-
 // Abstracts filesystem operations.
 //
 // We can't use os.DirFS or fs.StatFS because they lack some methods we need. So

--- a/templates/commands/render_action_print.go
+++ b/templates/commands/render_action_print.go
@@ -27,7 +27,7 @@ func actionPrint(ctx context.Context, p *model.Print, sp *stepParams) error {
 	for k, v := range sp.inputs {
 		inputsAndFlags[k] = v
 	}
-	inputsAndFlags["flags"] = sp.flags.forTemplate()
+	inputsAndFlags["flags"] = flagsForTemplate(sp.flags)
 	msg, err := parseAndExecuteGoTmpl(p.Message.Pos, p.Message.Val, inputsAndFlags)
 	if err != nil {
 		return err
@@ -43,4 +43,14 @@ func actionPrint(ctx context.Context, p *model.Print, sp *stepParams) error {
 	}
 
 	return nil
+}
+
+func flagsForTemplate(r *renderFlags) map[string]any {
+	// We only expose certain fields the print action; these are the ones that
+	// we have beneficial use cases for and that don't encourage bad API use.
+	return map[string]any{
+		"dest":   r.dest,
+		"source": r.source,
+		"spec":   r.spec,
+	}
 }


### PR DESCRIPTION
This follows up on a PR comment
https://github.com/abcxyz/abc/pull/98#discussion_r1261704163. Since only the `print` action uses these flags, it makes sense to move this logic next to the print logic.