### PR TITLE
Move test helpers to testutil/

### DIFF
--- a/templates/commands/render.go
+++ b/templates/commands/render.go
@@ -270,7 +270,7 @@ func (r *Render) Run(ctx context.Context, args []string) error {
 }
 
 // RunWithFlags renders a template according to the given flags, taking the
-// template form rf.Source and producing output in rf.Dest. This should be
+// template from rf.Source and producing output in rf.Dest. This should be
 // considered an unstable API and is primarily intended for testing. Use at your
 // own risk and accept the possibility of breaking changes.
 func (r *Render) RunWithFlags(ctx context.Context, rf *RenderFlags) error {

--- a/templates/commands/render_action_gotemplate_test.go
+++ b/templates/commands/render_action_gotemplate_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/abcxyz/abc/templates/model"
+	abctestutil "github.com/abcxyz/abc/testutil"
 	"github.com/abcxyz/pkg/testutil"
 	"github.com/google/go-cmp/cmp"
 )
@@ -161,9 +162,7 @@ func TestActionGoTemplate(t *testing.T) {
 			t.Parallel()
 
 			scratchDir := t.TempDir()
-			if err := writeAllDefaultMode(scratchDir, tc.initContents); err != nil {
-				t.Fatal(err)
-			}
+			abctestutil.WriteAllDefaultMode(t, scratchDir, tc.initContents)
 
 			ctx := context.Background()
 			sp := &stepParams{
@@ -176,7 +175,7 @@ func TestActionGoTemplate(t *testing.T) {
 				t.Error(diff)
 			}
 
-			got := loadDirWithoutMode(t, scratchDir)
+			got := abctestutil.LoadDirWithoutMode(t, scratchDir)
 			if diff := cmp.Diff(got, tc.want); diff != "" {
 				t.Errorf("output differed from expected, (-got,+want): %s", diff)
 			}

--- a/templates/commands/render_action_include_test.go
+++ b/templates/commands/render_action_include_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/abcxyz/abc/templates/model"
+	abctestutil "github.com/abcxyz/abc/testutil"
 	"github.com/abcxyz/pkg/logging"
 	"github.com/abcxyz/pkg/testutil"
 	"github.com/google/go-cmp/cmp"
@@ -32,11 +33,11 @@ func TestActionInclude(t *testing.T) {
 	cases := []struct {
 		name                 string
 		include              *model.Include
-		templateContents     map[string]modeAndContents
-		destDirContents      map[string]modeAndContents
+		templateContents     map[string]abctestutil.ModeAndContents
+		destDirContents      map[string]abctestutil.ModeAndContents
 		inputs               map[string]string
 		flagSpec             string
-		wantScratchContents  map[string]modeAndContents
+		wantScratchContents  map[string]abctestutil.ModeAndContents
 		wantIncludedFromDest []string
 		statErr              error
 		wantErr              string
@@ -46,11 +47,11 @@ func TestActionInclude(t *testing.T) {
 			include: &model.Include{
 				Paths: modelStrings([]string{"myfile.txt"}),
 			},
-			templateContents: map[string]modeAndContents{
-				"myfile.txt": {0o600, "my file contents"},
+			templateContents: map[string]abctestutil.ModeAndContents{
+				"myfile.txt": {Mode: 0o600, Contents: "my file contents"},
 			},
-			wantScratchContents: map[string]modeAndContents{
-				"myfile.txt": {0o600, "my file contents"},
+			wantScratchContents: map[string]abctestutil.ModeAndContents{
+				"myfile.txt": {Mode: 0o600, Contents: "my file contents"},
 			},
 		},
 		{
@@ -58,11 +59,11 @@ func TestActionInclude(t *testing.T) {
 			include: &model.Include{
 				Paths: modelStrings([]string{"/myfile.txt"}),
 			},
-			templateContents: map[string]modeAndContents{
-				"myfile.txt": {0o600, "my file contents"},
+			templateContents: map[string]abctestutil.ModeAndContents{
+				"myfile.txt": {Mode: 0o600, Contents: "my file contents"},
 			},
-			wantScratchContents: map[string]modeAndContents{
-				"myfile.txt": {0o600, "my file contents"},
+			wantScratchContents: map[string]abctestutil.ModeAndContents{
+				"myfile.txt": {Mode: 0o600, Contents: "my file contents"},
 			},
 		},
 		{
@@ -77,15 +78,15 @@ func TestActionInclude(t *testing.T) {
 			include: &model.Include{
 				Paths: modelStrings([]string{"{{.my_dir}}/{{.my_file}}"}),
 			},
-			templateContents: map[string]modeAndContents{
-				"foo/bar.txt": {0o600, "file contents"},
+			templateContents: map[string]abctestutil.ModeAndContents{
+				"foo/bar.txt": {Mode: 0o600, Contents: "file contents"},
 			},
 			inputs: map[string]string{
 				"my_dir":  "foo",
 				"my_file": "bar.txt",
 			},
-			wantScratchContents: map[string]modeAndContents{
-				"foo/bar.txt": {0o600, "file contents"},
+			wantScratchContents: map[string]abctestutil.ModeAndContents{
+				"foo/bar.txt": {Mode: 0o600, Contents: "file contents"},
 			},
 		},
 		{
@@ -93,11 +94,11 @@ func TestActionInclude(t *testing.T) {
 			include: &model.Include{
 				Paths: modelStrings([]string{"myfile.txt", "myfile.txt"}),
 			},
-			templateContents: map[string]modeAndContents{
-				"myfile.txt": {0o600, "my file contents"},
+			templateContents: map[string]abctestutil.ModeAndContents{
+				"myfile.txt": {Mode: 0o600, Contents: "my file contents"},
 			},
-			wantScratchContents: map[string]modeAndContents{
-				"myfile.txt": {0o600, "my file contents"},
+			wantScratchContents: map[string]abctestutil.ModeAndContents{
+				"myfile.txt": {Mode: 0o600, Contents: "my file contents"},
 			},
 		},
 		{
@@ -105,8 +106,8 @@ func TestActionInclude(t *testing.T) {
 			include: &model.Include{
 				Paths: modelStrings([]string{"{{.filename}}"}),
 			},
-			templateContents: map[string]modeAndContents{
-				"myfile.txt": {0o600, "file contents"},
+			templateContents: map[string]abctestutil.ModeAndContents{
+				"myfile.txt": {Mode: 0o600, Contents: "file contents"},
 			},
 			inputs:  map[string]string{},
 			wantErr: `nonexistent input variable name "filename"`,
@@ -116,8 +117,8 @@ func TestActionInclude(t *testing.T) {
 			include: &model.Include{
 				Paths: modelStrings([]string{"nonexistent"}),
 			},
-			templateContents: map[string]modeAndContents{
-				"myfile.txt": {0o600, "file contents"},
+			templateContents: map[string]abctestutil.ModeAndContents{
+				"myfile.txt": {Mode: 0o600, Contents: "file contents"},
 			},
 			wantErr: `include path doesn't exist: "nonexistent"`,
 		},
@@ -128,8 +129,8 @@ func TestActionInclude(t *testing.T) {
 			include: &model.Include{
 				Paths: modelStrings([]string{"myfile.txt"}),
 			},
-			templateContents: map[string]modeAndContents{
-				"myfile.txt": {0o600, "my file contents"},
+			templateContents: map[string]abctestutil.ModeAndContents{
+				"myfile.txt": {Mode: 0o600, Contents: "my file contents"},
 			},
 			statErr: fmt.Errorf("fake error"),
 			wantErr: "fake error",
@@ -140,11 +141,11 @@ func TestActionInclude(t *testing.T) {
 				Paths:       modelStrings([]string{"a/deep/subdir/hello.txt"}),
 				StripPrefix: model.String{Val: "a/deep/subdir"},
 			},
-			templateContents: map[string]modeAndContents{
-				"a/deep/subdir/hello.txt": {0o600, "my file contents"},
+			templateContents: map[string]abctestutil.ModeAndContents{
+				"a/deep/subdir/hello.txt": {Mode: 0o600, Contents: "my file contents"},
 			},
-			wantScratchContents: map[string]modeAndContents{
-				"hello.txt": {0o600, "my file contents"},
+			wantScratchContents: map[string]abctestutil.ModeAndContents{
+				"hello.txt": {Mode: 0o600, Contents: "my file contents"},
 			},
 		},
 		{
@@ -153,11 +154,11 @@ func TestActionInclude(t *testing.T) {
 				Paths:       modelStrings([]string{"a/deep/subdir/hello.txt"}),
 				StripPrefix: model.String{Val: "a/deep"},
 			},
-			templateContents: map[string]modeAndContents{
-				"a/deep/subdir/hello.txt": {0o600, "my file contents"},
+			templateContents: map[string]abctestutil.ModeAndContents{
+				"a/deep/subdir/hello.txt": {Mode: 0o600, Contents: "my file contents"},
 			},
-			wantScratchContents: map[string]modeAndContents{
-				"subdir/hello.txt": {0o600, "my file contents"},
+			wantScratchContents: map[string]abctestutil.ModeAndContents{
+				"subdir/hello.txt": {Mode: 0o600, Contents: "my file contents"},
 			},
 		},
 		{
@@ -171,11 +172,11 @@ func TestActionInclude(t *testing.T) {
 				"ay":  "a",
 				"bee": "b",
 			},
-			templateContents: map[string]modeAndContents{
-				"a/deep/subdir/hello.txt": {0o600, "my file contents"},
+			templateContents: map[string]abctestutil.ModeAndContents{
+				"a/deep/subdir/hello.txt": {Mode: 0o600, Contents: "my file contents"},
 			},
-			wantScratchContents: map[string]modeAndContents{
-				"b/deep/subdir/hello.txt": {0o600, "my file contents"},
+			wantScratchContents: map[string]abctestutil.ModeAndContents{
+				"b/deep/subdir/hello.txt": {Mode: 0o600, Contents: "my file contents"},
 			},
 		},
 		{
@@ -184,11 +185,11 @@ func TestActionInclude(t *testing.T) {
 				Paths: modelStrings([]string{"dir1/file1.txt"}),
 				As:    modelStrings([]string{"dir2/file2.txt"}),
 			},
-			templateContents: map[string]modeAndContents{
-				"dir1/file1.txt": {0o600, "my file contents"},
+			templateContents: map[string]abctestutil.ModeAndContents{
+				"dir1/file1.txt": {Mode: 0o600, Contents: "my file contents"},
 			},
-			wantScratchContents: map[string]modeAndContents{
-				"dir2/file2.txt": {0o600, "my file contents"},
+			wantScratchContents: map[string]abctestutil.ModeAndContents{
+				"dir2/file2.txt": {Mode: 0o600, Contents: "my file contents"},
 			},
 		},
 		{
@@ -203,13 +204,13 @@ func TestActionInclude(t *testing.T) {
 				"three": "3",
 				"four":  "4",
 			},
-			templateContents: map[string]modeAndContents{
-				"file1.txt": {0o600, "my file contents"},
-				"file2.txt": {0o600, "my file contents"},
+			templateContents: map[string]abctestutil.ModeAndContents{
+				"file1.txt": {Mode: 0o600, Contents: "my file contents"},
+				"file2.txt": {Mode: 0o600, Contents: "my file contents"},
 			},
-			wantScratchContents: map[string]modeAndContents{
-				"file3.txt": {0o600, "my file contents"},
-				"file4.txt": {0o600, "my file contents"},
+			wantScratchContents: map[string]abctestutil.ModeAndContents{
+				"file3.txt": {Mode: 0o600, Contents: "my file contents"},
+				"file4.txt": {Mode: 0o600, Contents: "my file contents"},
 			},
 		},
 		{
@@ -218,8 +219,8 @@ func TestActionInclude(t *testing.T) {
 				Paths:       modelStrings([]string{"a/b/c"}),
 				StripPrefix: model.String{Val: "x/"},
 			},
-			templateContents: map[string]modeAndContents{
-				"file1.txt": {0o600, "my file contents"},
+			templateContents: map[string]abctestutil.ModeAndContents{
+				"file1.txt": {Mode: 0o600, Contents: "my file contents"},
 			},
 			wantErr: "wasn't a prefix of the actual path",
 		},
@@ -229,12 +230,12 @@ func TestActionInclude(t *testing.T) {
 				Paths: modelStrings([]string{"."}),
 			},
 			flagSpec: "spec.yaml",
-			templateContents: map[string]modeAndContents{
-				"file1.txt": {0o600, "my file contents"},
-				"spec.yaml": {0o600, "spec contents"},
+			templateContents: map[string]abctestutil.ModeAndContents{
+				"file1.txt": {Mode: 0o600, Contents: "my file contents"},
+				"spec.yaml": {Mode: 0o600, Contents: "spec contents"},
 			},
-			wantScratchContents: map[string]modeAndContents{
-				"file1.txt": {0o600, "my file contents"},
+			wantScratchContents: map[string]abctestutil.ModeAndContents{
+				"file1.txt": {Mode: 0o600, Contents: "my file contents"},
 			},
 		},
 		{
@@ -243,13 +244,13 @@ func TestActionInclude(t *testing.T) {
 				Paths: modelStrings([]string{"."}),
 			},
 			flagSpec: "spec.yaml",
-			templateContents: map[string]modeAndContents{
-				"file1.txt":        {0o600, "my file contents"},
-				"subdir/spec.yaml": {0o600, "spec contents"},
+			templateContents: map[string]abctestutil.ModeAndContents{
+				"file1.txt":        {Mode: 0o600, Contents: "my file contents"},
+				"subdir/spec.yaml": {Mode: 0o600, Contents: "spec contents"},
 			},
-			wantScratchContents: map[string]modeAndContents{
-				"file1.txt":        {0o600, "my file contents"},
-				"subdir/spec.yaml": {0o600, "spec contents"},
+			wantScratchContents: map[string]abctestutil.ModeAndContents{
+				"file1.txt":        {Mode: 0o600, Contents: "my file contents"},
+				"subdir/spec.yaml": {Mode: 0o600, Contents: "spec contents"},
 			},
 		},
 		{
@@ -258,14 +259,14 @@ func TestActionInclude(t *testing.T) {
 				Paths: modelStrings([]string{"."}),
 				From:  model.String{Val: "destination"},
 			},
-			templateContents: map[string]modeAndContents{
-				"spec.yaml": {0o600, "spec contents"},
+			templateContents: map[string]abctestutil.ModeAndContents{
+				"spec.yaml": {Mode: 0o600, Contents: "spec contents"},
 			},
-			destDirContents: map[string]modeAndContents{
-				"file1.txt": {0o600, "file1 contents"},
+			destDirContents: map[string]abctestutil.ModeAndContents{
+				"file1.txt": {Mode: 0o600, Contents: "file1 contents"},
 			},
-			wantScratchContents: map[string]modeAndContents{
-				"file1.txt": {0o600, "file1 contents"},
+			wantScratchContents: map[string]abctestutil.ModeAndContents{
+				"file1.txt": {Mode: 0o600, Contents: "file1 contents"},
 			},
 			wantIncludedFromDest: []string{"file1.txt"},
 		},
@@ -275,15 +276,15 @@ func TestActionInclude(t *testing.T) {
 				Paths: modelStrings([]string{"subdir"}),
 				From:  model.String{Val: "destination"},
 			},
-			templateContents: map[string]modeAndContents{
-				"spec.yaml": {0o600, "spec contents"},
+			templateContents: map[string]abctestutil.ModeAndContents{
+				"spec.yaml": {Mode: 0o600, Contents: "spec contents"},
 			},
-			destDirContents: map[string]modeAndContents{
-				"file1.txt":        {0o600, "file1 contents"},
-				"subdir/file2.txt": {0o600, "file2 contents"},
+			destDirContents: map[string]abctestutil.ModeAndContents{
+				"file1.txt":        {Mode: 0o600, Contents: "file1 contents"},
+				"subdir/file2.txt": {Mode: 0o600, Contents: "file2 contents"},
 			},
-			wantScratchContents: map[string]modeAndContents{
-				"subdir/file2.txt": {0o600, "file2 contents"},
+			wantScratchContents: map[string]abctestutil.ModeAndContents{
+				"subdir/file2.txt": {Mode: 0o600, Contents: "file2 contents"},
 			},
 			wantIncludedFromDest: []string{"subdir/file2.txt"},
 		},
@@ -293,16 +294,16 @@ func TestActionInclude(t *testing.T) {
 				Paths: modelStrings([]string{"file1.txt", "subdir/file2.txt"}),
 				From:  model.String{Val: "destination"},
 			},
-			templateContents: map[string]modeAndContents{
-				"spec.yaml": {0o600, "spec contents"},
+			templateContents: map[string]abctestutil.ModeAndContents{
+				"spec.yaml": {Mode: 0o600, Contents: "spec contents"},
 			},
-			destDirContents: map[string]modeAndContents{
-				"file1.txt":        {0o600, "file1 contents"},
-				"subdir/file2.txt": {0o600, "file2 contents"},
+			destDirContents: map[string]abctestutil.ModeAndContents{
+				"file1.txt":        {Mode: 0o600, Contents: "file1 contents"},
+				"subdir/file2.txt": {Mode: 0o600, Contents: "file2 contents"},
 			},
-			wantScratchContents: map[string]modeAndContents{
-				"file1.txt":        {0o600, "file1 contents"},
-				"subdir/file2.txt": {0o600, "file2 contents"},
+			wantScratchContents: map[string]abctestutil.ModeAndContents{
+				"file1.txt":        {Mode: 0o600, Contents: "file1 contents"},
+				"subdir/file2.txt": {Mode: 0o600, Contents: "file2 contents"},
 			},
 			wantIncludedFromDest: []string{"file1.txt", "subdir/file2.txt"},
 		},
@@ -317,25 +318,20 @@ func TestActionInclude(t *testing.T) {
 			ctx := logging.WithLogger(context.Background(), logging.TestLogger(t))
 
 			// Convert to OS-specific paths
-			convertKeysToPlatformPaths(
+			abctestutil.KeysToPlatformPaths(
 				tc.templateContents,
 				tc.wantScratchContents,
 			)
-			toPlatformPaths(tc.wantIncludedFromDest)
+			abctestutil.ToPlatformPaths(tc.wantIncludedFromDest)
 
 			tempDir := t.TempDir()
 			templateDir := filepath.Join(tempDir, templateDirNamePart)
 			scratchDir := filepath.Join(tempDir, scratchDirNamePart)
 			destDir := filepath.Join(tempDir, "dest")
 
-			if err := writeAll(templateDir, tc.templateContents); err != nil {
-				t.Fatal(err)
-			}
-
+			abctestutil.WriteAll(t, templateDir, tc.templateContents)
 			// For testing "include from destination"
-			if err := writeAll(destDir, tc.destDirContents); err != nil {
-				t.Fatal(err)
-			}
+			abctestutil.WriteAll(t, destDir, tc.destDirContents)
 
 			sp := &stepParams{
 				flags: &RenderFlags{
@@ -355,12 +351,12 @@ func TestActionInclude(t *testing.T) {
 				t.Error(diff)
 			}
 
-			gotTemplateContents := loadDirContents(t, filepath.Join(tempDir, templateDirNamePart))
+			gotTemplateContents := abctestutil.LoadDirContents(t, filepath.Join(tempDir, templateDirNamePart))
 			if diff := cmp.Diff(gotTemplateContents, tc.templateContents, cmpFileMode); diff != "" {
 				t.Errorf("template directory should not have been touched (-got,+want): %s", diff)
 			}
 
-			gotScratchContents := loadDirContents(t, filepath.Join(tempDir, scratchDirNamePart))
+			gotScratchContents := abctestutil.LoadDirContents(t, filepath.Join(tempDir, scratchDirNamePart))
 			if diff := cmp.Diff(gotScratchContents, tc.wantScratchContents, cmpFileMode); diff != "" {
 				t.Errorf("scratch directory contents were not as expected (-got,+want): %s", diff)
 			}

--- a/templates/commands/render_action_regexnamelookup_test.go
+++ b/templates/commands/render_action_regexnamelookup_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/abcxyz/abc/templates/model"
+	abctestutil "github.com/abcxyz/abc/testutil"
 	"github.com/abcxyz/pkg/testutil"
 	"github.com/google/go-cmp/cmp"
 )
@@ -147,9 +148,7 @@ func TestActionRegexNameLookup(t *testing.T) {
 			t.Parallel()
 
 			scratchDir := t.TempDir()
-			if err := writeAllDefaultMode(scratchDir, tc.initContents); err != nil {
-				t.Fatal(err)
-			}
+			abctestutil.WriteAllDefaultMode(t, scratchDir, tc.initContents)
 
 			ctx := context.Background()
 			sp := &stepParams{
@@ -162,7 +161,7 @@ func TestActionRegexNameLookup(t *testing.T) {
 				t.Error(diff)
 			}
 
-			got := loadDirWithoutMode(t, scratchDir)
+			got := abctestutil.LoadDirWithoutMode(t, scratchDir)
 			if diff := cmp.Diff(got, tc.want); diff != "" {
 				t.Errorf("output differed from expected, (-got,+want): %s", diff)
 			}

--- a/templates/commands/render_action_regexreplace_test.go
+++ b/templates/commands/render_action_regexreplace_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/abcxyz/abc/templates/model"
+	abctestutil "github.com/abcxyz/abc/testutil"
 	"github.com/abcxyz/pkg/testutil"
 	"github.com/google/go-cmp/cmp"
 )
@@ -226,9 +227,7 @@ func TestActionRegexReplace(t *testing.T) {
 			t.Parallel()
 
 			scratchDir := t.TempDir()
-			if err := writeAllDefaultMode(scratchDir, tc.initContents); err != nil {
-				t.Fatal(err)
-			}
+			abctestutil.WriteAllDefaultMode(t, scratchDir, tc.initContents)
 
 			ctx := context.Background()
 			sp := &stepParams{
@@ -241,7 +240,7 @@ func TestActionRegexReplace(t *testing.T) {
 				t.Error(diff)
 			}
 
-			got := loadDirWithoutMode(t, scratchDir)
+			got := abctestutil.LoadDirWithoutMode(t, scratchDir)
 			if diff := cmp.Diff(got, tc.want); diff != "" {
 				t.Errorf("output differed from expected, (-got,+want): %s", diff)
 			}

--- a/templates/commands/render_action_stringreplace_test.go
+++ b/templates/commands/render_action_stringreplace_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/abcxyz/abc/templates/model"
+	abctestutil "github.com/abcxyz/abc/testutil"
 	"github.com/abcxyz/pkg/testutil"
 	"github.com/google/go-cmp/cmp"
 )
@@ -211,9 +212,7 @@ func TestActionStringReplace(t *testing.T) {
 			t.Parallel()
 
 			scratchDir := t.TempDir()
-			if err := writeAllDefaultMode(scratchDir, tc.initialContents); err != nil {
-				t.Fatal(err)
-			}
+			abctestutil.WriteAllDefaultMode(t, scratchDir, tc.initialContents)
 
 			sr := &model.StringReplace{
 				Paths:        modelStrings(tc.paths),
@@ -232,7 +231,7 @@ func TestActionStringReplace(t *testing.T) {
 				t.Error(diff)
 			}
 
-			got := loadDirWithoutMode(t, scratchDir)
+			got := abctestutil.LoadDirWithoutMode(t, scratchDir)
 			if diff := cmp.Diff(got, tc.want); diff != "" {
 				t.Errorf("scratch directory contents were not as expected (-got,+want): %v", diff)
 			}

--- a/templates/commands/render_test.go
+++ b/templates/commands/render_test.go
@@ -525,6 +525,7 @@ steps:
 			backupDir := filepath.Join(tempDir, "backups")
 			rfs := &realFS{}
 			fg := &fakeGetter{
+				t:      t,
 				err:    tc.getterErr,
 				output: tc.templateContents,
 			}
@@ -761,6 +762,7 @@ func (e *errorFS) WriteFile(name string, data []byte, perm os.FileMode) error {
 }
 
 type fakeGetter struct {
+	t         *testing.T
 	gotSource string
 	output    map[string]string
 	err       error
@@ -771,6 +773,6 @@ func (f *fakeGetter) Get(ctx context.Context, req *getter.Request) (*getter.GetR
 	if f.err != nil {
 		return nil, f.err
 	}
-	abctestutil.WriteAllDefaultMode(nil, req.Dst, f.output)
+	abctestutil.WriteAllDefaultMode(f.t, req.Dst, f.output)
 	return &getter.GetResult{Dst: req.Dst}, nil
 }

--- a/testutil/dirmap.go
+++ b/testutil/dirmap.go
@@ -1,0 +1,105 @@
+package testutil
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+type ModeAndContents struct {
+	Mode     os.FileMode
+	Contents string
+}
+
+// LoadDirContents reads all the files recursively under "dir", returning their
+// contents as a map[filename]->contents. Returns nil if dir doesn't exist.
+func LoadDirContents(t *testing.T, dir string) map[string]ModeAndContents {
+	t.Helper()
+
+	if _, err := os.Stat(dir); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+		t.Fatal(err)
+	}
+	out := map[string]ModeAndContents{}
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		contents, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("ReadFile(): %w", err)
+		}
+		rel, err := filepath.Rel(dir, path)
+		if err != nil {
+			return fmt.Errorf("Rel(): %w", err)
+		}
+		fi, err := d.Info()
+		if err != nil {
+			t.Fatal(err)
+		}
+		out[rel] = ModeAndContents{
+			Mode:     fi.Mode(),
+			Contents: string(contents),
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("WalkDir(): %v", err)
+	}
+	return out
+}
+
+// LoadDirWithoutMode is like LoadDirContents, but doesn't return permission
+// bits.
+func LoadDirWithoutMode(t *testing.T, dir string) map[string]string {
+	t.Helper()
+
+	withMode := LoadDirContents(t, dir)
+	if withMode == nil {
+		return nil
+	}
+	out := map[string]string{}
+	for name, mc := range withMode {
+		out[name] = mc.Contents
+	}
+	return out
+}
+
+// WriteAllDefaultMode wraps writeAll and sets file permissions to 0600.
+func WriteAllDefaultMode(t *testing.T, root string, files map[string]string) {
+	withMode := map[string]ModeAndContents{}
+	for name, contents := range files {
+		withMode[name] = ModeAndContents{
+			Mode:     0o600,
+			Contents: contents,
+		}
+	}
+	WriteAll(t, root, withMode)
+}
+
+// WriteAll saves the given file contents with the given permissions.
+func WriteAll(t *testing.T, root string, files map[string]ModeAndContents) {
+	for path, mc := range files {
+		fullPath := filepath.Join(root, path)
+		dir := filepath.Dir(fullPath)
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(fullPath, []byte(mc.Contents), mc.Mode); err != nil {
+			t.Fatal(err)
+		}
+		// The user's may have prevented the file from being created with the
+		// desired permissions. Use chmod to really set the desired permissions.
+		if err := os.Chmod(fullPath, mc.Mode); err != nil {
+			t.Fatal(err)
+		}
+	}
+}

--- a/testutil/dirmap.go
+++ b/testutil/dirmap.go
@@ -1,3 +1,17 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package testutil
 
 import (
@@ -75,6 +89,7 @@ func LoadDirWithoutMode(t *testing.T, dir string) map[string]string {
 
 // WriteAllDefaultMode wraps writeAll and sets file permissions to 0600.
 func WriteAllDefaultMode(t *testing.T, root string, files map[string]string) {
+	t.Helper()
 	withMode := map[string]ModeAndContents{}
 	for name, contents := range files {
 		withMode[name] = ModeAndContents{
@@ -87,6 +102,7 @@ func WriteAllDefaultMode(t *testing.T, root string, files map[string]string) {
 
 // WriteAll saves the given file contents with the given permissions.
 func WriteAll(t *testing.T, root string, files map[string]ModeAndContents) {
+	t.Helper()
 	for path, mc := range files {
 		fullPath := filepath.Join(root, path)
 		dir := filepath.Dir(fullPath)

--- a/testutil/separator.go
+++ b/testutil/separator.go
@@ -1,3 +1,17 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package testutil
 
 import "path/filepath"

--- a/testutil/separator.go
+++ b/testutil/separator.go
@@ -1,0 +1,26 @@
+package testutil
+
+import "path/filepath"
+
+// KeysToPlatformPaths converts the keys from slash-separated paths to the local
+// OS file separator. The maps are modified in place.
+func KeysToPlatformPaths[T any](maps ...map[string]T) {
+	for _, m := range maps {
+		for k, v := range m {
+			if newKey := filepath.FromSlash(k); newKey != k {
+				m[newKey] = v
+				delete(m, k)
+			}
+		}
+	}
+}
+
+// ToPlatformPaths converts each input from slash-separated paths to the local
+// OS file separator. The slices are modified in place.
+func ToPlatformPaths(slices ...[]string) {
+	for _, s := range slices {
+		for i := range s {
+			s[i] = filepath.FromSlash(s[i])
+		}
+	}
+}


### PR DESCRIPTION
This is change 2 of 4-ish for that will add a test framework for templates. The goal is to (1) allow template developers to test their templates and (2) allow abc CLI developers to verify that code changes haven't broken templates.

Reviewers, the only mildly interesting parts of this PR are in render_test.go and testutil/*. Everything else is just pointing to the new location.

This change:

 - Makes the test helpers usable outside the "commands" package
 - Changes the names slightly for conciseness

The convention I chose is to import the testutil package as "abctestutil" to avoid colliding with the github.com/abcxyz/pkg/testutil package.