### PR TITLE
feat: Add template for enabling project services

### DIFF
--- a/t/gcp_project_services/README.md
+++ b/t/gcp_project_services/README.md
@@ -1,0 +1,40 @@
+# Example: GCP Project Services
+
+Enables GCP services for a specific project in an environment specified by the [gcp-org-terraform-template](https://github.com/abcxyz/gcp-org-terraform-template).
+
+1. cd into the resources/[product_id] directory
+
+    ```shell
+    $ cd gcp-org-terraform-template/resources/[product_id]
+    ```
+
+1. Install the `abc` binary
+
+    ```shell
+    $ go install github.com/abcxyz/abc/cmd/abc@latest
+    $ abc --help
+    ```
+
+    This only works if you have go installed (https://go.dev/doc/install) and have the Go binary directory in your $PATH (try PATH=$PATH:~/go/bin).
+
+1. Execute the template defined in the `t` directory.
+This will output several Terraform files that can be applied to a project.
+
+    ```shell
+    $ abc templates render \
+    -input="product_id=abc-demo" \
+    -input="project_id=abc-demo-a-6a5eab" \
+    -input="services=artifactregistry.googleapis.com,iam.googleapis.com,run.googleapis.com" \
+    -input="environment=autopush" \
+    -input="bucket_name=abcxyz-tycho-terraform-state-f916" \
+    -input="bucket_prefix=infra" \
+    -dest="./test" \
+    -spec="spec.yaml" \
+    ~/gitrepos/abc/t/gcp_project_services
+    ```
+
+1. Terraform init and apply the project changes.
+
+    ```shell
+    terraform init -backend=false
+    ```

--- a/t/gcp_project_services/README.md
+++ b/t/gcp_project_services/README.md
@@ -4,12 +4,6 @@ Enables GCP services for a specific project in an environment specified by the [
 
 1. [Install the `abc` binary](https://github.com/abcxyz/abc/blob/main/README.md#installation).
 
-1. cd into the resources/[product_id] directory
-
-    ```shell
-    $ cd gcp-org-terraform-template/resources/[product_id]
-    ```
-
 1. Render this template, this will output several Terraform files that can be applied to a GCP project. See spec.yaml for more details.
 
 1. Terraform init and apply the project changes.

--- a/t/gcp_project_services/README.md
+++ b/t/gcp_project_services/README.md
@@ -2,36 +2,15 @@
 
 Enables GCP services for a specific project in an environment specified by the [gcp-org-terraform-template](https://github.com/abcxyz/gcp-org-terraform-template).
 
+1. [Install the `abc` binary](https://github.com/abcxyz/abc/blob/main/README.md#installation).
+
 1. cd into the resources/[product_id] directory
 
     ```shell
     $ cd gcp-org-terraform-template/resources/[product_id]
     ```
 
-1. Install the `abc` binary
-
-    ```shell
-    $ go install github.com/abcxyz/abc/cmd/abc@latest
-    $ abc --help
-    ```
-
-    This only works if you have go installed (https://go.dev/doc/install) and have the Go binary directory in your $PATH (try PATH=$PATH:~/go/bin).
-
-1. Execute the template defined in the `t` directory.
-This will output several Terraform files that can be applied to a project.
-
-    ```shell
-    $ abc templates render \
-    -input="product_id=abc-demo" \
-    -input="project_id=abc-demo-a-6a5eab" \
-    -input="services=artifactregistry.googleapis.com,iam.googleapis.com,run.googleapis.com" \
-    -input="environment=autopush" \
-    -input="bucket_name=abcxyz-tycho-terraform-state-f916" \
-    -input="bucket_prefix=infra" \
-    -dest="./test" \
-    -spec="spec.yaml" \
-    ~/gitrepos/abc/t/gcp_project_services
-    ```
+1. Render this template, this will output several Terraform files that can be applied to a GCP project. See spec.yaml for more details.
 
 1. Terraform init and apply the project changes.
 

--- a/t/gcp_project_services/environment-main.tf
+++ b/t/gcp_project_services/environment-main.tf
@@ -1,0 +1,16 @@
+locals {
+  project_id = "{{.project_id}}"
+}
+
+resource "google_project_service" "services" {
+  for_each = toset([
+    {{/* Replace comma with quote-comma-newline-fourspaces. Because TODO */ -}}
+    "{{replaceAll .services "," "\",\n    \""}}",
+  ])
+
+  project = local.project_id
+
+  service                    = each.value
+  disable_on_destroy         = false
+  disable_dependent_services = false
+}

--- a/t/gcp_project_services/environment-main.tf
+++ b/t/gcp_project_services/environment-main.tf
@@ -4,7 +4,7 @@ locals {
 
 resource "google_project_service" "services" {
   for_each = toset([
-    {{/* Replace comma with quote-comma-newline-fourspaces. Because TODO */ -}}
+    {{/* Replace comma with quote-comma-newline-fourspaces for proper formatting of services to enable*/ -}}
     "{{replaceAll .services "," "\",\n    \""}}",
   ])
 

--- a/t/gcp_project_services/environment-terraform.backend.tf
+++ b/t/gcp_project_services/environment-terraform.backend.tf
@@ -1,0 +1,6 @@
+terraform {
+  backend "gcs" {
+    bucket = "{{.bucket_name}}"
+    prefix = "{{.bucket_prefix}}/resources/{{.product_id}}/{{.environment}}"
+  }
+}

--- a/t/gcp_project_services/environment-terraform.tf
+++ b/t/gcp_project_services/environment-terraform.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    google = {
+      version = ">= 4.45"
+      source  = "hashicorp/google"
+    }
+  }
+}
+
+provider "google" {}

--- a/t/gcp_project_services/spec.yaml
+++ b/t/gcp_project_services/spec.yaml
@@ -15,7 +15,19 @@
 apiVersion: 'cli.abcxyz.dev/v1alpha1'
 kind: 'Template'
 
-desc: 'Enables Cloud Run and associated services for a resource project in a given environment'
+desc: |
+  'Enables Cloud Run and associated services for a resource project in a given environment.'
+  Usage:
+    $ abc templates render \
+    -input="product_id=abc-demo" \
+    -input="project_id=abc-demo-a-6a5eab" \
+    -input="services=artifactregistry.googleapis.com,iam.googleapis.com,run.googleapis.com" \
+    -input="environment=autopush" \
+    -input="bucket_name=abcxyz-tycho-terraform-state-f916" \
+    -input="bucket_prefix=infra" \
+    -spec="spec.yaml" \
+    ~/gitrepos/abc/t/gcp_project_services
+
 inputs:
   - name: 'product_id'
     desc: 'The id of the product to create'
@@ -25,7 +37,6 @@ inputs:
 
   - name: 'services'
     desc: 'A list of services to enable for each project'
-    default: 'artifactregistry.googleapis.com,iam.googleapis.com,run.googleapis.com'
 
   - name: 'environment'
     desc: 'The environment to enable services on'
@@ -35,7 +46,6 @@ inputs:
 
   - name: 'bucket_prefix'
     desc: 'The Terraform state bucket prefix'
-    default: 'gcp-org'
 
 steps:
   - desc: 'Include some files and directories'

--- a/t/gcp_project_services/spec.yaml
+++ b/t/gcp_project_services/spec.yaml
@@ -1,0 +1,58 @@
+# Copyright 2023 The Authors (see AUTHORS file)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: 'cli.abcxyz.dev/v1alpha1'
+kind: 'Template'
+
+desc: 'Enables Cloud Run and associated services for a resource project in a given environment'
+inputs:
+  - name: 'product_id'
+    desc: 'The id of the product to create'
+
+  - name: 'project_id'
+    desc: 'The id of the project to enable services on'
+
+  - name: 'services'
+    desc: 'A list of services to enable for each project'
+    default: 'artifactregistry.googleapis.com,iam.googleapis.com,run.googleapis.com'
+
+  - name: 'environment'
+    desc: 'The environment to enable services on'
+
+  - name: 'bucket_name'
+    desc: 'The Google Clod storage bucket name for the Terraform state'
+
+  - name: 'bucket_prefix'
+    desc: 'The Terraform state bucket prefix'
+    default: 'gcp-org'
+
+steps:
+  - desc: 'Include some files and directories'
+    action: 'include'
+    params:
+      paths:
+        - 'environment-main.tf'
+        - 'environment-terraform.tf'
+        - 'environment-terraform.backend.tf'
+      as:
+        - '{{.environment}}/main.tf'
+        - '{{.environment}}/terraform.tf'
+        - '{{.environment}}/terraform.backend.tf'
+
+  - desc: 'Render template with input variables'
+    action: 'go_template'
+    params:
+      paths:
+        - '{{.environment}}/main.tf'
+        - '{{.environment}}/terraform.backend.tf'

--- a/t/gcp_project_services/spec.yaml
+++ b/t/gcp_project_services/spec.yaml
@@ -22,9 +22,10 @@ desc: |
     -input="product_id=abc-demo" \
     -input="project_id=abc-demo-a-6a5eab" \
     -input="services=artifactregistry.googleapis.com,iam.googleapis.com,run.googleapis.com" \
-    -input="environment=autopush" \
+    -input="environment=integration" \
     -input="bucket_name=abcxyz-tycho-terraform-state-f916" \
     -input="bucket_prefix=infra" \
+    -dest="./resources/abc-demo" \
     -spec="spec.yaml" \
     ~/gitrepos/abc/t/gcp_project_services
 


### PR DESCRIPTION
Based off of the product + projects setup by https://github.com/abcxyz/terraform-modules/pull/42, this template enables specific services for projects that could eventually be used to demonstrate fully functioning e2e service setup with the rest_server template, for example.