### PR TITLE
Output module version from buildinfo if not built by goreleaser

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -26,7 +26,13 @@ var (
 
 	// Version is the main package version. This can be overridden by the build
 	// process.
-	Version = "source"
+	Version = func() string {
+		info, ok := debug.ReadBuildInfo()
+		if !ok {
+			return "source"
+		}
+		return info.Main.Version // e.g. "v0.0.1-alpha6.0.20230815191505-8628f8201363"
+	}()
 
 	// Commit is the git sha. This can be overridden by the build process.
 	Commit = func() string {


### PR DESCRIPTION
This fixes #148. Before, we weren't outputting the version number unless it had been placed in ldflags by goreleaser.

The outputted module version includes a partial git sha, so it unambiguously identifies the code that's running.

Example output when installed with `go install`:

```
$ abc -version
abc v0.0.1-alpha6.0.20230815192907-8d9c1c1a0444 (HEAD, linux/amd64)
```