### PR TITLE
Clean up positional error reporting

### DIFF
--- a/templates/commands/cel.go
+++ b/templates/commands/cel.go
@@ -73,17 +73,17 @@ func celCompile(ctx context.Context, scope *scope, expr model.String) (cel.Progr
 
 	env, err := cel.NewEnv(celOpts...)
 	if err != nil {
-		return nil, expr.Pos.AnnotateErr(fmt.Errorf("internal error: failed configuring CEL environment: %w", err)) //nolint:wrapcheck
+		return nil, expr.Pos.Errorf("internal error: failed configuring CEL environment: %w", err)
 	}
 
 	ast, issues := env.Compile(expr.Val)
 	if err := issues.Err(); err != nil {
-		return nil, expr.Pos.AnnotateErr(fmt.Errorf("failed compiling CEL expression: %w", err)) //nolint:wrapcheck
+		return nil, expr.Pos.Errorf("failed compiling CEL expression: %w", err)
 	}
 
 	prog, err := env.Program(ast)
 	if err != nil {
-		return nil, expr.Pos.AnnotateErr(fmt.Errorf("failed constructing CEL program: %w", err)) //nolint:wrapcheck
+		return nil, expr.Pos.Errorf("failed constructing CEL program: %w", err)
 	}
 
 	latency := time.Since(startedAt)
@@ -116,7 +116,7 @@ func celEval(ctx context.Context, scope *scope, pos *model.ConfigPos, prog cel.P
 
 	celOut, _, err := prog.Eval(scopeMapAny)
 	if err != nil {
-		return pos.AnnotateErr(fmt.Errorf("failed executing CEL expression: %w", err)) //nolint:wrapcheck
+		return pos.Errorf("failed executing CEL expression: %w", err)
 	}
 
 	outPtrRefVal := reflect.ValueOf(outPtr)
@@ -128,7 +128,7 @@ func celEval(ctx context.Context, scope *scope, pos *model.ConfigPos, prog cel.P
 
 	celAny, err := celOut.ConvertToNative(outRefVal.Type())
 	if err != nil {
-		return pos.AnnotateErr(fmt.Errorf("CEL expression result couldn't be converted to %s. The CEL engine error was: %w", outRefVal.Type(), err)) //nolint:wrapcheck
+		return pos.Errorf("CEL expression result couldn't be converted to %s. The CEL engine error was: %w", outRefVal.Type(), err)
 	}
 
 	outRefVal.Set(reflect.ValueOf(celAny))

--- a/templates/commands/render.go
+++ b/templates/commands/render.go
@@ -567,11 +567,11 @@ func mkdirAllChecked(pos *model.ConfigPos, rfs renderFS, path string, dryRun boo
 	info, err := rfs.Stat(path)
 	if err != nil {
 		if !os.IsNotExist(err) {
-			return model.ErrWithPos(pos, "Stat(): %w", err) //nolint:wrapcheck
+			return pos.Errorf("Stat(): %w", err)
 		}
 		create = true
 	} else if !info.Mode().IsDir() {
-		return model.ErrWithPos(pos, "cannot overwrite a file with a directory of the same name, %q", path) //nolint:wrapcheck
+		return pos.Errorf("cannot overwrite a file with a directory of the same name, %q", path)
 	}
 
 	if dryRun || !create {
@@ -579,7 +579,7 @@ func mkdirAllChecked(pos *model.ConfigPos, rfs renderFS, path string, dryRun boo
 	}
 
 	if err := rfs.MkdirAll(path, ownerRWXPerms); err != nil {
-		return model.ErrWithPos(pos, "MkdirAll(): %w", err) //nolint:wrapcheck
+		return pos.Errorf("MkdirAll(): %w", err)
 	}
 
 	return nil

--- a/templates/commands/render_action_include.go
+++ b/templates/commands/render_action_include.go
@@ -94,7 +94,7 @@ func actionInclude(ctx context.Context, inc *model.Include, sp *stepParams) erro
 
 		if _, err := sp.fs.Stat(absSrc); err != nil {
 			if errors.Is(err, os.ErrNotExist) {
-				return model.ErrWithPos(p.Pos, "include path doesn't exist: %q", walkRelPath) //nolint:wrapcheck
+				return p.Pos.Errorf("include path doesn't exist: %q", walkRelPath)
 			}
 			return fmt.Errorf("Stat(): %w", err)
 		}
@@ -130,7 +130,7 @@ func actionInclude(ctx context.Context, inc *model.Include, sp *stepParams) erro
 			},
 		}
 		if err := copyRecursive(ctx, p.Pos, params); err != nil {
-			return model.ErrWithPos(p.Pos, "copying failed: %w", err) //nolint:wrapcheck
+			return p.Pos.Errorf("copying failed: %w", err)
 		}
 	}
 	return nil
@@ -153,7 +153,7 @@ func dest(pathPos *model.ConfigPos, relPath, as, stripPrefix, addPrefix string) 
 		before := relPath
 		relPath = strings.TrimPrefix(relPath, stripPrefix)
 		if relPath == before {
-			return "", model.ErrWithPos(pathPos, "the strip_prefix %q wasn't a prefix of the actual path %q", //nolint:wrapcheck
+			return "", pathPos.Errorf("the strip_prefix %q wasn't a prefix of the actual path %q",
 				stripPrefix, relPath)
 		}
 	}

--- a/templates/commands/render_action_regexnamelookup.go
+++ b/templates/commands/render_action_regexnamelookup.go
@@ -72,7 +72,7 @@ func actionRegexNameLookup(ctx context.Context, rn *model.RegexNameLookup, sp *s
 func replaceWithNameLookup(allMatches [][]int, b []byte, rn *model.RegexNameLookupEntry, re *regexp.Regexp, scope *scope) ([]byte, error) {
 	for i := 1; i < len(re.SubexpNames()); i++ { // skip group 0, which is always unnamed because it's "the whole regex match"
 		if re.SubexpNames()[i] == "" {
-			return nil, model.ErrWithPos(rn.Regex.Pos, `all capturing groups in a regex_name_lookup must be named, like (?P<myinputvar>myregex), not like (myregex)`) //nolint:wrapcheck
+			return nil, rn.Regex.Pos.Errorf(`all capturing groups in a regex_name_lookup must be named, like (?P<myinputvar>myregex), not like (myregex)`)
 		}
 	}
 
@@ -89,7 +89,7 @@ func replaceWithNameLookup(allMatches [][]int, b []byte, rn *model.RegexNameLook
 			subGroupName := re.SubexpNames()[subGroupIdx]
 			replacementVal, ok := scope.Lookup(subGroupName)
 			if !ok {
-				return nil, model.ErrWithPos(rn.Regex.Pos, "there was no template input variable matching the subgroup name %q; available variables are %v", //nolint:wrapcheck
+				return nil, rn.Regex.Pos.Errorf("there was no template input variable matching the subgroup name %q; available variables are %v",
 					subGroupName, maps.Keys(scope.All()))
 			}
 			replaceAtStartIdx := oneMatch[subGroupIdx*2]

--- a/templates/commands/render_action_regexreplace.go
+++ b/templates/commands/render_action_regexreplace.go
@@ -53,7 +53,7 @@ func actionRegexReplace(ctx context.Context, rr *model.RegexReplace, sp *stepPar
 				continue
 			}
 			if name == "" {
-				return model.ErrWithPos(rp.Regex.Pos, "all capturing groups in regexes must be named, like (?P<myname>re) . The %d'th capturing group in regex %s is an unnamed group, like (re) . Please use either a named capturing group or an non-capturing group like (?:re)", subexpIdx, rp.Regex.Val) //nolint:wrapcheck
+				return rp.Regex.Pos.Errorf("all capturing groups in regexes must be named, like (?P<myname>re) . The %d'th capturing group in regex %s is an unnamed group, like (re) . Please use either a named capturing group or an non-capturing group like (?:re)", subexpIdx, rp.Regex.Val)
 			}
 		}
 	}
@@ -118,7 +118,7 @@ func replaceWithTemplate(allMatches [][]int, b []byte, rr *model.RegexReplaceEnt
 		if rr.SubgroupToReplace.Val != "" {
 			subgroupNum = re.SubexpIndex(rr.SubgroupToReplace.Val)
 			if subgroupNum < 0 {
-				return nil, model.ErrWithPos(rr.SubgroupToReplace.Pos, "subgroup name %q is not a named subgroup in the regex %s", rr.SubgroupToReplace.Val, re.String()) //nolint:wrapcheck
+				return nil, rr.SubgroupToReplace.Pos.Errorf("subgroup name %q is not a named subgroup in the regex %s", rr.SubgroupToReplace.Val, re.String())
 			}
 		}
 		replaceAtStartIdx := oneMatch[subgroupNum*2] // bounds have already been checked in the caller
@@ -151,7 +151,7 @@ func rejectNumberedSubgroupExpand(with model.String) error {
 			continue
 		}
 
-		return model.ErrWithPos(with.Pos, "regex expansions must reference the subgroup by name, like ${mygroup}, rather than by number, like ${1}; we saw %s", oneMatch[0]) //nolint:wrapcheck
+		return with.Pos.Errorf("regex expansions must reference the subgroup by name, like ${mygroup}, rather than by number, like ${1}; we saw %s", oneMatch[0])
 	}
 	return nil
 }

--- a/templates/commands/render_action_regexreplace_test.go
+++ b/templates/commands/render_action_regexreplace_test.go
@@ -432,7 +432,7 @@ func TestRejectNumberedSubgroupExpand(t *testing.T) {
 		{
 			name:    "reject_numbered",
 			in:      "abc $5 def",
-			wantErr: "failed executing template spec file at line 1: regex expansions must reference the subgroup by name, like ${mygroup}, rather than by number, like ${1}; we saw $5",
+			wantErr: "at spec.yaml line 1 column 1: regex expansions must reference the subgroup by name, like ${mygroup}, rather than by number, like ${1}; we saw $5",
 		},
 		{
 			// Note: "$$" expands to "$", this is not a subgroup reference

--- a/templates/commands/render_action_test.go
+++ b/templates/commands/render_action_test.go
@@ -677,7 +677,7 @@ func TestParseAndExecute(t *testing.T) {
 				"something_else": "🥲",
 			},
 			wantUnknownKeyErr: true,
-			wantErr:           `failed executing template spec file at line 1: template.Execute() failed: the template referenced a nonexistent input variable name "my_input"; available variable names are [something_else]`,
+			wantErr:           `at spec.yaml line 1 column 0: template.Execute() failed: the template referenced a nonexistent input variable name "my_input"; available variable names are [something_else]`,
 		},
 		{
 			name: "unclosed_braces",

--- a/templates/model/pos.go
+++ b/templates/model/pos.go
@@ -41,32 +41,19 @@ func yamlPos(n *yaml.Node) *ConfigPos {
 	}
 }
 
-// AnnotateErr prepends the config file location of a parsed value to an error. If the input err is
-// nil, then nil is returned.
-func (c *ConfigPos) AnnotateErr(err error) error {
-	if err == nil {
-		return nil
-	}
-
-	pos := "(position unavailable)" // This can happen when field values are defaults, rather that coming from the config file
-	if c != nil && *c != (ConfigPos{}) {
-		pos = fmt.Sprintf("line %d column %d", c.Line, c.Column)
-	}
-
-	return fmt.Errorf("invalid config near %s: %w", pos, err)
-}
-
-// ErrWithPos includes information about the given config line with a given
-// error. One good way to use this is with %w, like:
+// Errorf returns a error prepended with spec.yaml position information, if
+// available.
 //
-//	ErrWithPos(pos, "Foo(): %w", err)
+// Examples:
 //
-// Calling this function with a zero or nil ConfigPos is valid. The resulting
-// error will just omit information about config location.
-func ErrWithPos(pos *ConfigPos, fmtStr string, args ...any) error {
+//	Wrapping an error: c.Errorf("foo(): %w", err)
+//
+//	Creating an error: c.Errorf("something went wrong doing action %s", action)
+func (c *ConfigPos) Errorf(fmtStr string, args ...any) error {
 	err := fmt.Errorf(fmtStr, args...)
-	if pos == nil || *pos == (ConfigPos{}) {
-		return err // No location info is available.
+	if c == nil || *c == (ConfigPos{}) {
+		return err
 	}
-	return fmt.Errorf("failed executing template spec file at line %d: %w", pos.Line, err)
+
+	return fmt.Errorf("at spec.yaml line %d column %d: %w", c.Line, c.Column, err)
 }

--- a/templates/model/pos_test.go
+++ b/templates/model/pos_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestErrWithPos(t *testing.T) {
+func TestPosErrorf(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
@@ -36,7 +36,7 @@ func TestErrWithPos(t *testing.T) {
 			pos:     &ConfigPos{10, 11},
 			fmtStr:  "Oh no! some number %d: %w",
 			args:    []any{345, fmt.Errorf("wrapped error")},
-			wantErr: "failed executing template spec file at line 10: Oh no! some number 345: wrapped error",
+			wantErr: "at spec.yaml line 10 column 11: Oh no! some number 345: wrapped error",
 		},
 		{
 			name:    "nil_position",
@@ -57,7 +57,7 @@ func TestErrWithPos(t *testing.T) {
 			pos:     &ConfigPos{10, 11},
 			fmtStr:  "abc def",
 			args:    nil,
-			wantErr: "failed executing template spec file at line 10: abc def",
+			wantErr: "at spec.yaml line 10 column 11: abc def",
 		},
 	}
 
@@ -67,7 +67,7 @@ func TestErrWithPos(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := ErrWithPos(tc.pos, tc.fmtStr, tc.args...)
+			got := tc.pos.Errorf(tc.fmtStr, tc.args...)
 			if diff := cmp.Diff(got.Error(), tc.wantErr); diff != "" {
 				t.Error(diff)
 			}

--- a/templates/model/spec.go
+++ b/templates/model/spec.go
@@ -155,7 +155,7 @@ func (i *Input) UnmarshalYAML(n *yaml.Node) error {
 func (i *Input) Validate() error {
 	var reservedNameErr error
 	if strings.HasPrefix(i.Name.Val, "_") {
-		reservedNameErr = i.Name.Pos.AnnotateErr(fmt.Errorf("input names beginning with _ are reserved"))
+		reservedNameErr = i.Name.Pos.Errorf("input names beginning with _ are reserved")
 	}
 
 	return errors.Join(
@@ -237,9 +237,9 @@ func (s *Step) UnmarshalYAML(n *yaml.Node) error {
 		unmarshalInto = s.StringReplace
 		s.StringReplace.Pos = s.Pos
 	case "":
-		return s.Pos.AnnotateErr(fmt.Errorf(`missing "action" field in this step`))
+		return s.Pos.Errorf(`missing "action" field in this step`)
 	default:
-		return s.Pos.AnnotateErr(fmt.Errorf("unknown action type %q", s.Action.Val))
+		return s.Pos.Errorf("unknown action type %q", s.Action.Val)
 	}
 
 	params := struct {
@@ -340,17 +340,17 @@ func (i *Include) Validate() error {
 	var exclusivityErr error
 	if len(i.As) != 0 {
 		if i.StripPrefix.Val != "" || i.AddPrefix.Val != "" {
-			exclusivityErr = i.As[0].Pos.AnnotateErr(fmt.Errorf(`"as" may not be used with "strip_prefix" or "add_prefix"`))
+			exclusivityErr = i.As[0].Pos.Errorf(`"as" may not be used with "strip_prefix" or "add_prefix"`)
 		} else if len(i.Paths) != len(i.As) {
-			exclusivityErr = i.As[0].Pos.AnnotateErr(fmt.Errorf(`when using "as", the size of "as" (%d) must be the same as the size of "paths" (%d)`,
-				len(i.As), len(i.Paths)))
+			exclusivityErr = i.As[0].Pos.Errorf(`when using "as", the size of "as" (%d) must be the same as the size of "paths" (%d)`,
+				len(i.As), len(i.Paths))
 		}
 	}
 
 	var fromErr error
 	validFrom := []string{"destination"}
 	if i.From.Val != "" && !slices.Contains(validFrom, i.From.Val) {
-		fromErr = i.From.Pos.AnnotateErr(fmt.Errorf(`"from" must be one of %v`, validFrom))
+		fromErr = i.From.Pos.Errorf(`"from" must be one of %v`, validFrom)
 	}
 
 	return errors.Join(

--- a/templates/model/spec_test.go
+++ b/templates/model/spec_test.go
@@ -83,15 +83,15 @@ steps:
   action: 'print'
   params:
     message: 'Hello, {{.or .person_name "World"}}'`,
-			wantValidateErr: `invalid config near line 3 column 3: field "desc" is required`,
+			wantValidateErr: `at spec.yaml line 3 column 3: field "desc" is required`,
 		},
 		{
 			name: "check_required_fields",
 			in:   "inputs:",
-			wantValidateErr: `invalid config near line 1 column 1: field "apiVersion" value must be one of [cli.abcxyz.dev/v1alpha1]
-invalid config near line 1 column 1: field "kind" value must be one of [Template]
-invalid config near line 1 column 1: field "desc" is required
-invalid config near line 1 column 1: field "steps" is required`,
+			wantValidateErr: `at spec.yaml line 1 column 1: field "apiVersion" value must be one of [cli.abcxyz.dev/v1alpha1]
+at spec.yaml line 1 column 1: field "kind" value must be one of [Template]
+at spec.yaml line 1 column 1: field "desc" is required
+at spec.yaml line 1 column 1: field "steps" is required`,
 		},
 
 		{
@@ -110,7 +110,7 @@ steps:
   action: 'print'
   params:
     message: 'Hello'`,
-			wantUnmarshalErr: `invalid config near line 8 column 3: unknown field name "not_a_real_field"`,
+			wantUnmarshalErr: `at spec.yaml line 8 column 3: unknown field name "not_a_real_field"`,
 		},
 	}
 
@@ -178,14 +178,14 @@ desc: "The name of a person to greet"`,
 		{
 			name:            "missing_required_fields_should_fail",
 			in:              `desc: 'a thing'`,
-			wantValidateErr: `invalid config near line 1 column 1: field "name" is required`,
+			wantValidateErr: `at spec.yaml line 1 column 1: field "name" is required`,
 		},
 		{
 			name: "unexpected_field_should_fail",
 			in: `name: 'a'
 desc: 'b'
 nonexistent_field: 'oops'`,
-			wantUnmarshalErr: `invalid config near line 3 column 1: unknown field name "nonexistent_field"`,
+			wantUnmarshalErr: `at spec.yaml line 3 column 1: unknown field name "nonexistent_field"`,
 		},
 		{
 			name: "reserved_input_name",
@@ -261,7 +261,7 @@ params:
 action: 'append'
 params:
   paths: ['a.txt']`,
-			wantValidateErr: `invalid config near line 4 column 3: field "with" is required`,
+			wantValidateErr: `at spec.yaml line 4 column 3: field "with" is required`,
 		},
 		{
 			name: "append_missing_paths_field_should_fail",
@@ -269,7 +269,7 @@ params:
 action: 'append'
 params:
   with: 'def'`,
-			wantValidateErr: `invalid config near line 4 column 3: field "paths" is required`,
+			wantValidateErr: `at spec.yaml line 4 column 3: field "paths" is required`,
 		},
 		{
 			name: "append_non_bool_skip_ensure_newline_field_should_fail",
@@ -310,14 +310,14 @@ action: 'print'
 params:
   message: 'hello'
   extra_field: 'oops'`,
-			wantUnmarshalErr: `invalid config near line 5 column 3: unknown field name "extra_field"`,
+			wantUnmarshalErr: `at spec.yaml line 5 column 3: unknown field name "extra_field"`,
 		},
 		{
 			name: "print_missing_message",
 			in: `desc: 'Print a message'
 action: 'print'
 params: `,
-			wantValidateErr: `invalid config near line 1 column 1: field "message" is required`,
+			wantValidateErr: `at spec.yaml line 1 column 1: field "message" is required`,
 		},
 		{
 			name: "include_success",
@@ -513,14 +513,14 @@ params:
 action: 'include'
 params:
   paths:`,
-			wantValidateErr: `invalid config near line 4 column 3: field "paths" is required`,
+			wantValidateErr: `at spec.yaml line 4 column 3: field "paths" is required`,
 		},
 		{
 			name: "missing_include_paths_should_fail",
 			in: `desc: 'mydesc'
 action: 'include'
 params:`,
-			wantValidateErr: `invalid config near line 1 column 1: field "paths" is required`,
+			wantValidateErr: `at spec.yaml line 1 column 1: field "paths" is required`,
 		},
 		{
 			name: "unknown_params_should_fail",
@@ -528,7 +528,7 @@ params:`,
 action: 'include'
 params:
   nonexistent: 'foo'`,
-			wantUnmarshalErr: `invalid config near line 4 column 3: unknown field name "nonexistent"`,
+			wantUnmarshalErr: `at spec.yaml line 4 column 3: unknown field name "nonexistent"`,
 		},
 		{
 			name: "regex_replace_success",
@@ -575,7 +575,7 @@ params:
   - regex: '(?p<x>y)'
     subgroup_to_replace: 1
     with: 'some_template'`,
-			wantValidateErr: `invalid config near line 7 column 26: subgroup name must be a letter followed by zero or more alphanumerics`,
+			wantValidateErr: `at spec.yaml line 7 column 26: subgroup name must be a letter followed by zero or more alphanumerics`,
 		},
 		{
 			name: "regex_missing_fields_should_fail",
@@ -585,8 +585,8 @@ params:
   paths: ['a.txt']
   replacements:
   - subgroup_to_replace: xyz`,
-			wantValidateErr: `invalid config near line 6 column 5: field "regex" is required
-invalid config near line 6 column 5: field "with" is required`,
+			wantValidateErr: `at spec.yaml line 6 column 5: field "regex" is required
+at spec.yaml line 6 column 5: field "with" is required`,
 		},
 
 		{
@@ -599,7 +599,7 @@ params:
   - regex: 'my_regex'
     subgroup_to_replace: -1
     with: 'some_template'`,
-			wantValidateErr: `invalid config near line 7 column 26: subgroup name must be a letter followed by zero or more alphanumerics`,
+			wantValidateErr: `at spec.yaml line 7 column 26: subgroup name must be a letter followed by zero or more alphanumerics`,
 		},
 		{
 			name: "regex_missing_fields_should_fail",
@@ -609,8 +609,8 @@ params:
   paths: ['a.txt']
   replacements:
   - subgroup_to_replace: xyz`,
-			wantValidateErr: `invalid config near line 6 column 5: field "regex" is required
-invalid config near line 6 column 5: field "with" is required`,
+			wantValidateErr: `at spec.yaml line 6 column 5: field "regex" is required
+at spec.yaml line 6 column 5: field "with" is required`,
 		},
 		{
 			name: "regex_name_lookup_success",
@@ -684,7 +684,7 @@ params:
 action: 'string_replace'
 params:
   paths: ['a.txt']`,
-			wantValidateErr: `invalid config near line 4 column 3: field "replacements" is required`,
+			wantValidateErr: `at spec.yaml line 4 column 3: field "replacements" is required`,
 		},
 		{
 			name: "string_replace_missing_paths_field_should_fail",
@@ -694,7 +694,7 @@ params:
   replacements:
   - to_replace: 'abc'
     with: 'def'`,
-			wantValidateErr: `invalid config near line 4 column 3: field "paths" is required`,
+			wantValidateErr: `at spec.yaml line 4 column 3: field "paths" is required`,
 		},
 		{
 			name: "go_template_success",
@@ -719,7 +719,7 @@ params:
 action: 'go_template'
 params:
   paths: []`,
-			wantValidateErr: `invalid config near line 4 column 3: field "paths" is required`,
+			wantValidateErr: `at spec.yaml line 4 column 3: field "paths" is required`,
 		},
 		{
 			name: "for_each_range_over_list",

--- a/templates/model/validate.go
+++ b/templates/model/validate.go
@@ -33,7 +33,7 @@ func notZeroModel[T comparable](pos *ConfigPos, x valWithPos[T], fieldName strin
 func notZero[T comparable](pos *ConfigPos, t T, fieldName string) error {
 	var zero T
 	if t == zero {
-		return pos.AnnotateErr(fmt.Errorf("field %q is required", fieldName))
+		return pos.Errorf("field %q is required", fieldName)
 	}
 	return nil
 }
@@ -41,7 +41,7 @@ func notZero[T comparable](pos *ConfigPos, t T, fieldName string) error {
 // Returns error if the given slice is empty.
 func nonEmptySlice[T any](pos *ConfigPos, s []T, fieldName string) error {
 	if len(s) == 0 {
-		return pos.AnnotateErr(fmt.Errorf("field %q is required", fieldName))
+		return pos.Errorf("field %q is required", fieldName)
 	}
 	return nil
 }
@@ -52,7 +52,7 @@ var validRegexGroupName = regexp.MustCompile(`[a-zA-Z][a-zA-Z0-9]*`)
 
 func isValidRegexGroupName(s String, fieldName string) error {
 	if !validRegexGroupName.MatchString(s.Val) {
-		return s.Pos.AnnotateErr(fmt.Errorf("subgroup name must be a letter followed by zero or more alphanumerics"))
+		return s.Pos.Errorf("subgroup name must be a letter followed by zero or more alphanumerics")
 	}
 	return nil
 }
@@ -62,7 +62,7 @@ func oneOf[T comparable](pos *ConfigPos, x valWithPos[T], allowed []T, fieldName
 	if slices.Contains(allowed, x.Val) {
 		return nil
 	}
-	return pos.AnnotateErr(fmt.Errorf("field %q value must be one of %v", fieldName, allowed))
+	return pos.Errorf("field %q value must be one of %v", fieldName, allowed)
 }
 
 // Fail if any unexpected fields are seen. The input must be a mapping/object; anything else will
@@ -101,7 +101,7 @@ func extraFields(n *yaml.Node, knownFields []string) error {
 		}
 	}
 
-	return pos.AnnotateErr(fmt.Errorf("unknown field name %q; valid choices are %v", unknownField, knownFields))
+	return pos.Errorf("unknown field name %q; valid choices are %v", unknownField, knownFields)
 }
 
 type validator interface {


### PR DESCRIPTION
We had two separate similar mechanisms for reporting an error along with the position in the spec.yaml where it happened. Both were overly verbose. Now there's one simple, concise way.

As a bonus we get to remove lots of nolint annotations because functions named Errorf() are exempted from the `wrapcheck` linter.