### PR TITLE
feat: add --debug-scratch-contents flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ Examples of template locations:
 
 #### Flags
 
+- `--debug-scratch-contents`: for template authors, not regular users. This will
+  print the contents of the scratch directory after executing each step of the
+  spec.yaml. Useful for debugging errors like
+  `path "src/app.js" doesn't exist in the scratch directory, did you forget to "include" it first?"`
 - `--dest <output_dir>`: the directory on the local filesystem to write output
   to. Defaults to the current directory. If it doesn't exist, it will be
   created.

--- a/templates/commands/render.go
+++ b/templates/commands/render.go
@@ -460,34 +460,42 @@ func executeSpec(ctx context.Context, spec *model.Spec, sp *stepParams) error {
 		}
 		logger.Debugw("completed template action", "action", step.Action.Val)
 		if sp.flags.DebugScratchContents {
-			sb := &strings.Builder{}
-			fmt.Fprintf(sb, "Scratch dir contents after step %d (starting from 0), which is action type %q, defined at spec file line %d:\n",
-				i, step.Action.Val, step.Action.Pos.Line)
-			err := filepath.WalkDir(sp.scratchDir, func(path string, d fs.DirEntry, err error) error {
-				if err != nil {
-					return err // some filesystem error happened
-				}
-				if d.IsDir() {
-					// it's not possible to have an empty directory in the
-					// scratch directory, and directory names will be shown as
-					// part of filenames, so we don't show plain directory
-					// names. Like in Git.
-					return nil
-				}
-				rel, err := filepath.Rel(sp.scratchDir, path)
-				if err != nil {
-					return fmt.Errorf("filepath.Rel(): %w", err)
-				}
-				fmt.Fprintf(sb, "  %s\n", rel)
-				return nil
-			})
+			contents, err := scratchContents(ctx, i, step, sp)
 			if err != nil {
-				return fmt.Errorf("error crawling scratch directory: %w", err)
+				return err
 			}
-			logger.Info(sb.String())
+			logger.Info(contents)
 		}
 	}
 	return nil
+}
+
+func scratchContents(ctx context.Context, stepIdx int, step *model.Step, sp *stepParams) (string, error) {
+	sb := &strings.Builder{}
+	fmt.Fprintf(sb, "Scratch dir contents after step %d (starting from 0), which is action type %q, defined at spec file line %d:\n",
+		stepIdx, step.Action.Val, step.Action.Pos.Line)
+	err := filepath.WalkDir(sp.scratchDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err // some filesystem error happened
+		}
+		if d.IsDir() {
+			// it's not possible to have an empty directory in the
+			// scratch directory, and directory names will be shown as
+			// part of filenames, so we don't show plain directory
+			// names. Like in Git.
+			return nil
+		}
+		rel, err := filepath.Rel(sp.scratchDir, path)
+		if err != nil {
+			return fmt.Errorf("filepath.Rel(): %w", err)
+		}
+		fmt.Fprintf(sb, "  %s\n", rel)
+		return nil
+	})
+	if err != nil {
+		return "", fmt.Errorf("error crawling scratch directory: %w", err)
+	}
+	return sb.String(), nil
 }
 
 type stepParams struct {

--- a/templates/commands/render.go
+++ b/templates/commands/render.go
@@ -454,11 +454,38 @@ func (c *RenderCommand) checkInputsMissing(spec *model.Spec) []string {
 func executeSpec(ctx context.Context, spec *model.Spec, sp *stepParams) error {
 	logger := logging.FromContext(ctx).Named("executeSpec")
 
-	for _, step := range spec.Steps {
+	for i, step := range spec.Steps {
 		if err := executeOneStep(ctx, step, sp); err != nil {
 			return err
 		}
 		logger.Debugw("completed template action", "action", step.Action.Val)
+		if sp.flags.DebugScratchContents {
+			sb := &strings.Builder{}
+			fmt.Fprintf(sb, "Scratch dir contents after step %d (starting from 0), which is action type %q, defined at spec file line %d:\n",
+				i, step.Action.Val, step.Action.Pos.Line)
+			err := filepath.WalkDir(sp.scratchDir, func(path string, d fs.DirEntry, err error) error {
+				if err != nil {
+					return err // some filesystem error happened
+				}
+				if d.IsDir() {
+					// it's not possible to have an empty directory in the
+					// scratch directory, and directory names will be shown as
+					// part of filenames, so we don't show plain directory
+					// names. Like in Git.
+					return nil
+				}
+				rel, err := filepath.Rel(sp.scratchDir, path)
+				if err != nil {
+					return fmt.Errorf("filepath.Rel(): %w", err)
+				}
+				fmt.Fprintf(sb, "  %s\n", rel)
+				return nil
+			})
+			if err != nil {
+				return fmt.Errorf("error crawling scratch directory: %w", err)
+			}
+			logger.Info(sb.String())
+		}
 	}
 	return nil
 }

--- a/templates/commands/render_flags.go
+++ b/templates/commands/render_flags.go
@@ -59,6 +59,10 @@ type RenderFlags struct {
 
 	// Whether to prompt the user for template inputs.
 	Prompt bool
+
+	// DebugScratchContents causes the contents of the scratch directory to be
+	// logged at level INFO after each step of the spec.yaml.
+	DebugScratchContents bool
 }
 
 func (r *RenderFlags) Register(set *cli.FlagSet) {
@@ -120,6 +124,13 @@ func (r *RenderFlags) Register(set *cli.FlagSet) {
 		Default: false,
 
 		Usage: "Prompt the user for template inputs that weren't provided as flags.",
+	})
+
+	f.BoolVar(&cli.BoolVar{
+		Name:    "debug-scratch-contents",
+		Target:  &r.DebugScratchContents,
+		Default: false,
+		Usage:   "Print the contents of the scratch directory after each step; for debugging spec.yaml files",
 	})
 
 	g := set.NewSection("GIT OPTIONS")

--- a/templates/commands/render_flags.go
+++ b/templates/commands/render_flags.go
@@ -126,7 +126,8 @@ func (r *RenderFlags) Register(set *cli.FlagSet) {
 		Usage: "Prompt the user for template inputs that weren't provided as flags.",
 	})
 
-	f.BoolVar(&cli.BoolVar{
+	t := set.NewSection("TEMPLATE AUTHORS")
+	t.BoolVar(&cli.BoolVar{
 		Name:    "debug-scratch-contents",
 		Target:  &r.DebugScratchContents,
 		Default: false,


### PR DESCRIPTION
This is a feature for template authors that makes it easier to understand the state of the scratch directory.
If the flag is provided, we print a recursive directory listing of the scratch directory after each step of the spec file.

This addresses part of #121. It was useful in debugging #145.