### PR TITLE
fix: log level and mode were being ignored

### DIFF
--- a/templates/commands/render.go
+++ b/templates/commands/render.go
@@ -98,6 +98,7 @@ func (c *RenderCommand) Run(ctx context.Context, args []string) error {
 	}
 
 	c.setLogEnvVars()
+	ctx = logging.WithLogger(ctx, logging.NewFromEnv("ABC_"))
 
 	fSys := c.testFS // allow filesystem interaction to be faked for testing
 	if fSys == nil {


### PR DESCRIPTION
We were setting the right environment variables to configure the `logging` package, but since we never called `logging.NewFromEnv`, it had no effect.

This fixes JSON output being printed to the console unexpectedly.

This is hard to unit test, but I manually verified that the output levels and modes look good. There's no more surprise JSON output.

cc @verbanicm who noticed this problem.