### PR TITLE
Run presubmits on all PRs

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -19,8 +19,6 @@ on:
     branches:
       - 'main'
   pull_request:
-    branches:
-      - 'main'
   workflow_dispatch:
   workflow_call:
 


### PR DESCRIPTION
We'll run the lint&test actions for all PRs, not just those targeting `main`.

This improves the "stacked PR" workflow where the user breaks a change into several PRs, each one "based" on the previous PR, and sends them separately for review. Before this change, only the first PR in the stack would automatically be linted&tested.

If this works sanely, we can consider making a similar change to other abcxyz repos.