### PR TITLE
fix: the regex actions weren't expanding path templates

### DIFF
--- a/templates/commands/render_action_regexnamelookup.go
+++ b/templates/commands/render_action_regexnamelookup.go
@@ -42,7 +42,16 @@ func actionRegexNameLookup(ctx context.Context, rn *model.RegexNameLookup, sp *s
 		return err
 	}
 
-	if err := walkAndModify(ctx, sp.fs, sp.scratchDir, rn.Paths, func(b []byte) ([]byte, error) {
+	paths := make([]model.String, 0, len(rn.Paths))
+	for _, p := range rn.Paths {
+		path, err := parseAndExecuteGoTmpl(p.Pos, p.Val, sp.inputs)
+		if err != nil {
+			return err
+		}
+		paths = append(paths, model.String{Pos: p.Pos, Val: path})
+	}
+
+	if err := walkAndModify(ctx, sp.fs, sp.scratchDir, paths, func(b []byte) ([]byte, error) {
 		for i, rn := range rn.Replacements {
 			cr := compiledRegexes[i]
 			allMatches := cr.FindAllSubmatchIndex(b, -1)

--- a/templates/commands/render_action_regexnamelookup_test.go
+++ b/templates/commands/render_action_regexnamelookup_test.go
@@ -158,6 +158,27 @@ func TestActionRegexNameLookup(t *testing.T) {
 				"b.txt": "alpha foo foo delta", //nolint:dupword
 			},
 		},
+		{
+			name: "templated_filename",
+			initContents: map[string]string{
+				"a.txt": "alpha beta gamma",
+			},
+			rr: &model.RegexNameLookup{
+				Paths: modelStrings([]string{"{{.filename}}"}),
+				Replacements: []*model.RegexNameLookupEntry{
+					{
+						Regex: model.String{Val: "(?P<cake>beta)"},
+					},
+				},
+			},
+			inputs: map[string]string{
+				"filename": "a.txt",
+				"cake":     "chocolate",
+			},
+			want: map[string]string{
+				"a.txt": "alpha chocolate gamma",
+			},
+		},
 	}
 
 	for _, tc := range cases {

--- a/templates/commands/render_action_regexreplace.go
+++ b/templates/commands/render_action_regexreplace.go
@@ -66,7 +66,16 @@ func actionRegexReplace(ctx context.Context, rr *model.RegexReplace, sp *stepPar
 		}
 	}
 
-	if err := walkAndModify(ctx, sp.fs, sp.scratchDir, rr.Paths, func(b []byte) ([]byte, error) {
+	paths := make([]model.String, 0, len(rr.Paths))
+	for _, p := range rr.Paths {
+		path, err := parseAndExecuteGoTmpl(p.Pos, p.Val, sp.inputs)
+		if err != nil {
+			return err
+		}
+		paths = append(paths, model.String{Pos: p.Pos, Val: path})
+	}
+
+	if err := walkAndModify(ctx, sp.fs, sp.scratchDir, paths, func(b []byte) ([]byte, error) {
 		for i, rr := range rr.Replacements {
 			cr := compiledRegexes[i]
 			allMatches := cr.FindAllSubmatchIndex(b, -1)

--- a/templates/commands/render_action_regexreplace_test.go
+++ b/templates/commands/render_action_regexreplace_test.go
@@ -365,6 +365,27 @@ gamma`,
 				"b.txt": "sigma bar chi",
 			},
 		},
+		{
+			name: "templated_filename",
+			initContents: map[string]string{
+				"a.txt": "alpha foo gamma",
+			},
+			rr: &model.RegexReplace{
+				Paths: modelStrings([]string{"{{.filename}}"}),
+				Replacements: []*model.RegexReplaceEntry{
+					{
+						Regex: model.String{Val: "foo"},
+						With:  model.String{Val: "bar"},
+					},
+				},
+			},
+			inputs: map[string]string{
+				"filename": "a.txt",
+			},
+			want: map[string]string{
+				"a.txt": "alpha bar gamma",
+			},
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Every action should process the templates in its `paths` parameter, like `paths: ['{{.input_filename}}']`. This was accidentally overlooked when I wrote these two regex actions (regex_replace, regex_name_lookup).

There's a separate issue #143 to potentially refactor this to make it cleaner and less vulnerable to oversights like this, but that's out of scope here.

Fixes #142 .