### PR TITLE
fix: files were incorrectly skipped

### DIFF
--- a/templates/commands/render_action.go
+++ b/templates/commands/render_action.go
@@ -304,8 +304,11 @@ func copyRecursive(ctx context.Context, pos *model.ConfigPos, p *copyParams) (ou
 		}
 
 		if ch.skip {
-			logger.Debugw("walkdir visitor skipped file", "path", relToSrc)
-			return fs.SkipDir
+			logger.Debugw("walkdir visitor skipped file or directory", "path", relToSrc)
+			if de.IsDir() {
+				return fs.SkipDir
+			}
+			return nil
 		}
 
 		if de.IsDir() {

--- a/templates/commands/render_action_test.go
+++ b/templates/commands/render_action_test.go
@@ -480,7 +480,7 @@ func TestCopyRecursive(t *testing.T) {
 			},
 			visitor: func(relPath string, de fs.DirEntry) (copyHint, error) {
 				return copyHint{
-					skip: slices.Contains([]string{"skip1.txt", "subdir/skip2.txt"}, relPath),
+					skip: slices.Contains([]string{"skip1.txt", filepath.Join("subdir", "skip2.txt")}, relPath),
 				}, nil
 			},
 			want: map[string]modeAndContents{

--- a/templates/commands/render_action_test.go
+++ b/templates/commands/render_action_test.go
@@ -476,6 +476,7 @@ func TestCopyRecursive(t *testing.T) {
 				"dir1/file2.txt":   {0o600, "file2 contents"},
 				"skip1.txt":        {0o600, "skip1.txt contents"},
 				"subdir/skip2.txt": {0o600, "skip2.txt contents"},
+				"z.txt":            {0o600, "z.txt contents"},
 			},
 			visitor: func(relPath string, de fs.DirEntry) (copyHint, error) {
 				return copyHint{
@@ -485,6 +486,7 @@ func TestCopyRecursive(t *testing.T) {
 			want: map[string]modeAndContents{
 				"file1.txt":      {0o600, "file1 contents"},
 				"dir1/file2.txt": {0o600, "file2 contents"},
+				"z.txt":          {0o600, "z.txt contents"},
 			},
 		},
 		{


### PR DESCRIPTION
We were returning fs.SkipDir when skipping files *and* directories, but we should have only returned it when skipping a directory. When we return SkipDir to skip a file, we accidentally were skipping the remainder of the files in the directory.