### PR TITLE
check in csp trusted type for react

### DIFF
--- a/t/react_template/public/index.html
+++ b/t/react_template/public/index.html
@@ -9,6 +9,8 @@
       name="description"
       content="React template"
     />
+    <!-- sctrict to add trusted type when using dangerouslySetInnerHTML -->
+    <meta http-equiv="Content-Security-Policy" content="require-trusted-types-for 'script'" />
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/

--- a/t/react_template/src/App.tsx
+++ b/t/react_template/src/App.tsx
@@ -14,25 +14,10 @@
 
 import Typography from '@mui/material/Typography';
 import Grid from '@mui/material/Grid';
-import {useEffect, useState} from 'react';
 
 const logo = require('./img/bets-platform-logo.png');
 
 const App = () => {
-  const [message, setMessage] = useState('Waiting response...');
-  useEffect(() => {
-    fetch('https://rest-server-demo-5nsxs6u22q-uw.a.run.app/', {
-      method: 'GET',
-    })
-      .then(response => response.json())
-      .then(data => {
-        setMessage(data.message);
-      })
-      .catch(err => {
-        console.log(err);
-      });
-  }, []);
-
   return (
     <Grid
       container
@@ -46,7 +31,7 @@ const App = () => {
       <Grid item xs={3}>
         <img src={logo} alt="bets-platform" height={200} />
         <Typography variant="h4" textAlign="center">
-          {message}
+          hellow world
         </Typography>
       </Grid>
     </Grid>


### PR DESCRIPTION
Goal: improve React security

Security concern:
React applies automatic escaping , but it has limitation - no strict contextual auto-escaping. For example, it allows innerHTML pass by dangerouslySetInnerHTML, which is easily to get XSS attack.  

Solution:
1.  Sanitization the content using DOMPurify package. 
cons: only works for dangerouslySetInnerHTML. 

2. Add Trusted Types - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/require-trusted-types-for 
pros: works for all types of inner context, such as ref.inner  
cons: not support in all browsers. 

addition:
I decided to move the backend api call, to make the template easier to start. The backend call would be shown in the demo.
