### PR TITLE
fix: spec.yaml wasn't always being skipped

### DIFF
--- a/templates/commands/render_action_include.go
+++ b/templates/commands/render_action_include.go
@@ -89,7 +89,7 @@ func actionInclude(ctx context.Context, inc *model.Include, sp *stepParams) erro
 			// If we're copying the template root directory, automatically skip
 			// the spec.yaml file, because it's very unlikely that the user actually
 			// wants the spec file in the template output.
-			skipNow[sp.flags.Spec] = struct{}{}
+			skipNow[filepath.Clean(sp.flags.Spec)] = struct{}{}
 		}
 
 		if _, err := sp.fs.Stat(absSrc); err != nil {

--- a/templates/commands/render_action_include_test.go
+++ b/templates/commands/render_action_include_test.go
@@ -238,6 +238,20 @@ func TestActionInclude(t *testing.T) {
 			},
 		},
 		{
+			name: "spec_yaml_should_be_skipped_even_with_dot_slash",
+			include: &model.Include{
+				Paths: modelStrings([]string{"."}),
+			},
+			flagSpec: "./spec.yaml",
+			templateContents: map[string]modeAndContents{
+				"file1.txt": {0o600, "my file contents"},
+				"spec.yaml": {0o600, "spec contents"},
+			},
+			wantScratchContents: map[string]modeAndContents{
+				"file1.txt": {0o600, "my file contents"},
+			},
+		},
+		{
 			name: "spec_yaml_in_subdir_should_not_be_skipped",
 			include: &model.Include{
 				Paths: modelStrings([]string{"."}),


### PR DESCRIPTION
Background: there's a special case in `abc` where the spec.yaml file isn't included in the template output, even if there's an `include` for path `.`. It turns out this was buggy, and is being fixed here.

Since we were comparing unnormalized paths to normalized paths, we'd sometimes overlook that `./spec.yaml` and `spec.yaml` were the same file. The visitor function provided to copyRecursive was being called with the output of `filepath.Rel()`, which calls `filepath.Clean()` implicitly. But the blocklist was being initialized with un-Clean()ed paths. So the fix is just to `Clean()` the path before adding it to the blocklist.

cc @kevya-google who noticed and reported this.