### PR TITLE
Partial for_each support

### DIFF
--- a/templates/commands/render_action.go
+++ b/templates/commands/render_action.go
@@ -207,6 +207,18 @@ func parseAndExecuteGoTmpl(pos *model.ConfigPos, tmpl string, scope *scope) (str
 	return sb.String(), nil
 }
 
+func parseAndExecuteGoTmplAll(ss []model.String, scope *scope) ([]string, error) {
+	out := make([]string, len(ss))
+	for i, in := range ss {
+		var err error
+		out[i], err = parseAndExecuteGoTmpl(in.Pos, in.Val, scope)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
+}
+
 // unknownTemplateKeyError is an error that will be returned when a template
 // references a variable that's nonexistent.
 type unknownTemplateKeyError struct {

--- a/templates/commands/render_action_foreach.go
+++ b/templates/commands/render_action_foreach.go
@@ -1,0 +1,49 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commands
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/abcxyz/abc/templates/model"
+)
+
+func actionForEach(ctx context.Context, fe *model.ForEach, sp *stepParams) error {
+	key, err := parseAndExecuteGoTmpl(fe.Iterator.Key.Pos, fe.Iterator.Key.Val, sp.scope)
+	if err != nil {
+		return err
+	}
+
+	var values []string
+	if len(fe.Iterator.Values) > 0 {
+		var err error
+		values, err = parseAndExecuteGoTmplAll(fe.Iterator.Values, sp.scope)
+		if err != nil {
+			return err
+		}
+	} else {
+		return fmt.Errorf("not implemented. for_each with values_from is not supported yet")
+	}
+
+	for _, keyVal := range values {
+		subStepParams := sp.WithScope(map[string]string{key: keyVal})
+		if err := executeSteps(ctx, fe.Steps, subStepParams); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/templates/commands/render_action_foreach_test.go
+++ b/templates/commands/render_action_foreach_test.go
@@ -1,0 +1,194 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commands
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/abcxyz/abc/templates/model"
+	"github.com/abcxyz/pkg/testutil"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestActionForEach(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		in         *model.ForEach
+		inputs     map[string]string
+		wantStdout string
+		wantErr    string
+	}{
+		{
+			name: "values_literal",
+			inputs: map[string]string{
+				"from": "Alice",
+			},
+			in: &model.ForEach{
+				Iterator: &model.ForEachIterator{
+					Key: model.String{Val: "greeting_target"},
+					Values: []model.String{
+						{Val: "Bob"},
+						{Val: "Charlie"},
+					},
+				},
+				Steps: []*model.Step{
+					{
+						Print: &model.Print{
+							Message: model.String{Val: "Hello {{.greeting_target}} from {{.from}}"},
+						},
+					},
+				},
+			},
+			wantStdout: "Hello Bob from Alice\nHello Charlie from Alice\n",
+		},
+		{
+			name: "templated_values",
+			inputs: map[string]string{
+				"from":             "Alice",
+				"first_recipient":  "Bob",
+				"second_recipient": "Charlie",
+			},
+			in: &model.ForEach{
+				Iterator: &model.ForEachIterator{
+					Key: model.String{Val: "greeting_target"},
+					Values: []model.String{
+						{Val: "{{.first_recipient}}"},
+						{Val: "{{.second_recipient}}"},
+					},
+				},
+				Steps: []*model.Step{
+					{
+						Print: &model.Print{
+							Message: model.String{Val: "Hello {{.greeting_target}} from {{.from}}"},
+						},
+					},
+				},
+			},
+			wantStdout: "Hello Bob from Alice\nHello Charlie from Alice\n",
+		},
+		{
+			name: "nested",
+			inputs: map[string]string{
+				"first_greeter":    "Alice",
+				"second_greeter":   "Zendaya",
+				"first_recipient":  "Bob",
+				"second_recipient": "Charlie",
+			},
+			in: &model.ForEach{
+				Iterator: &model.ForEachIterator{
+					Key: model.String{Val: "greeter"},
+					Values: []model.String{
+						{Val: "{{.first_greeter}}"},
+						{Val: "{{.second_greeter}}"},
+					},
+				},
+				Steps: []*model.Step{
+					{
+						Action: model.String{Val: "for_each"},
+						ForEach: &model.ForEach{
+							Iterator: &model.ForEachIterator{
+								Key: model.String{Val: "greeting_target"},
+								Values: []model.String{
+									{Val: "{{.first_recipient}}"},
+									{Val: "{{.second_recipient}}"},
+								},
+							},
+							Steps: []*model.Step{
+								{
+									Print: &model.Print{
+										Message: model.String{Val: "Hello {{.greeting_target}} from {{.greeter}}"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantStdout: "Hello Bob from Alice\nHello Charlie from Alice\nHello Bob from Zendaya\nHello Charlie from Zendaya\n",
+		},
+		{
+			name: "values_literal",
+			inputs: map[string]string{
+				"color": "Blue",
+			},
+			in: &model.ForEach{
+				Iterator: &model.ForEachIterator{
+					Key: model.String{Val: "color"},
+					Values: []model.String{
+						{Val: "Red"},
+					},
+				},
+				Steps: []*model.Step{
+					{
+						Print: &model.Print{
+							Message: model.String{Val: "{{.color}}"},
+						},
+					},
+				},
+			},
+			wantStdout: "Red\n",
+		},
+		{
+			name:   "errors_are_propagated",
+			inputs: map[string]string{},
+			in: &model.ForEach{
+				Iterator: &model.ForEachIterator{
+					Key: model.String{Val: "x"},
+					Values: []model.String{
+						{Val: "Alice"},
+					},
+				},
+				Steps: []*model.Step{
+					{
+						Print: &model.Print{
+							Message: model.String{Val: "{{.nonexistent}}"},
+						},
+					},
+				},
+			},
+			wantErr: `nonexistent input variable name "nonexistent"`,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+
+			buf := &bytes.Buffer{}
+			sp := &stepParams{
+				scope:  newScope(tc.inputs),
+				stdout: buf,
+				flags:  &RenderFlags{},
+			}
+			err := actionForEach(ctx, tc.in, sp)
+			if diff := testutil.DiffErrString(err, tc.wantErr); diff != "" {
+				t.Error(diff)
+			}
+
+			got := buf.String()
+			if diff := cmp.Diff(got, tc.wantStdout); diff != "" {
+				t.Errorf("stdout was not as expected (-got,+want): %s", diff)
+			}
+		})
+	}
+}

--- a/templates/commands/render_test.go
+++ b/templates/commands/render_test.go
@@ -184,6 +184,7 @@ func TestDestOK(t *testing.T) {
 func TestRealRun(t *testing.T) {
 	t.Parallel()
 
+	// Many (but not all) of the subtests use this spec.yaml.
 	specContents := `
 apiVersion: 'cli.abcxyz.dev/v1alpha1'
 kind: 'Template'
@@ -496,6 +497,28 @@ steps:
 			wantBackupContents: map[string]string{
 				"file_a.txt": "purple is my favorite color",
 			},
+		},
+		{
+			name: "for_each",
+			templateContents: map[string]string{
+				"spec.yaml": `apiVersion: 'cli.abcxyz.dev/v1alpha1'
+kind: 'Template'
+desc: 'A template for the ages'
+steps:
+  - desc: 'Iterate over environments'
+    action: 'for_each'
+    params:
+      iterator:
+        key: 'env'
+        values: ['production', 'dev']
+      steps:
+        - desc: 'Print a message'
+          action: 'print'
+          params:
+            message: 'Working on environment {{.env}}'
+`,
+			},
+			wantStdout: "Working on environment production\nWorking on environment dev\n",
 		},
 	}
 


### PR DESCRIPTION
This adds partial support for the `for_each` action (#127). This includes the core logic for running a sequence of steps over each of a list of values.

This only supports iterating over a literal YAML list of values. Future PRs will add CEL integration to iterate over a programmatically defined list.

Docs are also still missing.