### PR TITLE
Add more log messages for template rendering

### DIFF
--- a/templates/commands/render.go
+++ b/templates/commands/render.go
@@ -406,9 +406,9 @@ func (r *Render) realRun(ctx context.Context, rp *runParams) (outErr error) {
 			return fmt.Errorf("failed writing to --dest directory: %w", err)
 		}
 		if dryRun {
-			logger.Debug("template render (dry run) succeed")
+			logger.Debug("template render (dry run) succeeded")
 		} else {
-			logger.Debug("template render succeed")
+			logger.Debug("template render succeeded")
 		}
 	}
 

--- a/templates/commands/render_action_gotemplate.go
+++ b/templates/commands/render_action_gotemplate.go
@@ -34,7 +34,7 @@ func actionGoTemplate(ctx context.Context, p *model.GoTemplate, sp *stepParams) 
 			return err
 		}
 
-		if err := walkAndModify(p.Pos, sp.fs, sp.scratchDir, walkRelPath, func(b []byte) ([]byte, error) {
+		if err := walkAndModify(ctx, p.Pos, sp.fs, sp.scratchDir, walkRelPath, func(b []byte) ([]byte, error) {
 			executed, err := parseAndExecuteGoTmpl(nil, string(b), sp.inputs)
 			if err != nil {
 				return nil, fmt.Errorf("failed executing file as Go template: %w", err)

--- a/templates/commands/render_action_regexnamelookup.go
+++ b/templates/commands/render_action_regexnamelookup.go
@@ -43,7 +43,7 @@ func actionRegexNameLookup(ctx context.Context, rn *model.RegexNameLookup, sp *s
 	}
 
 	for _, p := range rn.Paths {
-		if err := walkAndModify(p.Pos, sp.fs, sp.scratchDir, p.Val, func(b []byte) ([]byte, error) {
+		if err := walkAndModify(ctx, p.Pos, sp.fs, sp.scratchDir, p.Val, func(b []byte) ([]byte, error) {
 			for i, rn := range rn.Replacements {
 				cr := compiledRegexes[i]
 				allMatches := cr.FindAllSubmatchIndex(b, -1)

--- a/templates/commands/render_action_regexreplace.go
+++ b/templates/commands/render_action_regexreplace.go
@@ -67,7 +67,7 @@ func actionRegexReplace(ctx context.Context, rr *model.RegexReplace, sp *stepPar
 	}
 
 	for _, p := range rr.Paths {
-		if err := walkAndModify(p.Pos, sp.fs, sp.scratchDir, p.Val, func(b []byte) ([]byte, error) {
+		if err := walkAndModify(ctx, p.Pos, sp.fs, sp.scratchDir, p.Val, func(b []byte) ([]byte, error) {
 			for i, rr := range rr.Replacements {
 				cr := compiledRegexes[i]
 				allMatches := cr.FindAllSubmatchIndex(b, -1)

--- a/templates/commands/render_action_stringreplace.go
+++ b/templates/commands/render_action_stringreplace.go
@@ -42,7 +42,7 @@ func actionStringReplace(ctx context.Context, sr *model.StringReplace, sp *stepP
 			return err
 		}
 
-		if err := walkAndModify(p.Pos, sp.fs, sp.scratchDir, path, func(buf []byte) ([]byte, error) {
+		if err := walkAndModify(ctx, p.Pos, sp.fs, sp.scratchDir, path, func(buf []byte) ([]byte, error) {
 			return []byte(replacer.Replace(string(buf))), nil
 		}); err != nil {
 			return err

--- a/templates/commands/render_action_test.go
+++ b/templates/commands/render_action_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/abcxyz/abc/templates/model"
+	"github.com/abcxyz/pkg/logging"
 	"github.com/abcxyz/pkg/testutil"
 	"github.com/benbjohnson/clock"
 	"github.com/google/go-cmp/cmp"
@@ -209,7 +210,8 @@ func TestWalkAndModify(t *testing.T) {
 				statErr:      tc.statErr,
 				writeFileErr: tc.writeFileErr,
 			}
-			err := walkAndModify(nil, fs, scratchDir, tc.relPath, tc.visitor)
+			ctx := logging.WithLogger(context.Background(), logging.TestLogger(t))
+			err := walkAndModify(ctx, nil, fs, scratchDir, tc.relPath, tc.visitor)
 			if diff := testutil.DiffErrString(err, tc.wantErr); diff != "" {
 				t.Error(diff)
 			}


### PR DESCRIPTION
1. Move r.setLogEnvVars() before flag parse, so cli could correctly intake flag value
2. Add logs everywhere
example
```
INFO	commands/render.go:592	created temporary template directory at: /tmp/abc-template-copy-7745125156508404672
INFO	commands/render.go:593	copied source template github.com/abcxyz/abc.git//examples/templates/render/hello_jupiter into temporary directory /tmp/abc-template-copy-7745125156508404672
INFO	commands/render.go:346	created temporary scratch directory at: /tmp/abc-scratch-13218785992439717935
INFO	commands/render.go:393	created backup directory at my_home/.abc/backups/1689614607/2066743529
INFO	commands/render_action.go:380	backed up previous contents of main.go at my_home/.abc/backups/1689614607/2066743529/main.go
INFO	commands/render.go:604	removing all temporary directories (skip this with --keep-temp-dirs)
```

```
INFO	commands/render.go:592	created temporary template directory at: /tmp/abc-template-copy-5304447187202649298
INFO	commands/render.go:593	copied source template github.com/abcxyz/abc.git//examples/templates/render/hello_jupiter into temporary directory /tmp/abc-template-copy-5304447187202649298
INFO	commands/render.go:346	created temporary scratch directory at: /tmp/abc-scratch-8610268306021048948
DEBUG	commands/render_action.go:347	copyFile: from /tmp/abc-template-copy-5304447187202649298/main.go to /tmp/abc-scratch-8610268306021048948/main.go
DEBUG	commands/render.go:474	completed template action include
DEBUG	commands/render_action.go:93	walkAndModify: wrote modification to /tmp/abc-scratch-8610268306021048948/main.go
DEBUG	commands/render.go:474	completed template action string_replace
DEBUG	commands/render.go:409	template render (dry run) succeed
INFO	commands/render.go:393	created backup directory at my_home/.abc/backups/1689614632/3213846716
DEBUG	commands/render_action.go:347	copyFile: from main.go to my_home/.abc/backups/1689614632/3213846716/main.go
INFO	commands/render_action.go:380	backed up previous contents of main.go at my_home/.abc/backups/1689614632/3213846716/main.go
DEBUG	commands/render_action.go:347	copyFile: from /tmp/abc-scratch-8610268306021048948/main.go to main.go
DEBUG	commands/render.go:411	template render succeed
INFO	commands/render.go:604	removing all temporary directories (skip this with --keep-temp-dirs)
```

Closes #26 