### PR TITLE
Add AST models for `for_each`

### DIFF
--- a/templates/model/spec.go
+++ b/templates/model/spec.go
@@ -112,7 +112,7 @@ func (s *Spec) Validate() error {
 	return errors.Join(
 		oneOf(s.Pos, s.APIVersion, []string{"cli.abcxyz.dev/v1alpha1"}, "apiVersion"),
 		oneOf(s.Pos, s.Kind, []string{"Template"}, "kind"),
-		notZero(s.Pos, s.Desc, "desc"),
+		notZeroModel(s.Pos, s.Desc, "desc"),
 		nonEmptySlice(s.Pos, s.Steps, "steps"),
 		validateEach(s.Inputs),
 		validateEach(s.Steps),
@@ -161,8 +161,8 @@ func (i *Input) Validate() error {
 	}
 
 	return errors.Join(
-		notZero(i.Pos, i.Name, "name"),
-		notZero(i.Pos, i.Desc, "desc"),
+		notZeroModel(i.Pos, i.Name, "name"),
+		notZeroModel(i.Pos, i.Desc, "desc"),
 		reservedNameErr,
 	)
 }
@@ -177,6 +177,7 @@ type Step struct {
 
 	// Each action type has a field below. Only one of these will be set.
 	Append          *Append          `yaml:"-"`
+	ForEach         *ForEach         `yaml:"-"`
 	GoTemplate      *GoTemplate      `yaml:"-"`
 	Include         *Include         `yaml:"-"`
 	Print           *Print           `yaml:"-"`
@@ -205,34 +206,38 @@ func (s *Step) UnmarshalYAML(n *yaml.Node) error {
 	// on the value of "action".
 	var unmarshalInto any
 	switch s.Action.Val {
-	case "print":
-		s.Print = new(Print)
-		unmarshalInto = s.Print
-		s.Print.Pos = s.Pos // Set an approximate position in case yaml unmarshaling fails later
-	case "include":
-		s.Include = new(Include)
-		unmarshalInto = s.Include
-		s.Include.Pos = s.Pos
-	case "regex_replace":
-		s.RegexReplace = new(RegexReplace)
-		unmarshalInto = s.RegexReplace
-		s.RegexReplace.Pos = s.Pos
-	case "regex_name_lookup":
-		s.RegexNameLookup = new(RegexNameLookup)
-		unmarshalInto = s.RegexNameLookup
-		s.RegexNameLookup.Pos = s.Pos
-	case "string_replace":
-		s.StringReplace = new(StringReplace)
-		unmarshalInto = s.StringReplace
-		s.StringReplace.Pos = s.Pos
 	case "append":
 		s.Append = new(Append)
 		unmarshalInto = s.Append
 		s.Append.Pos = s.Pos
+	case "for_each":
+		s.ForEach = new(ForEach)
+		unmarshalInto = s.ForEach
+		s.ForEach.Pos = s.Pos
 	case "go_template":
 		s.GoTemplate = new(GoTemplate)
 		unmarshalInto = s.GoTemplate
 		s.GoTemplate.Pos = s.Pos
+	case "include":
+		s.Include = new(Include)
+		unmarshalInto = s.Include
+		s.Include.Pos = s.Pos
+	case "print":
+		s.Print = new(Print)
+		unmarshalInto = s.Print
+		s.Print.Pos = s.Pos // Set an approximate position in case yaml unmarshaling fails later
+	case "regex_name_lookup":
+		s.RegexNameLookup = new(RegexNameLookup)
+		unmarshalInto = s.RegexNameLookup
+		s.RegexNameLookup.Pos = s.Pos
+	case "regex_replace":
+		s.RegexReplace = new(RegexReplace)
+		unmarshalInto = s.RegexReplace
+		s.RegexReplace.Pos = s.Pos
+	case "string_replace":
+		s.StringReplace = new(StringReplace)
+		unmarshalInto = s.StringReplace
+		s.StringReplace.Pos = s.Pos
 	case "":
 		return s.Pos.AnnotateErr(fmt.Errorf(`missing "action" field in this step`))
 	default:
@@ -255,8 +260,9 @@ func (s *Step) UnmarshalYAML(n *yaml.Node) error {
 func (s *Step) Validate() error {
 	// The "action" field is implicitly validated by UnmarshalYAML, so not included here.
 	return errors.Join(
-		notZero(s.Pos, s.Desc, "desc"),
+		notZeroModel(s.Pos, s.Desc, "desc"),
 		validateUnlessNil(s.Append),
+		validateUnlessNil(s.ForEach),
 		validateUnlessNil(s.GoTemplate),
 		validateUnlessNil(s.Include),
 		validateUnlessNil(s.Print),
@@ -296,7 +302,7 @@ func (p *Print) UnmarshalYAML(n *yaml.Node) error {
 // Validate implements Validator.
 func (p *Print) Validate() error {
 	return errors.Join(
-		notZero(p.Pos, p.Message, "message"),
+		notZeroModel(p.Pos, p.Message, "message"),
 	)
 }
 
@@ -414,8 +420,8 @@ func (r *RegexReplaceEntry) Validate() error {
 	}
 
 	return errors.Join(
-		notZero(r.Pos, r.Regex, "regex"),
-		notZero(r.Pos, r.With, "with"),
+		notZeroModel(r.Pos, r.Regex, "regex"),
+		notZeroModel(r.Pos, r.With, "with"),
 		subgroupErr,
 	)
 }
@@ -484,7 +490,7 @@ type RegexNameLookupEntry struct {
 func (r *RegexNameLookupEntry) Validate() error {
 	return errors.Join(
 
-		notZero(r.Pos, r.Regex, "regex"),
+		notZeroModel(r.Pos, r.Regex, "regex"),
 	)
 }
 
@@ -555,8 +561,8 @@ type StringReplacement struct {
 
 func (s *StringReplacement) Validate() error {
 	return errors.Join(
-		notZero(s.Pos, s.ToReplace, "to_replace"),
-		notZero(s.Pos, s.With, "with"),
+		notZeroModel(s.Pos, s.ToReplace, "to_replace"),
+		notZeroModel(s.Pos, s.With, "with"),
 	)
 }
 
@@ -609,7 +615,7 @@ func (s *Append) UnmarshalYAML(n *yaml.Node) error {
 func (s *Append) Validate() error {
 	return errors.Join(
 		nonEmptySlice(s.Pos, s.Paths, "paths"),
-		notZero(s.Pos, s.With, "with"),
+		notZeroModel(s.Pos, s.With, "with"),
 	)
 }
 
@@ -644,4 +650,84 @@ func (g *GoTemplate) UnmarshalYAML(n *yaml.Node) error {
 func (g *GoTemplate) Validate() error {
 	// Checking that the input paths are valid will happen later.
 	return errors.Join(nonEmptySlice(g.Pos, g.Paths, "paths"))
+}
+
+type ForEach struct {
+	// Pos is the YAML file location where this object started.
+	Pos *ConfigPos `yaml:"-"`
+
+	Iterator *ForEachIterator `yaml:"iterator"`
+	Steps    []*Step          `yaml:"steps"`
+}
+
+// UnmarshalYAML implements yaml.Unmarshaler.
+func (f *ForEach) UnmarshalYAML(n *yaml.Node) error {
+	knownYAMLFields := []string{"iterator", "steps"}
+	if err := extraFields(n, knownYAMLFields); err != nil {
+		return err
+	}
+	type shadowType ForEach
+	shadow := &shadowType{} // see "Q2" in file comment above
+
+	if err := n.Decode(shadow); err != nil {
+		return err
+	}
+	*f = ForEach(*shadow)
+	f.Pos = yamlPos(n)
+
+	return nil
+}
+
+func (f *ForEach) Validate() error {
+	return errors.Join(
+		notZero(f.Pos, f.Iterator, "iterator"),
+		nonEmptySlice(f.Pos, f.Steps, "steps"),
+		validateUnlessNil(f.Iterator),
+		validateEach(f.Steps),
+	)
+}
+
+type ForEachIterator struct {
+	// Pos is the YAML file location where this object started.
+	Pos *ConfigPos `yaml:"-"`
+
+	// The name by which the range value is accessed.
+	Key String `yaml:"key"`
+
+	// Exactly one of the following fields must be set.
+
+	// Values is a list to range over, e.g. ["dev", "prod"]
+	Values []String `yaml:"values"`
+	// ValuesFrom is a CEL expression returning a list of strings to range over.
+	ValuesFrom *String `yaml:"values_from"`
+}
+
+// UnmarshalYAML implements yaml.Unmarshaler.
+func (f *ForEachIterator) UnmarshalYAML(n *yaml.Node) error {
+	knownYAMLFields := []string{"key", "values", "values_from"}
+	if err := extraFields(n, knownYAMLFields); err != nil {
+		return err
+	}
+	type shadowType ForEachIterator
+	shadow := &shadowType{} // see "Q2" in file comment above
+
+	if err := n.Decode(shadow); err != nil {
+		return err
+	}
+	*f = ForEachIterator(*shadow)
+	f.Pos = yamlPos(n)
+
+	return nil
+}
+
+func (f *ForEachIterator) Validate() error {
+	var exclusivityErr error
+	if (len(f.Values) > 0 && f.ValuesFrom != nil) || (len(f.Values) == 0 && f.ValuesFrom == nil) {
+		exclusivityErr = errors.New(`exactly one of the fields "values" or "values_from" must be set`)
+	}
+
+	return errors.Join(
+		notZeroModel(f.Pos, f.Key, "key"),
+		exclusivityErr,
+	)
 }

--- a/templates/model/validate.go
+++ b/templates/model/validate.go
@@ -24,10 +24,15 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// Returns error if the given model's value is equal to the zero value for type T.
+func notZeroModel[T comparable](pos *ConfigPos, x valWithPos[T], fieldName string) error {
+	return notZero(pos, x.Val, fieldName)
+}
+
 // Returns error if the given value is equal to the zero value for type T.
-func notZero[T comparable](pos *ConfigPos, x valWithPos[T], fieldName string) error {
+func notZero[T comparable](pos *ConfigPos, t T, fieldName string) error {
 	var zero T
-	if x.Val == zero {
+	if t == zero {
 		return pos.AnnotateErr(fmt.Errorf("field %q is required", fieldName))
 	}
 	return nil
@@ -52,7 +57,7 @@ func isValidRegexGroupName(s String, fieldName string) error {
 	return nil
 }
 
-// Returns error of x.Val is not one of the given allowed choices.
+// Returns error if x.Val is not one of the given allowed choices.
 func oneOf[T comparable](pos *ConfigPos, x valWithPos[T], allowed []T, fieldName string) error {
 	if slices.Contains(allowed, x.Val) {
 		return nil


### PR DESCRIPTION
This is the first of several PRs implementing `for_each` (see #127). This just adds the data structures that the YAML is parsed into, and some parsing tests.