### PR TITLE
feat: CEL validation rules for template inputs

### DIFF
--- a/examples/templates/render/inputs/spec.yaml
+++ b/examples/templates/render/inputs/spec.yaml
@@ -29,6 +29,17 @@ inputs:
     desc: 'Default-empty-string is treated differently than no-default'
     default: ''
 
+  - name: 'my_length_limited_input'
+    desc: "An input that's length-checked"
+    default: 'foo'
+    rules:
+      - rule: 'size(my_length_limited_input)) < 10'
+        message: 'length must be small enough to fit in the database table'
+
+      - rule: 'size(my_length_limited_input+my_input_with_default) < 20'
+        message: |
+          the combined length of my_length_limited_input and my_input_with_default must be less than 20
+
 steps:
   - desc: 'Print input values'
     action: 'print'
@@ -38,3 +49,4 @@ steps:
           my_input_with_default={{.my_input_with_default}}
           my_input_without_default={{.my_input_without_default}}
           my_input_with_default_empty_string={{.my_input_with_default_empty_string}}
+          my_length_limited_input={{.my_length_limited_input}}

--- a/templates/commands/cel.go
+++ b/templates/commands/cel.go
@@ -61,6 +61,25 @@ var (
 	}
 )
 
+// celCompileAndEval parses, compiles, and executes the given CEL expr with the
+// given variables in scope.
+//
+// The output of CEL execution is written into the location pointed to by
+// outPtr. It must be a pointer. If the output of the CEL expression can't be
+// converted to the given type, then an error will be returned. For example, if
+// the CEL expression is "hello" and outPtr points to an int, an error will
+// returned because CEL cannot treat "hello" as an integer.
+func celCompileAndEval(ctx context.Context, scope *scope, expr model.String, outPtr any) error {
+	prog, err := celCompile(ctx, scope, expr)
+	if err != nil {
+		return err
+	}
+	if err := celEval(ctx, scope, expr.Pos, prog, outPtr); err != nil {
+		return err
+	}
+	return nil
+}
+
 // celCompile parses and compiles the given expr into executable Program.
 func celCompile(ctx context.Context, scope *scope, expr model.String) (cel.Program, error) {
 	startedAt := time.Now()

--- a/templates/commands/render_action_foreach.go
+++ b/templates/commands/render_action_foreach.go
@@ -34,13 +34,7 @@ func actionForEach(ctx context.Context, fe *model.ForEach, sp *stepParams) error
 			return err
 		}
 	} else {
-		prog, err := celCompile(ctx, sp.scope, *fe.Iterator.ValuesFrom)
-		if err != nil {
-			return err
-		}
-
-		err = celEval(ctx, sp.scope, fe.Iterator.ValuesFrom.Pos, prog, &values)
-		if err != nil {
+		if err := celCompileAndEval(ctx, sp.scope, *fe.Iterator.ValuesFrom, &values); err != nil {
 			return err
 		}
 	}

--- a/templates/commands/render_flags.go
+++ b/templates/commands/render_flags.go
@@ -51,6 +51,9 @@ type RenderFlags struct {
 	// Inputs provide values that are substituted into the template. The keys in
 	// this map must match the input names in the Source template's spec.yaml
 	// file.
+	//
+	// This is mutable, even after flag parsing. It may be updated when default
+	// values are added and as the user is prompted for inputs.
 	Inputs map[string]string // these are just the --input values from flags; doesn't inclue values from config file or env vars
 
 	// KeepTempDirs prevents the cleanup of temporary directories after rendering is complete.

--- a/templates/model/spec_test.go
+++ b/templates/model/spec_test.go
@@ -193,6 +193,64 @@ nonexistent_field: 'oops'`,
 name: '_name_with_leading_underscore'`,
 			wantValidateErr: "are reserved",
 		},
+		{
+			name: "validation-rule",
+			in: `desc: 'foo'
+name: 'a'
+rules:
+  - rule: 'size(a) > 5'
+    message: 'my message'`,
+			want: &Input{
+				Name: String{Val: "a"},
+				Desc: String{Val: "foo"},
+				Rules: []*InputRule{
+					{
+						Rule:    String{Val: "size(a) > 5"},
+						Message: String{Val: "my message"},
+					},
+				},
+			},
+		},
+		{
+			name: "validation-rule-without-message",
+			in: `desc: 'foo'
+name: 'a'
+rules:
+  - rule: 'size(a) > 5'`,
+			want: &Input{
+				Name: String{Val: "a"},
+				Desc: String{Val: "foo"},
+				Rules: []*InputRule{
+					{
+						Rule: String{Val: "size(a) > 5"},
+					},
+				},
+			},
+		},
+		{
+			name: "multiple-validation-rules",
+			in: `desc: 'foo'
+name: 'a'
+rules:
+  - rule: 'size(a) > 5'
+    message: 'my message'
+  - rule: 'size(a) < 100'
+    message: 'my other message'`,
+			want: &Input{
+				Name: String{Val: "a"},
+				Desc: String{Val: "foo"},
+				Rules: []*InputRule{
+					{
+						Rule:    String{Val: "size(a) > 5"},
+						Message: String{Val: "my message"},
+					},
+					{
+						Rule:    String{Val: "size(a) < 100"},
+						Message: String{Val: "my other message"},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Each input in spec.yaml can now optionally have a list of "rules" (CEL predicates) to check it for validity. An example use case is to check that a given string is suitable to be used as a GCP project ID.

Partially implements #28.

Example error message:

```
input validation failed:

Input name:   my_input
Input value:  foo
Rule:         my_input.startsWith("ham")
Rule msg:     Must start with "ham"
```

We support validating multiple inputs together. For example, you could require that the combined length of two strings is less than some number, or you could require that exactly one of two inputs is non-empty. Every input is in scope in every validation function.

We also include information about the validation rules when prompting for user inputs. This will help the user input something valid. Example prompt:

```
Input name:   animal
Description:  your favorite animal
Rule:         size(animal) > 1
Rule msg:     length must be greater than 1

Enter value: 
```

Upcoming work will add custom CEL functions like `gcp.matches_service_account` for commonly needed validations.