### PR TITLE
Remove the `--spec` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Usage: `abc templates render [flags] <template_location>`
 
 The `<template_location>` parameter is any directory-like location that can be
 downloaded by the library that we use for template downloads,
-github.com/hashicorp/go-getter. It should contain a `spec.yaml` file in its root
-(or use the `--spec` flag to specify an alternate spec file name).
+github.com/hashicorp/go-getter. It should contain a `spec.yaml` file in its
+root.
 
 Examples of template locations:
 
@@ -43,8 +43,6 @@ Examples of template locations:
 
 #### Flags
 
-- `--spec <path_to_spec_yaml>`: the path of the spec yaml file, relative to the
-  template root. Defaults to `spec.yaml`.
 - `--dest <output_dir>`: the directory on the local filesystem to write output
   to. Defaults to the current directory. If it doesn't exist, it will be
   created.
@@ -166,14 +164,6 @@ create a "hello world" Go web service.
    # Assuming you're using GitHub, now go create a PR.
    ```
 
-It's possible for multiple templates to live in the same git repo, directory,
-tar file, etc. When this happens, there are multiple spec files, and the CLI
-user provides the `--spec=foo.yaml` flag to choose which spec file to execute.
-The `--spec` path is relative to the template root that was provided by the CLI.
-For example, if the user ran
-`abc templates render --spec=foo.yaml github.com/abcxyz/abc.git//examples/templates/render/hello_jupiter`,
-then the `foo.yaml` should be in the `hello_jupiter` directory.
-
 ## Template developer guide
 
 This section explains how you can create a template for others to install (aka
@@ -190,7 +180,7 @@ https://github.com/hashicorp/go-getter library, including:
 - A GCP Cloud Storage bucket
 
 In essence, a template is a directory or directory-like object containing a
-"spec file", usually named `spec.yaml`
+"spec file", named `spec.yaml`
 ([example](https://github.com/abcxyz/abc/blob/main/examples/templates/render/hello_jupiter/spec.yaml)),
 and other files such as source code and config files.
 
@@ -200,9 +190,9 @@ Template rendering has a few phases:
 
 - The template is downloaded and unpacked into a temp directory, called the
   "template directory."
-- The spec file is loaded and parsed as YAML from the template directory
+- The spec.yaml file is loaded and parsed as YAML from the template directory
 - Another temp directory called the "scratch directory" is created.
-- The steps in the spec file are executed in sequence:
+- The steps in the spec.yaml file are executed in sequence:
   - `include` actions copy files and directories from the template directory to
     the scratch directory. This is analogous to a Dockerfile COPY command. For
     example:
@@ -215,7 +205,7 @@ Template rendering has a few phases:
     `go_template` actions transform the files that are in the scratch directory
     at the time they're executed.
     - This means that for example a string_replace after an append will affect
-      the appended text, but if put before it will not. 
+      the appended text, but if put before it will not.
 - Once all steps are executed, the contents of the scratch directory are copied
   to the output directory.
 
@@ -225,7 +215,7 @@ them for inspection.
 
 ### The spec file
 
-The spec file describes the template, including:
+The spec file, named `spec.yaml` describes the template, including:
 
 - A human-readable description of the template
 - What inputs are needed from the user (e.g. their service name)
@@ -399,7 +389,6 @@ Params:
   - `{{.flags.dest}}`: the value of the the `--dest` flag, e.g. `.`
   - `{{.flags.source}}`: the template location that's being rendered, e.g.
     `github.com/abcxyz/abc.git//t/my_template`
-  - `{{.flags.spec}}`: the value of the `--spec` flag, e.g. `spec.yaml`
 
 Example:
 
@@ -421,15 +410,17 @@ If you need to remove an existing trailing newline before appending, use
 `regex_replace` instead.
 
 Params:
-- `paths`: List of files and/or directory trees to append to end of.
-  May use template expressions (e.g. `{{.my_input}}`). Directories will be
-  crawled recursively and every file underneath will be processed.
+
+- `paths`: List of files and/or directory trees to append to end of. May use
+  template expressions (e.g. `{{.my_input}}`). Directories will be crawled
+  recursively and every file underneath will be processed.
 - `with`: String to append to the file.
-- `skip_ensure_newline`: Bool (default false). When true, a `with` not ending
-  in a newline will result in a file with no terminating newline. If `false`, a
+- `skip_ensure_newline`: Bool (default false). When true, a `with` not ending in
+  a newline will result in a file with no terminating newline. If `false`, a
   newline will be added automatically if not provided.
 
 Example:
+
 ```yaml
 - action: 'append'
   params:

--- a/templates/commands/render.go
+++ b/templates/commands/render.go
@@ -50,6 +50,9 @@ const (
 
 	defaultLogLevel = "warn"
 	defaultLogMode  = "dev"
+
+	// The spec file is always located in the template root dir and named spec.yaml.
+	specName = "spec.yaml"
 )
 
 type RenderCommand struct {
@@ -227,12 +230,7 @@ func (c *RenderCommand) realRun(ctx context.Context, rp *runParams) (outErr erro
 		return err
 	}
 
-	safeSpecPath, err := safeRelPath(nil, c.flags.Spec)
-	if err != nil {
-		return fmt.Errorf("invalid --spec path %q: %w", c.flags.Spec, err)
-	}
-
-	spec, err := loadSpecFile(rp.fs, templateDir, safeSpecPath)
+	spec, err := loadSpecFile(rp.fs, templateDir, specName)
 	if err != nil {
 		return err
 	}

--- a/templates/commands/render_action_include.go
+++ b/templates/commands/render_action_include.go
@@ -89,7 +89,7 @@ func actionInclude(ctx context.Context, inc *model.Include, sp *stepParams) erro
 			// If we're copying the template root directory, automatically skip
 			// the spec.yaml file, because it's very unlikely that the user actually
 			// wants the spec file in the template output.
-			skipNow[sp.flags.Spec] = struct{}{}
+			skipNow["spec.yaml"] = struct{}{}
 		}
 
 		if _, err := sp.fs.Stat(absSrc); err != nil {

--- a/templates/commands/render_action_include_test.go
+++ b/templates/commands/render_action_include_test.go
@@ -35,7 +35,6 @@ func TestActionInclude(t *testing.T) {
 		templateContents     map[string]modeAndContents
 		destDirContents      map[string]modeAndContents
 		inputs               map[string]string
-		flagSpec             string
 		wantScratchContents  map[string]modeAndContents
 		wantIncludedFromDest []string
 		statErr              error
@@ -228,7 +227,6 @@ func TestActionInclude(t *testing.T) {
 			include: &model.Include{
 				Paths: modelStrings([]string{"."}),
 			},
-			flagSpec: "spec.yaml",
 			templateContents: map[string]modeAndContents{
 				"file1.txt": {0o600, "my file contents"},
 				"spec.yaml": {0o600, "spec contents"},
@@ -242,7 +240,6 @@ func TestActionInclude(t *testing.T) {
 			include: &model.Include{
 				Paths: modelStrings([]string{"."}),
 			},
-			flagSpec: "spec.yaml",
 			templateContents: map[string]modeAndContents{
 				"file1.txt":        {0o600, "my file contents"},
 				"subdir/spec.yaml": {0o600, "spec contents"},
@@ -339,7 +336,6 @@ func TestActionInclude(t *testing.T) {
 
 			sp := &stepParams{
 				flags: &RenderFlags{
-					Spec: tc.flagSpec,
 					Dest: destDir,
 				},
 				fs: &errorFS{

--- a/templates/commands/render_action_print.go
+++ b/templates/commands/render_action_print.go
@@ -51,6 +51,5 @@ func flagsForTemplate(r *RenderFlags) map[string]any {
 	return map[string]any{
 		"dest":   r.Dest,
 		"source": r.Source,
-		"spec":   r.Spec,
 	}
 }

--- a/templates/commands/render_action_print_test.go
+++ b/templates/commands/render_action_print_test.go
@@ -57,7 +57,7 @@ func TestActionPrint(t *testing.T) {
 		},
 		{
 			name: "flags_in_message",
-			in:   "{{.flags.dest}} {{.flags.source}} {{.flags.spec}}",
+			in:   "{{.flags.dest}} {{.flags.source}}",
 			flags: RenderFlags{
 				Source:         "mysource",
 				Dest:           "mydest",
@@ -65,9 +65,8 @@ func TestActionPrint(t *testing.T) {
 				LogLevel:       "myloglevel",
 				ForceOverwrite: true,
 				KeepTempDirs:   true,
-				Spec:           "myspec",
 			},
-			want: "mydest mysource myspec\n",
+			want: "mydest mysource\n",
 		},
 	}
 

--- a/templates/commands/render_flags.go
+++ b/templates/commands/render_flags.go
@@ -55,22 +55,10 @@ type RenderFlags struct {
 	// KeepTempDirs prevents the cleanup of temporary directories after rendering is complete.
 	// This can be useful for debugging a failing template.
 	KeepTempDirs bool
-
-	// Spec is the relative path within the template of the YAML file that
-	// specifies how the template is rendered. This will often be just
-	// "spec.yaml".
-	Spec string
 }
 
 func (r *RenderFlags) Register(set *cli.FlagSet) {
 	f := set.NewSection("RENDER OPTIONS")
-	f.StringVar(&cli.StringVar{
-		Name:    "spec",
-		Example: "path/to/spec.yaml",
-		Target:  &r.Spec,
-		Default: "./spec.yaml",
-		Usage:   "The path of the .yaml file within the unpacked template directory that specifies how the template is rendered.",
-	})
 
 	f.StringVar(&cli.StringVar{
 		Name:    "dest",

--- a/templates/commands/render_test.go
+++ b/templates/commands/render_test.go
@@ -70,7 +70,6 @@ func TestRenderFlags_Parse(t *testing.T) {
 		{
 			name: "all_flags_present",
 			args: []string{
-				"--spec", "my_spec.yaml",
 				"--dest", "my_dir",
 				"--git-protocol", "https",
 				"--input", "x=y",
@@ -81,7 +80,6 @@ func TestRenderFlags_Parse(t *testing.T) {
 			},
 			want: RenderFlags{
 				Source:         "helloworld@v1",
-				Spec:           "my_spec.yaml",
 				Dest:           "my_dir",
 				GitProtocol:    "https",
 				Inputs:         map[string]string{"x": "y"},
@@ -97,7 +95,6 @@ func TestRenderFlags_Parse(t *testing.T) {
 			},
 			want: RenderFlags{
 				Source:         "helloworld@v1",
-				Spec:           "./spec.yaml",
 				Dest:           ".",
 				GitProtocol:    "https",
 				Inputs:         map[string]string{},
@@ -220,7 +217,6 @@ steps:
 		existingDestContents map[string]string
 		flagInputs           map[string]string
 		flagKeepTempDirs     bool
-		flagSpec             string
 		flagForceOverwrite   bool
 		getterErr            error
 		removeAllErr         error
@@ -262,7 +258,6 @@ steps:
 				"defaulted_input": "default",
 			},
 			flagKeepTempDirs: true,
-			flagSpec:         "spec.yaml",
 			templateContents: map[string]string{
 				"spec.yaml":            specContents,
 				"file1.txt":            "my favorite color is blue",
@@ -295,7 +290,6 @@ steps:
 				"defaulted_input": "default",
 			},
 			flagKeepTempDirs: true,
-			flagSpec:         "spec.yaml",
 			templateContents: map[string]string{
 				"spec.yaml": "this is an unparseable YAML file *&^#%$",
 			},
@@ -548,7 +542,6 @@ steps:
 					ForceOverwrite: tc.flagForceOverwrite,
 					Inputs:         tc.flagInputs,
 					KeepTempDirs:   tc.flagKeepTempDirs,
-					Spec:           "spec.yaml",
 					Source:         "github.com/myorg/myrepo",
 				},
 			}


### PR DESCRIPTION
This was a group decision at this week's team meeting. We think it's cleaner to have a template be unambiguously identified by its `<location>` string, rather than a (location,--spec) tuple. This simplifies the mental model for users.

So, now we always look for `spec.yaml` in the root directory of the template location that was provided by the user.