### PR TITLE
Add placeholder for `abc template test` commands.

### DIFF
--- a/cmd/abc/abc.go
+++ b/cmd/abc/abc.go
@@ -40,6 +40,20 @@ var rootCmd = func() *cli.RootCommand {
 						"render": func() cli.Command {
 							return &commands.RenderCommand{}
 						},
+						"test": func() cli.Command {
+							return &cli.RootCommand{
+								Name:        "test",
+								Description: "subcommands for validating template rendering with golden tests",
+								Commands: map[string]cli.CommandFactory{
+									"record": func() cli.Command {
+										return &commands.TestRecordCommand{}
+									},
+									"verify": func() cli.Command {
+										return &commands.TestVerifyCommand{}
+									},
+								},
+							}
+						},
 					},
 				}
 			},

--- a/templates/commands/render_action.go
+++ b/templates/commands/render_action.go
@@ -237,7 +237,7 @@ func (n *unknownTemplateKeyError) Unwrap() error {
 }
 
 func (n *unknownTemplateKeyError) Is(other error) bool {
-	_, ok := other.(*unknownTemplateKeyError) //nolint:errorlint
+	_, ok := other.(*unknownTemplateKeyError)
 	return ok
 }
 

--- a/templates/commands/test_record.go
+++ b/templates/commands/test_record.go
@@ -48,11 +48,6 @@ For every test case, it is expected that
 template input params.`
 }
 
-func (c *TestRecordCommand) Flags() *cli.FlagSet {
-	set := c.NewFlagSet()
-	return set
-}
-
 func (c *TestRecordCommand) Run(ctx context.Context, args []string) error {
 	return fmt.Errorf("Unimplemented")
 }

--- a/templates/commands/test_record.go
+++ b/templates/commands/test_record.go
@@ -1,0 +1,58 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package commands implements the template-related subcommands.
+package commands
+
+// This file implements the "templates test record" subcommand for
+// recording template tests.
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/abcxyz/pkg/cli"
+)
+
+type TestRecordCommand struct {
+	cli.BaseCommand
+}
+
+func (c *TestRecordCommand) Desc() string {
+	return "record the template rendering result to golden tests"
+}
+
+func (c *TestRecordCommand) Help() string {
+	return `
+Usage: {{ COMMAND }} [options] <test_name>
+
+The {{ COMMAND }} records the template golden tests.
+
+The "<test_name>" is the name of the test. If no <test_name> is specified,
+all tests will be recoreded.
+
+For every test case, it is expected that
+  - a testdata/golden/<test_name> folder exists to host test results.
+  - a testdata/golden/<test_name>/inputs.yaml exists to define
+template input params.`
+}
+
+func (c *TestRecordCommand) Flags() *cli.FlagSet {
+	set := c.NewFlagSet()
+	return set
+}
+
+func (c *TestRecordCommand) Run(ctx context.Context, args []string) error {
+	return fmt.Errorf("Unimplemented")
+}

--- a/templates/commands/test_verify.go
+++ b/templates/commands/test_verify.go
@@ -1,0 +1,58 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package commands implements the template-related subcommands.
+package commands
+
+// This file implements the "templates test verify" subcommand for
+// verifying a template test.
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/abcxyz/pkg/cli"
+)
+
+type TestVerifyCommand struct {
+	cli.BaseCommand
+}
+
+func (c *TestVerifyCommand) Desc() string {
+	return "verify the template rendering result against golden tests"
+}
+
+func (c *TestVerifyCommand) Help() string {
+	return `
+Usage: {{ COMMAND }} [options] <test_name>
+
+The {{ COMMAND }} verify the template golden test.
+
+The "<test_name>" is the name of the test. If no <test_name> is specified,
+all tests will be run against.
+
+For every test case, it is expected that
+  - a testdata/golden/<test_name> folder exists to host test results.
+  - a testdata/golden/<test_name>/inputs.yaml exists to define
+template input params.`
+}
+
+func (c *TestVerifyCommand) Flags() *cli.FlagSet {
+	set := c.NewFlagSet()
+	return set
+}
+
+func (c *TestVerifyCommand) Run(ctx context.Context, args []string) error {
+	return fmt.Errorf("Unimplemented")
+}

--- a/templates/commands/test_verify.go
+++ b/templates/commands/test_verify.go
@@ -48,11 +48,6 @@ For every test case, it is expected that
 template input params.`
 }
 
-func (c *TestVerifyCommand) Flags() *cli.FlagSet {
-	set := c.NewFlagSet()
-	return set
-}
-
 func (c *TestVerifyCommand) Run(ctx context.Context, args []string) error {
 	return fmt.Errorf("Unimplemented")
 }


### PR DESCRIPTION
Boilerplate for post validation tests.

Modified an existing file to pass linter CI:
directive `//nolint:errorlint` is unused for linter "errorlint" (nolintlint)