### PR TITLE
Add hierarchical variable scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,14 +383,14 @@ Params:
 - `message`: the message to show. May use template expressions (e.g.
   `{{.my_input}}`).
 
-  The print action has special access to an extra template variable named
-  `flags` containing the values of some of the command line flags. This can be
-  useful to print a message like
-  `Template rendering is done, now please to go the {{.flags.dest}} directory and run a certain command.`
+  The print action has special access to extra template variables named
+  `_flag_*` containing the values of _some_ of the command line flags. This can
+  be useful to print a message like
+  `Template rendering is done, now please to go the {{._flag_dest}} directory and run a certain command.`
   The available values are:
 
-  - `{{.flags.dest}}`: the value of the the `--dest` flag, e.g. `.`
-  - `{{.flags.source}}`: the template location that's being rendered, e.g.
+  - `{{._flag_dest}}`: the value of the the `--dest` flag, e.g. `.`
+  - `{{._flag_source}}`: the template location that's being rendered, e.g.
     `github.com/abcxyz/abc.git//t/my_template`
 
 Example:

--- a/templates/commands/render.go
+++ b/templates/commands/render.go
@@ -256,7 +256,7 @@ func (c *RenderCommand) realRun(ctx context.Context, rp *runParams) (outErr erro
 	sp := &stepParams{
 		flags:       &c.flags,
 		fs:          rp.fs,
-		inputs:      c.flags.Inputs,
+		scope:       newScope(c.flags.Inputs),
 		scratchDir:  scratchDir,
 		stdout:      rp.stdout,
 		templateDir: templateDir,
@@ -502,11 +502,10 @@ type stepParams struct {
 	flags *RenderFlags
 	fs    renderFS
 
-	// inputs are the template values to plug in, provided by the user. Why is
-	// this separate from flags.inputs? Because these are the processed form,
-	// which includes defaults, and may include other sources like env vars and
-	// file inputs in the future.
-	inputs map[string]string
+	// Scope contains all variable names that are in scope. This includes
+	// user-provided inputs, as well as any programmatically created variables
+	// like for_each keys.
+	scope *scope
 
 	scratchDir  string
 	stdout      io.Writer

--- a/templates/commands/render_action_append.go
+++ b/templates/commands/render_action_append.go
@@ -22,7 +22,7 @@ import (
 )
 
 func actionAppend(ctx context.Context, ap *model.Append, sp *stepParams) error {
-	with, err := parseAndExecuteGoTmpl(ap.With.Pos, ap.With.Val, sp.inputs)
+	with, err := parseAndExecuteGoTmpl(ap.With.Pos, ap.With.Val, sp.scope)
 	if err != nil {
 		return err
 	}
@@ -36,7 +36,7 @@ func actionAppend(ctx context.Context, ap *model.Append, sp *stepParams) error {
 	paths := make([]model.String, 0, len(ap.Paths))
 
 	for _, p := range ap.Paths {
-		path, err := parseAndExecuteGoTmpl(p.Pos, p.Val, sp.inputs)
+		path, err := parseAndExecuteGoTmpl(p.Pos, p.Val, sp.scope)
 		if err != nil {
 			return err
 		}

--- a/templates/commands/render_action_append_test.go
+++ b/templates/commands/render_action_append_test.go
@@ -186,7 +186,7 @@ func TestActionAppend(t *testing.T) {
 					readFileErr: tc.readFileErr,
 				},
 				scratchDir: scratchDir,
-				inputs:     tc.inputs,
+				scope:      newScope(tc.inputs),
 			}
 			err := actionAppend(context.Background(), sr, sp)
 			if diff := testutil.DiffErrString(err, tc.wantErr); diff != "" {

--- a/templates/commands/render_action_gotemplate.go
+++ b/templates/commands/render_action_gotemplate.go
@@ -24,7 +24,7 @@ import (
 func actionGoTemplate(ctx context.Context, p *model.GoTemplate, sp *stepParams) error {
 	for _, p := range p.Paths {
 		// Paths may contain template expressions, so render them first.
-		walkRelPath, err := parseAndExecuteGoTmpl(p.Pos, p.Val, sp.inputs)
+		walkRelPath, err := parseAndExecuteGoTmpl(p.Pos, p.Val, sp.scope)
 		if err != nil {
 			return err
 		}
@@ -37,7 +37,7 @@ func actionGoTemplate(ctx context.Context, p *model.GoTemplate, sp *stepParams) 
 		relPathPos := model.String{Pos: p.Pos, Val: walkRelPath}
 
 		if err := walkAndModify(ctx, sp.fs, sp.scratchDir, []model.String{relPathPos}, func(b []byte) ([]byte, error) {
-			executed, err := parseAndExecuteGoTmpl(nil, string(b), sp.inputs)
+			executed, err := parseAndExecuteGoTmpl(nil, string(b), sp.scope)
 			if err != nil {
 				return nil, fmt.Errorf("failed executing file as Go template: %w", err)
 			}

--- a/templates/commands/render_action_gotemplate_test.go
+++ b/templates/commands/render_action_gotemplate_test.go
@@ -171,7 +171,7 @@ func TestActionGoTemplate(t *testing.T) {
 			ctx := context.Background()
 			sp := &stepParams{
 				fs:         &realFS{},
-				inputs:     tc.inputs,
+				scope:      newScope(tc.inputs),
 				scratchDir: scratchDir,
 			}
 			err := actionGoTemplate(ctx, tc.gt, sp)

--- a/templates/commands/render_action_include.go
+++ b/templates/commands/render_action_include.go
@@ -28,18 +28,18 @@ import (
 )
 
 func actionInclude(ctx context.Context, inc *model.Include, sp *stepParams) error {
-	stripPrefixStr, err := parseAndExecuteGoTmpl(inc.StripPrefix.Pos, inc.StripPrefix.Val, sp.inputs)
+	stripPrefixStr, err := parseAndExecuteGoTmpl(inc.StripPrefix.Pos, inc.StripPrefix.Val, sp.scope)
 	if err != nil {
 		return err
 	}
-	addPrefixStr, err := parseAndExecuteGoTmpl(inc.AddPrefix.Pos, inc.AddPrefix.Val, sp.inputs)
+	addPrefixStr, err := parseAndExecuteGoTmpl(inc.AddPrefix.Pos, inc.AddPrefix.Val, sp.scope)
 	if err != nil {
 		return err
 	}
 
 	skip := make(map[string]struct{}, len(inc.Skip))
 	for _, s := range inc.Skip {
-		skipRelPath, err := parseAndExecuteGoTmpl(s.Pos, s.Val, sp.inputs)
+		skipRelPath, err := parseAndExecuteGoTmpl(s.Pos, s.Val, sp.scope)
 		if err != nil {
 			return err
 		}
@@ -48,7 +48,7 @@ func actionInclude(ctx context.Context, inc *model.Include, sp *stepParams) erro
 
 	for i, p := range inc.Paths {
 		// Paths may contain template expressions, so render them first.
-		walkRelPath, err := parseAndExecuteGoTmpl(p.Pos, p.Val, sp.inputs)
+		walkRelPath, err := parseAndExecuteGoTmpl(p.Pos, p.Val, sp.scope)
 		if err != nil {
 			return err
 		}
@@ -63,7 +63,7 @@ func actionInclude(ctx context.Context, inc *model.Include, sp *stepParams) erro
 		//  - len(inc.As) == len(inc.Paths)
 		var as string
 		if len(inc.As) > 0 {
-			as, err = parseAndExecuteGoTmpl(inc.As[i].Pos, inc.As[i].Val, sp.inputs)
+			as, err = parseAndExecuteGoTmpl(inc.As[i].Pos, inc.As[i].Val, sp.scope)
 			if err != nil {
 				return err
 			}

--- a/templates/commands/render_action_include_test.go
+++ b/templates/commands/render_action_include_test.go
@@ -356,7 +356,7 @@ func TestActionInclude(t *testing.T) {
 				},
 				scratchDir:  scratchDir,
 				templateDir: templateDir,
-				inputs:      tc.inputs,
+				scope:       newScope(tc.inputs),
 			}
 			err := actionInclude(ctx, tc.include, sp)
 			if diff := testutil.DiffErrString(err, tc.wantErr); diff != "" {

--- a/templates/commands/render_action_print.go
+++ b/templates/commands/render_action_print.go
@@ -23,12 +23,9 @@ import (
 )
 
 func actionPrint(ctx context.Context, p *model.Print, sp *stepParams) error {
-	inputsAndFlags := map[string]any{}
-	for k, v := range sp.inputs {
-		inputsAndFlags[k] = v
-	}
-	inputsAndFlags["flags"] = flagsForTemplate(sp.flags)
-	msg, err := parseAndExecuteGoTmpl(p.Message.Pos, p.Message.Val, inputsAndFlags)
+	scope := sp.scope.With(flagsForTemplate(sp.flags))
+
+	msg, err := parseAndExecuteGoTmpl(p.Message.Pos, p.Message.Val, scope)
 	if err != nil {
 		return err
 	}
@@ -45,11 +42,11 @@ func actionPrint(ctx context.Context, p *model.Print, sp *stepParams) error {
 	return nil
 }
 
-func flagsForTemplate(r *RenderFlags) map[string]any {
+func flagsForTemplate(r *RenderFlags) map[string]string {
 	// We only expose certain fields the print action; these are the ones that
 	// we have beneficial use cases for and that don't encourage bad API use.
-	return map[string]any{
-		"dest":   r.Dest,
-		"source": r.Source,
+	return map[string]string{
+		"_flag_dest":   r.Dest,
+		"_flag_source": r.Source,
 	}
 }

--- a/templates/commands/render_action_print_test.go
+++ b/templates/commands/render_action_print_test.go
@@ -57,7 +57,7 @@ func TestActionPrint(t *testing.T) {
 		},
 		{
 			name: "flags_in_message",
-			in:   "{{.flags.dest}} {{.flags.source}}",
+			in:   "{{._flag_dest}} {{._flag_source}}",
 			flags: RenderFlags{
 				Source:         "mysource",
 				Dest:           "mydest",
@@ -79,7 +79,7 @@ func TestActionPrint(t *testing.T) {
 			var outBuf bytes.Buffer
 			sp := &stepParams{
 				stdout: &outBuf,
-				inputs: tc.inputs,
+				scope:  newScope(tc.inputs),
 				flags:  &tc.flags,
 			}
 			pr := &model.Print{

--- a/templates/commands/render_action_regexnamelookup_test.go
+++ b/templates/commands/render_action_regexnamelookup_test.go
@@ -198,7 +198,7 @@ func TestActionRegexNameLookup(t *testing.T) {
 			ctx := context.Background()
 			sp := &stepParams{
 				fs:         &realFS{},
-				inputs:     tc.inputs,
+				scope:      newScope(tc.inputs),
 				scratchDir: scratchDir,
 			}
 			err := actionRegexNameLookup(ctx, tc.rr, sp)

--- a/templates/commands/render_action_regexreplace_test.go
+++ b/templates/commands/render_action_regexreplace_test.go
@@ -405,7 +405,7 @@ gamma`,
 			ctx := context.Background()
 			sp := &stepParams{
 				fs:         &realFS{},
-				inputs:     tc.inputs,
+				scope:      newScope(tc.inputs),
 				scratchDir: scratchDir,
 			}
 			err := actionRegexReplace(ctx, tc.rr, sp)

--- a/templates/commands/render_action_stringreplace.go
+++ b/templates/commands/render_action_stringreplace.go
@@ -24,11 +24,11 @@ import (
 func actionStringReplace(ctx context.Context, sr *model.StringReplace, sp *stepParams) error {
 	var replacerArgs []string //nolint:prealloc // strings.NewReplacer has a weird input slice, it's less confusing to append rather than preallocate.
 	for _, r := range sr.Replacements {
-		toReplace, err := parseAndExecuteGoTmpl(r.ToReplace.Pos, r.ToReplace.Val, sp.inputs)
+		toReplace, err := parseAndExecuteGoTmpl(r.ToReplace.Pos, r.ToReplace.Val, sp.scope)
 		if err != nil {
 			return err
 		}
-		replaceWith, err := parseAndExecuteGoTmpl(r.With.Pos, r.With.Val, sp.inputs)
+		replaceWith, err := parseAndExecuteGoTmpl(r.With.Pos, r.With.Val, sp.scope)
 		if err != nil {
 			return err
 		}
@@ -38,7 +38,7 @@ func actionStringReplace(ctx context.Context, sr *model.StringReplace, sp *stepP
 
 	paths := make([]model.String, 0, len(sr.Paths))
 	for _, p := range sr.Paths {
-		path, err := parseAndExecuteGoTmpl(p.Pos, p.Val, sp.inputs)
+		path, err := parseAndExecuteGoTmpl(p.Pos, p.Val, sp.scope)
 		if err != nil {
 			return err
 		}

--- a/templates/commands/render_action_stringreplace_test.go
+++ b/templates/commands/render_action_stringreplace_test.go
@@ -244,7 +244,7 @@ func TestActionStringReplace(t *testing.T) {
 					readFileErr: tc.readFileErr,
 				},
 				scratchDir: scratchDir,
-				inputs:     tc.inputs,
+				scope:      newScope(tc.inputs),
 			}
 			err := actionStringReplace(context.Background(), sr, sp)
 			if diff := testutil.DiffErrString(err, tc.wantErr); diff != "" {

--- a/templates/commands/render_action_test.go
+++ b/templates/commands/render_action_test.go
@@ -695,7 +695,7 @@ func TestParseAndExecute(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := parseAndExecuteGoTmpl(tc.pos, tc.tmpl, tc.inputs)
+			got, err := parseAndExecuteGoTmpl(tc.pos, tc.tmpl, newScope(tc.inputs))
 			if diff := testutil.DiffErrString(err, tc.wantErr); diff != "" {
 				t.Error(diff)
 			}
@@ -741,7 +741,7 @@ func TestTemplateFuncs(t *testing.T) {
 	cases := []struct {
 		name    string
 		tmpl    string
-		inputs  map[string]any
+		inputs  map[string]string
 		want    string
 		wantErr string
 	}{
@@ -767,10 +767,7 @@ func TestTemplateFuncs(t *testing.T) {
 		},
 		{
 			name: "sortStrings",
-			tmpl: `{{ .strings | sortStrings }}`,
-			inputs: map[string]any{
-				"strings": []string{"zebra", "car", "foo"},
-			},
+			tmpl: `{{ split "zebra,car,foo" "," | sortStrings }}`,
 			want: "[car foo zebra]",
 		},
 		{
@@ -840,7 +837,7 @@ func TestTemplateFuncs(t *testing.T) {
 				Line: 1,
 			}
 
-			got, err := parseAndExecuteGoTmpl(pos, tc.tmpl, tc.inputs)
+			got, err := parseAndExecuteGoTmpl(pos, tc.tmpl, newScope(map[string]string{}))
 			if diff := testutil.DiffErrString(err, tc.wantErr); diff != "" {
 				t.Error(diff)
 			}

--- a/templates/commands/scope.go
+++ b/templates/commands/scope.go
@@ -1,0 +1,82 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commands
+
+import "golang.org/x/exp/maps"
+
+// scope binds variable names to values. It has a stack-like structure that
+// allows inner scopes to inherit values from outer scopes. Variable names are
+// looked up in order of innermost-to-outermost.
+//
+// For example, a for_each action defines a key value that is assigned to each
+// of a list of values. The new variable introduced in this way "shadows" any
+// variable that may previously exist of the same name. When the for_each loop
+// is finished, then the outer scope's variable becomes available again.
+type scope struct {
+	vars    map[string]string // never nil
+	inherit *scope            // is nil if this is the outermost scope.
+}
+
+func newScope(m map[string]string) *scope {
+	if m == nil {
+		// This isn't strictly necessary, because a lookup in a nil map just
+		// returns false, but it saves complexity in the other methods.
+		m = map[string]string{}
+	}
+	return &scope{
+		vars: m,
+	}
+}
+
+// Lookup returns the current value of a given variable name, or false.
+func (s *scope) Lookup(name string) (string, bool) {
+	val, ok := s.vars[name]
+	if ok {
+		return val, true
+	}
+
+	if s.inherit == nil {
+		// This is the outermost scope, there's no more variables anywhere else.
+		return "", false
+	}
+
+	return s.inherit.Lookup(name)
+}
+
+// With returns a new scope containing a new set of variable values. It forwards
+// lookups to the previously existing scope if the lookup key is not found in m.
+func (s *scope) With(m map[string]string) *scope {
+	return &scope{
+		vars:    maps.Clone(m), // defensively clone to avoid bugs if the caller modifies their copy
+		inherit: s,
+	}
+}
+
+// All returns all variable bindings that are in scope. Inner/top-of-stack
+// bindings take priority over outer bindings of the same name.
+//
+// The returned map is a copy that is owned by the caller; it can be changed
+// safely.
+//
+// The return value is never nil.
+func (s *scope) All() map[string]string {
+	if s.inherit == nil {
+		return maps.Clone(s.vars)
+	}
+
+	out := s.inherit.All()
+	maps.Copy(out, s.vars)
+	return out
+}

--- a/templates/commands/scope_test.go
+++ b/templates/commands/scope_test.go
@@ -1,0 +1,140 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commands
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestScope(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		with    map[string]string
+		inherit map[string]string
+		want    map[string]string
+	}{
+		{
+			name: "simple_unnested",
+			with: map[string]string{
+				"a": "A",
+			},
+			inherit: nil,
+			want: map[string]string{
+				"a": "A",
+			},
+		},
+		{
+			name: "outer_scope_should_be_shadowed",
+			with: map[string]string{
+				"a": "good",
+			},
+			inherit: map[string]string{
+				"a": "bad",
+			},
+			want: map[string]string{
+				"a": "good",
+			},
+		},
+		{
+			name: "mingling_of_scopes",
+			with: map[string]string{
+				"a":           "good",
+				"other_inner": "foo",
+			},
+			inherit: map[string]string{
+				"a":           "bad",
+				"other_outer": "bar",
+			},
+			want: map[string]string{
+				"a":           "good",
+				"other_inner": "foo",
+				"other_outer": "bar",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			scope := newScope(tc.inherit)
+			scope = scope.With(tc.with)
+
+			if diff := cmp.Diff(scope.All(), tc.want); diff != "" {
+				t.Errorf("All() returned unexpected value (-got,+want): %s", diff)
+			}
+
+			for key, want := range tc.want {
+				got, ok := scope.Lookup(key)
+				if !ok {
+					t.Errorf("Lookup(%q) got false, want (%q,true)", key, want)
+					continue
+				}
+				if got != want {
+					t.Errorf("Lookup(%q) got %q, want %q", key, got, want)
+				}
+			}
+
+			if got, ok := scope.Lookup("nonexistent"); ok {
+				t.Errorf(`Lookup("nonexistent") got (%q,true), but wanted false`, got)
+			}
+		})
+	}
+}
+
+func TestScopeDeepNesting(t *testing.T) {
+	t.Parallel()
+
+	inMaps := make([]map[string]string, 10)
+	for i := 0; i <= 9; i++ {
+		asStr := strconv.Itoa(i)
+
+		inMaps[i] = map[string]string{
+			"key_" + asStr: "value_" + asStr,
+			"overwrite":    asStr,
+		}
+	}
+
+	scope := newScope(inMaps[0])
+	for i := 1; i <= 9; i++ {
+		scope = scope.With(inMaps[i])
+	}
+
+	want := map[string]string{
+		"key_0":     "value_0",
+		"key_1":     "value_1",
+		"key_2":     "value_2",
+		"key_3":     "value_3",
+		"key_4":     "value_4",
+		"key_5":     "value_5",
+		"key_6":     "value_6",
+		"key_7":     "value_7",
+		"key_8":     "value_8",
+		"key_9":     "value_9",
+		"overwrite": "9",
+	}
+	got := scope.All()
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("output map wasn't as expected (-got,+want): %s", diff)
+	}
+}

--- a/templates/model/spec.go
+++ b/templates/model/spec.go
@@ -49,6 +49,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 
 	"golang.org/x/exp/slices"
 	"gopkg.in/yaml.v3"
@@ -153,11 +154,8 @@ func (i *Input) UnmarshalYAML(n *yaml.Node) error {
 // Validate implements Validator.
 func (i *Input) Validate() error {
 	var reservedNameErr error
-	// Reasons for reserved input names:
-	//  - "flags" is used as expose the CLI flags to the print action. If it was also
-	//    an input name, there would be a collision when trying to do {{.flags.foo}}
-	if slices.Contains([]string{"flags"}, i.Name.Val) {
-		reservedNameErr = i.Name.Pos.AnnotateErr(fmt.Errorf("input name %q is reserved, please pick a different name", i.Name.Val))
+	if strings.HasPrefix(i.Name.Val, "_") {
+		reservedNameErr = i.Name.Pos.AnnotateErr(fmt.Errorf("input names beginning with _ are reserved"))
 	}
 
 	return errors.Join(

--- a/templates/model/spec_test.go
+++ b/templates/model/spec_test.go
@@ -190,8 +190,8 @@ nonexistent_field: 'oops'`,
 		{
 			name: "reserved_input_name",
 			in: `desc: 'foo'
-name: 'flags'`,
-			wantValidateErr: "is reserved",
+name: '_name_with_leading_underscore'`,
+			wantValidateErr: "are reserved",
 		},
 	}
 


### PR DESCRIPTION
This is one of several PRs adding the `for_each` feature.

In `for_each`, we add the concept of an "key", which is the index variable of the loop that takes on a sequence of values. This means that we need a way to bring a new variable into scope for the lifetime of the for_each loop.

The solution is to do lexical scoping like in a programming language. The "body" of the for_each is its own scope, and the for_each key is only in-scope for those actions. If there's a variable of the same name in an outer scope, it is temporarily shadowed until the inner scope is done.

Perhaps controversial: the `print` action has privileged access to some flag values, by doing lookups like `{{.flags.dest}}`. This was a weird outlier, because `flags` was the only thing we exposed to users that wasn't a string (it was a map). In this PR we change the lookup syntax to `{{.flag_dest}}` to preserve the conceptual uniformity of "all names that can be looked up by the user return strings." This saves much complexity. To go along with this change, we prevent the user from declaring any inputs starting with `_`, which reserves all those names for our own use.

Alternatives considered: we could have just kept everything as a map instead of introducing the "scope" type. We could have just temporarily added a new variable to the map while the for_each loop was in scope. This option wasn't taken because (1) mutability causes problems and (2) scopes serve as a better theoretical foundation for future needs.