### PR TITLE
feat: custom CEL functions for matching GCP service accounts

### DIFF
--- a/examples/templates/render/inputs/spec.yaml
+++ b/examples/templates/render/inputs/spec.yaml
@@ -30,15 +30,29 @@ inputs:
     default: ''
 
   - name: 'my_length_limited_input'
-    desc: "An input that's length-checked"
+    desc: 'A length-checked input'
     default: 'foo'
     rules:
-      - rule: 'size(my_length_limited_input)) < 10'
+      - rule: 'size(my_length_limited_input) < 10'
         message: 'length must be small enough to fit in the database table'
 
       - rule: 'size(my_length_limited_input+my_input_with_default) < 20'
         message: |
           the combined length of my_length_limited_input and my_input_with_default must be less than 20
+
+  - name: 'my_service_account'
+    desc:
+      'The name of the existing GCP service account to grant access to
+      something. Either user-created or service agent.'
+    rules:
+      - rule: 'gcp_matches_service_account(my_service_account)'
+
+  - name: 'my_service_account_id'
+    desc:
+      'The ID (the part before the @ sign) of the GCP service account to be
+      created'
+    rules:
+      - rule: 'gcp_matches_service_account_id(my_service_account_id)'
 
 steps:
   - desc: 'Print input values'
@@ -50,3 +64,5 @@ steps:
           my_input_without_default={{.my_input_without_default}}
           my_input_with_default_empty_string={{.my_input_with_default_empty_string}}
           my_length_limited_input={{.my_length_limited_input}}
+          my_service_account={{.my_service_account}}
+          my_service_account_id={{.my_service_account_id}}


### PR DESCRIPTION
These new CEL functions are intended to be used for input validation. They validate that their input matches the expected format. This PR adds functions for validating GCP service accounts and project IDs.

Part of #39.