### PR TITLE
Detect and handle old-style paths-as-list-of-strings

### DIFF
--- a/templates/model/spec_test.go
+++ b/templates/model/spec_test.go
@@ -378,12 +378,40 @@ params: `,
 			wantValidateErr: `at spec.yaml line 1 column 1: field "message" is required`,
 		},
 		{
-			name: "include_old_style", // not path objects, paths are just strings
+			name: "include_success_paths_are_string", // not path objects, paths are just strings
 			in: `desc: 'mydesc'
 action: 'include'
 params:
   paths: ['a/b/c', 'x/y.txt']
   from: 'destination'`,
+			want: &Step{
+				Desc:   String{Val: "mydesc"},
+				Action: String{Val: "include"},
+				Include: &Include{
+					Paths: []*IncludePath{
+						{
+							From: String{Val: "destination"},
+							Paths: []String{
+								{
+									Val: "a/b/c",
+								},
+								{
+									Val: "x/y.txt",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "include_success_paths_are_objects",
+			in: `desc: 'mydesc'
+action: 'include'
+params:
+  paths: 
+  - paths: ['a/b/c', 'x/y.txt']
+    from: 'destination'`,
 			want: &Step{
 				Desc:   String{Val: "mydesc"},
 				Action: String{Val: "include"},
@@ -534,6 +562,17 @@ params:
     - 'a.txt'
     - paths: ['b.txt']`,
 			wantUnmarshalErr: "Lists of paths must be homogeneous, either all strings or all objects",
+		},
+		{
+			name: "other_include_fields_forbidden_with_path_objects",
+			in: `desc: 'mydesc'
+action: 'include'
+params:
+  from: 'destination'
+  paths:
+    - paths: 
+      - 'a.txt'`,
+			wantUnmarshalErr: `unknown field name "from"`,
 		},
 		{
 			name: "include_from_invalid",

--- a/templates/model/spec_test.go
+++ b/templates/model/spec_test.go
@@ -378,25 +378,23 @@ params: `,
 			wantValidateErr: `at spec.yaml line 1 column 1: field "message" is required`,
 		},
 		{
-			name: "include_success",
+			name: "include_old_style", // not path objects, paths are just strings
 			in: `desc: 'mydesc'
 action: 'include'
 params:
-  paths: ['a/b/c', 'x/y.txt']`,
+  paths: ['a/b/c', 'x/y.txt']
+  from: 'destination'`,
 			want: &Step{
 				Desc:   String{Val: "mydesc"},
 				Action: String{Val: "include"},
 				Include: &Include{
 					Paths: []*IncludePath{
 						{
+							From: String{Val: "destination"},
 							Paths: []String{
 								{
 									Val: "a/b/c",
 								},
-							},
-						},
-						{
-							Paths: []String{
 								{
 									Val: "x/y.txt",
 								},
@@ -528,6 +526,16 @@ params:
 			},
 		},
 		{
+			name: "include_paths_heterogeneous_list",
+			in: `desc: 'mydesc'
+action: 'include'
+params:
+  paths:
+    - 'a.txt'
+    - paths: ['b.txt']`,
+			wantUnmarshalErr: "Lists of paths must be homogeneous, either all strings or all objects",
+		},
+		{
 			name: "include_from_invalid",
 			in: `desc: 'mydesc'
 action: 'include'
@@ -608,7 +616,7 @@ params:
 			in: `desc: 'mydesc'
 action: 'include'
 params:
-  paths:`,
+  paths: []`,
 			wantValidateErr: `at spec.yaml line 4 column 3: field "paths" is required`,
 		},
 		{
@@ -623,7 +631,8 @@ params:`,
 			in: `desc: 'mydesc'
 action: 'include'
 params:
-  nonexistent: 'foo'`,
+  nonexistent: 'foo'
+  paths: ['a.txt']`,
 			wantUnmarshalErr: `at spec.yaml line 4 column 3: unknown field name "nonexistent"`,
 		},
 		{


### PR DESCRIPTION
We do YAML magic to detect when old-style input was provided (the `paths` field is a list of strings) and automatically parse it into new-style structs.

This is part of @kevya-google's work on supporting path objects. This provides backward compatibility with preexisting spec.yaml files.