### PR TITLE
Add an API for running Render programmatically

### DIFF
--- a/templates/commands/render_action_include.go
+++ b/templates/commands/render_action_include.go
@@ -79,7 +79,7 @@ func actionInclude(ctx context.Context, inc *model.Include, sp *stepParams) erro
 		// that already exist in the destination.
 		fromDir := sp.templateDir
 		if inc.From.Val == "destination" {
-			fromDir = sp.flags.dest
+			fromDir = sp.flags.Dest
 		}
 		absSrc := filepath.Join(fromDir, walkRelPath)
 		absDst := filepath.Join(sp.scratchDir, relDst)
@@ -89,7 +89,7 @@ func actionInclude(ctx context.Context, inc *model.Include, sp *stepParams) erro
 			// If we're copying the template root directory, automatically skip
 			// the spec.yaml file, because it's very unlikely that the user actually
 			// wants the spec file in the template output.
-			skipNow[sp.flags.spec] = struct{}{}
+			skipNow[sp.flags.Spec] = struct{}{}
 		}
 
 		if _, err := sp.fs.Stat(absSrc); err != nil {

--- a/templates/commands/render_action_include_test.go
+++ b/templates/commands/render_action_include_test.go
@@ -338,9 +338,9 @@ func TestActionInclude(t *testing.T) {
 			}
 
 			sp := &stepParams{
-				flags: &renderFlags{
-					spec: tc.flagSpec,
-					dest: destDir,
+				flags: &RenderFlags{
+					Spec: tc.flagSpec,
+					Dest: destDir,
 				},
 				fs: &errorFS{
 					renderFS: &realFS{},

--- a/templates/commands/render_action_print.go
+++ b/templates/commands/render_action_print.go
@@ -45,12 +45,12 @@ func actionPrint(ctx context.Context, p *model.Print, sp *stepParams) error {
 	return nil
 }
 
-func flagsForTemplate(r *renderFlags) map[string]any {
+func flagsForTemplate(r *RenderFlags) map[string]any {
 	// We only expose certain fields the print action; these are the ones that
 	// we have beneficial use cases for and that don't encourage bad API use.
 	return map[string]any{
-		"dest":   r.dest,
-		"source": r.source,
-		"spec":   r.spec,
+		"dest":   r.Dest,
+		"source": r.Source,
+		"spec":   r.Spec,
 	}
 }

--- a/templates/commands/render_action_print_test.go
+++ b/templates/commands/render_action_print_test.go
@@ -32,7 +32,7 @@ func TestActionPrint(t *testing.T) {
 		name    string
 		in      string
 		inputs  map[string]string
-		flags   renderFlags
+		flags   RenderFlags
 		want    string
 		wantErr string
 	}{
@@ -58,14 +58,14 @@ func TestActionPrint(t *testing.T) {
 		{
 			name: "flags_in_message",
 			in:   "{{.flags.dest}} {{.flags.source}} {{.flags.spec}}",
-			flags: renderFlags{
-				source:         "mysource",
-				dest:           "mydest",
-				gitProtocol:    "mygitprotocol",
-				logLevel:       "myloglevel",
-				forceOverwrite: true,
-				keepTempDirs:   true,
-				spec:           "myspec",
+			flags: RenderFlags{
+				Source:         "mysource",
+				Dest:           "mydest",
+				GitProtocol:    "mygitprotocol",
+				LogLevel:       "myloglevel",
+				ForceOverwrite: true,
+				KeepTempDirs:   true,
+				Spec:           "myspec",
 			},
 			want: "mydest mysource myspec\n",
 		},

--- a/templates/commands/render_test.go
+++ b/templates/commands/render_test.go
@@ -64,7 +64,7 @@ func TestParseFlags(t *testing.T) {
 	cases := []struct {
 		name    string
 		args    []string
-		want    *Render
+		want    RenderFlags
 		wantErr string
 	}{
 		{
@@ -79,17 +79,15 @@ func TestParseFlags(t *testing.T) {
 				"--keep-temp-dirs",
 				"helloworld@v1",
 			},
-			want: &Render{
-				flags: renderFlags{
-					source:         "helloworld@v1",
-					spec:           "my_spec.yaml",
-					dest:           "my_dir",
-					gitProtocol:    "https",
-					inputs:         map[string]string{"x": "y"},
-					logLevel:       "info",
-					forceOverwrite: true,
-					keepTempDirs:   true,
-				},
+			want: RenderFlags{
+				Source:         "helloworld@v1",
+				Spec:           "my_spec.yaml",
+				Dest:           "my_dir",
+				GitProtocol:    "https",
+				Inputs:         map[string]string{"x": "y"},
+				LogLevel:       "info",
+				ForceOverwrite: true,
+				KeepTempDirs:   true,
 			},
 		},
 		{
@@ -97,17 +95,15 @@ func TestParseFlags(t *testing.T) {
 			args: []string{
 				"helloworld@v1",
 			},
-			want: &Render{
-				flags: renderFlags{
-					source:         "helloworld@v1",
-					spec:           "./spec.yaml",
-					dest:           ".",
-					gitProtocol:    "https",
-					inputs:         map[string]string{},
-					logLevel:       "warn",
-					forceOverwrite: false,
-					keepTempDirs:   false,
-				},
+			want: RenderFlags{
+				Source:         "helloworld@v1",
+				Spec:           "./spec.yaml",
+				Dest:           ".",
+				GitProtocol:    "https",
+				Inputs:         map[string]string{},
+				LogLevel:       "warn",
+				ForceOverwrite: false,
+				KeepTempDirs:   false,
 			},
 		},
 		{
@@ -121,8 +117,8 @@ func TestParseFlags(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			r := &Render{}
-			err := r.parseFlags(tc.args)
+			var r RenderFlags
+			err := r.Parse(tc.args)
 			if err != nil || tc.wantErr != "" {
 				if diff := testutil.DiffErrString(err, tc.wantErr); diff != "" {
 					t.Fatal(diff)
@@ -130,9 +126,7 @@ func TestParseFlags(t *testing.T) {
 				return
 			}
 			opts := []cmp.Option{
-				cmp.AllowUnexported(Render{}),
-				cmp.AllowUnexported(renderFlags{}),
-				cmpopts.IgnoreFields(Render{}, "BaseCommand"),
+				cmp.AllowUnexported(RenderFlags{}),
 			}
 			if diff := cmp.Diff(r, tc.want, opts...); diff != "" {
 				t.Errorf("got %#v, want %#v, diff (-got, +want): %v", r, tc.want, diff)
@@ -548,13 +542,13 @@ steps:
 				tempDirNamer: tempDirNamer,
 			}
 			r := &Render{
-				flags: renderFlags{
-					dest:           dest,
-					forceOverwrite: tc.flagForceOverwrite,
-					inputs:         tc.flagInputs,
-					keepTempDirs:   tc.flagKeepTempDirs,
-					spec:           "spec.yaml",
-					source:         "github.com/myorg/myrepo",
+				flags: &RenderFlags{
+					Dest:           dest,
+					ForceOverwrite: tc.flagForceOverwrite,
+					Inputs:         tc.flagInputs,
+					KeepTempDirs:   tc.flagKeepTempDirs,
+					Spec:           "spec.yaml",
+					Source:         "github.com/myorg/myrepo",
 				},
 			}
 
@@ -564,12 +558,12 @@ steps:
 				t.Error(diff)
 			}
 
-			if fg.gotSource != r.flags.source {
-				t.Errorf("fake getter got template source %s but wanted %s", fg.gotSource, r.flags.source)
+			if fg.gotSource != r.flags.Source {
+				t.Errorf("fake getter got template source %s but wanted %s", fg.gotSource, r.flags.Source)
 			}
 
 			if tc.wantFlagInputs != nil {
-				if diff := cmp.Diff(r.flags.inputs, tc.wantFlagInputs); diff != "" {
+				if diff := cmp.Diff(r.flags.Inputs, tc.wantFlagInputs); diff != "" {
 					t.Errorf("flagInputs was not as expected; (-got,+want): %s", diff)
 				}
 			}


### PR DESCRIPTION
This exposes the RenderFlags struct for external use, and adds the Render.RunWithFlags method.

This is PR 1 of 3-ish that will add a test framework for templates. The goal is to (1) allow template developers to test their templates and (2) allow abc CLI developers to verify that code changes haven't broken templates.

Reviewers, all of the interesting changes are in render.go, and the rest is just changed capitalization and renaming.