### PR TITLE
Refactor the `model` package into subpackages

### DIFF
--- a/templates/commands/render/render_action_append.go
+++ b/templates/commands/render/render_action_append.go
@@ -19,9 +19,10 @@ import (
 	"strings"
 
 	"github.com/abcxyz/abc/templates/model"
+	"github.com/abcxyz/abc/templates/model/spec"
 )
 
-func actionAppend(ctx context.Context, ap *model.Append, sp *stepParams) error {
+func actionAppend(ctx context.Context, ap *spec.Append, sp *stepParams) error {
 	with, err := parseAndExecuteGoTmpl(ap.With.Pos, ap.With.Val, sp.scope)
 	if err != nil {
 		return err

--- a/templates/commands/render/render_action_append_test.go
+++ b/templates/commands/render/render_action_append_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/abcxyz/abc/templates/common"
 	"github.com/abcxyz/abc/templates/model"
+	"github.com/abcxyz/abc/templates/model/spec"
 	"github.com/abcxyz/pkg/testutil"
 	"github.com/google/go-cmp/cmp"
 )
@@ -170,7 +171,7 @@ func TestActionAppend(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			sr := &model.Append{
+			sr := &spec.Append{
 				Paths: modelStrings(tc.paths),
 				With: model.String{
 					Pos: &model.ConfigPos{},

--- a/templates/commands/render/render_action_foreach.go
+++ b/templates/commands/render/render_action_foreach.go
@@ -18,10 +18,10 @@ import (
 	"context"
 
 	"github.com/abcxyz/abc/templates/common"
-	"github.com/abcxyz/abc/templates/model"
+	"github.com/abcxyz/abc/templates/model/spec"
 )
 
-func actionForEach(ctx context.Context, fe *model.ForEach, sp *stepParams) error {
+func actionForEach(ctx context.Context, fe *spec.ForEach, sp *stepParams) error {
 	key, err := parseAndExecuteGoTmpl(fe.Iterator.Key.Pos, fe.Iterator.Key.Val, sp.scope)
 	if err != nil {
 		return err

--- a/templates/commands/render/render_action_foreach_test.go
+++ b/templates/commands/render/render_action_foreach_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/abcxyz/abc/templates/common"
 	"github.com/abcxyz/abc/templates/model"
+	"github.com/abcxyz/abc/templates/model/spec"
 	"github.com/abcxyz/pkg/testutil"
 	"github.com/google/go-cmp/cmp"
 )
@@ -30,7 +31,7 @@ func TestActionForEach(t *testing.T) {
 
 	cases := []struct {
 		name       string
-		in         *model.ForEach
+		in         *spec.ForEach
 		inputs     map[string]string
 		wantStdout string
 		wantErr    string
@@ -40,17 +41,17 @@ func TestActionForEach(t *testing.T) {
 			inputs: map[string]string{
 				"from": "Alice",
 			},
-			in: &model.ForEach{
-				Iterator: &model.ForEachIterator{
+			in: &spec.ForEach{
+				Iterator: &spec.ForEachIterator{
 					Key: model.String{Val: "greeting_target"},
 					Values: []model.String{
 						{Val: "Bob"},
 						{Val: "Charlie"},
 					},
 				},
-				Steps: []*model.Step{
+				Steps: []*spec.Step{
 					{
-						Print: &model.Print{
+						Print: &spec.Print{
 							Message: model.String{Val: "Hello {{.greeting_target}} from {{.from}}"},
 						},
 					},
@@ -65,17 +66,17 @@ func TestActionForEach(t *testing.T) {
 				"first_recipient":  "Bob",
 				"second_recipient": "Charlie",
 			},
-			in: &model.ForEach{
-				Iterator: &model.ForEachIterator{
+			in: &spec.ForEach{
+				Iterator: &spec.ForEachIterator{
 					Key: model.String{Val: "greeting_target"},
 					Values: []model.String{
 						{Val: "{{.first_recipient}}"},
 						{Val: "{{.second_recipient}}"},
 					},
 				},
-				Steps: []*model.Step{
+				Steps: []*spec.Step{
 					{
-						Print: &model.Print{
+						Print: &spec.Print{
 							Message: model.String{Val: "Hello {{.greeting_target}} from {{.from}}"},
 						},
 					},
@@ -91,28 +92,28 @@ func TestActionForEach(t *testing.T) {
 				"first_recipient":  "Bob",
 				"second_recipient": "Charlie",
 			},
-			in: &model.ForEach{
-				Iterator: &model.ForEachIterator{
+			in: &spec.ForEach{
+				Iterator: &spec.ForEachIterator{
 					Key: model.String{Val: "greeter"},
 					Values: []model.String{
 						{Val: "{{.first_greeter}}"},
 						{Val: "{{.second_greeter}}"},
 					},
 				},
-				Steps: []*model.Step{
+				Steps: []*spec.Step{
 					{
 						Action: model.String{Val: "for_each"},
-						ForEach: &model.ForEach{
-							Iterator: &model.ForEachIterator{
+						ForEach: &spec.ForEach{
+							Iterator: &spec.ForEachIterator{
 								Key: model.String{Val: "greeting_target"},
 								Values: []model.String{
 									{Val: "{{.first_recipient}}"},
 									{Val: "{{.second_recipient}}"},
 								},
 							},
-							Steps: []*model.Step{
+							Steps: []*spec.Step{
 								{
-									Print: &model.Print{
+									Print: &spec.Print{
 										Message: model.String{Val: "Hello {{.greeting_target}} from {{.greeter}}"},
 									},
 								},
@@ -128,16 +129,16 @@ func TestActionForEach(t *testing.T) {
 			inputs: map[string]string{
 				"color": "Blue",
 			},
-			in: &model.ForEach{
-				Iterator: &model.ForEachIterator{
+			in: &spec.ForEach{
+				Iterator: &spec.ForEachIterator{
 					Key: model.String{Val: "color"},
 					Values: []model.String{
 						{Val: "Red"},
 					},
 				},
-				Steps: []*model.Step{
+				Steps: []*spec.Step{
 					{
-						Print: &model.Print{
+						Print: &spec.Print{
 							Message: model.String{Val: "{{.color}}"},
 						},
 					},
@@ -148,16 +149,16 @@ func TestActionForEach(t *testing.T) {
 		{
 			name:   "errors_are_propagated",
 			inputs: map[string]string{},
-			in: &model.ForEach{
-				Iterator: &model.ForEachIterator{
+			in: &spec.ForEach{
+				Iterator: &spec.ForEachIterator{
 					Key: model.String{Val: "x"},
 					Values: []model.String{
 						{Val: "Alice"},
 					},
 				},
-				Steps: []*model.Step{
+				Steps: []*spec.Step{
 					{
-						Print: &model.Print{
+						Print: &spec.Print{
 							Message: model.String{Val: "{{.nonexistent}}"},
 						},
 					},
@@ -170,14 +171,14 @@ func TestActionForEach(t *testing.T) {
 			inputs: map[string]string{
 				"environments": "production,dev",
 			},
-			in: &model.ForEach{
-				Iterator: &model.ForEachIterator{
+			in: &spec.ForEach{
+				Iterator: &spec.ForEachIterator{
 					Key:        model.String{Val: "env"},
 					ValuesFrom: &model.String{Val: `environments.split(",")`},
 				},
-				Steps: []*model.Step{
+				Steps: []*spec.Step{
 					{
-						Print: &model.Print{
+						Print: &spec.Print{
 							Message: model.String{Val: "{{.env}}"},
 						},
 					},
@@ -187,14 +188,14 @@ func TestActionForEach(t *testing.T) {
 		},
 		{
 			name: "cel-values-empty-no-actions",
-			in: &model.ForEach{
-				Iterator: &model.ForEachIterator{
+			in: &spec.ForEach{
+				Iterator: &spec.ForEachIterator{
 					Key:        model.String{Val: "env"},
 					ValuesFrom: &model.String{Val: `[]`},
 				},
-				Steps: []*model.Step{
+				Steps: []*spec.Step{
 					{
-						Print: &model.Print{
+						Print: &spec.Print{
 							Message: model.String{Val: "{{.env}}"},
 						},
 					},
@@ -204,14 +205,14 @@ func TestActionForEach(t *testing.T) {
 		},
 		{
 			name: "cel-values-literal",
-			in: &model.ForEach{
-				Iterator: &model.ForEachIterator{
+			in: &spec.ForEach{
+				Iterator: &spec.ForEachIterator{
 					Key:        model.String{Val: "env"},
 					ValuesFrom: &model.String{Val: `["production", "dev"]`},
 				},
-				Steps: []*model.Step{
+				Steps: []*spec.Step{
 					{
-						Print: &model.Print{
+						Print: &spec.Print{
 							Message: model.String{Val: "{{.env}}"},
 						},
 					},

--- a/templates/commands/render/render_action_gotemplate.go
+++ b/templates/commands/render/render_action_gotemplate.go
@@ -19,9 +19,10 @@ import (
 	"fmt"
 
 	"github.com/abcxyz/abc/templates/model"
+	"github.com/abcxyz/abc/templates/model/spec"
 )
 
-func actionGoTemplate(ctx context.Context, p *model.GoTemplate, sp *stepParams) error {
+func actionGoTemplate(ctx context.Context, p *spec.GoTemplate, sp *stepParams) error {
 	for _, p := range p.Paths {
 		// Paths may contain template expressions, so render them first.
 		walkRelPath, err := parseAndExecuteGoTmpl(p.Pos, p.Val, sp.scope)

--- a/templates/commands/render/render_action_gotemplate_test.go
+++ b/templates/commands/render/render_action_gotemplate_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 
 	"github.com/abcxyz/abc/templates/common"
-	"github.com/abcxyz/abc/templates/model"
+	"github.com/abcxyz/abc/templates/model/spec"
 	"github.com/abcxyz/pkg/testutil"
 	"github.com/google/go-cmp/cmp"
 )
@@ -31,7 +31,7 @@ func TestActionGoTemplate(t *testing.T) {
 		name         string
 		inputs       map[string]string
 		initContents map[string]string
-		gt           *model.GoTemplate
+		gt           *spec.GoTemplate
 		want         map[string]string
 		wantErr      string
 	}{
@@ -43,7 +43,7 @@ func TestActionGoTemplate(t *testing.T) {
 			initContents: map[string]string{
 				"a.txt": "Hello, {{.person}}!",
 			},
-			gt: &model.GoTemplate{
+			gt: &spec.GoTemplate{
 				Paths: modelStrings([]string{"."}),
 			},
 			want: map[string]string{
@@ -56,7 +56,7 @@ func TestActionGoTemplate(t *testing.T) {
 			initContents: map[string]string{
 				"a.txt": "Hello, world!",
 			},
-			gt: &model.GoTemplate{
+			gt: &spec.GoTemplate{
 				Paths: modelStrings([]string{"."}),
 			},
 			want: map[string]string{
@@ -72,7 +72,7 @@ func TestActionGoTemplate(t *testing.T) {
 			initContents: map[string]string{
 				"a.txt": "{{.greeting}}, {{.person}}!",
 			},
-			gt: &model.GoTemplate{
+			gt: &spec.GoTemplate{
 				Paths: modelStrings([]string{"."}),
 			},
 			want: map[string]string{
@@ -88,7 +88,7 @@ func TestActionGoTemplate(t *testing.T) {
 			initContents: map[string]string{
 				"a_Alice.txt": "{{.greeting}}, {{.person}}!",
 			},
-			gt: &model.GoTemplate{
+			gt: &spec.GoTemplate{
 				Paths: modelStrings([]string{"a_{{.person}}.txt"}),
 			},
 			want: map[string]string{
@@ -103,7 +103,7 @@ func TestActionGoTemplate(t *testing.T) {
 			initContents: map[string]string{
 				"a.txt": "Hello, {{.person}}!",
 			},
-			gt: &model.GoTemplate{
+			gt: &spec.GoTemplate{
 				Paths: modelStrings([]string{"."}),
 			},
 			want: map[string]string{
@@ -117,7 +117,7 @@ func TestActionGoTemplate(t *testing.T) {
 			initContents: map[string]string{
 				"a.txt": "Hello, {{",
 			},
-			gt: &model.GoTemplate{
+			gt: &spec.GoTemplate{
 				Paths: modelStrings([]string{"."}),
 			},
 			want: map[string]string{
@@ -141,7 +141,7 @@ func TestActionGoTemplate(t *testing.T) {
 				"prefix.txt":       `{{ trimPrefix .prefix "prefix" }}`,
 				"suffix.txt":       `{{ trimSuffix .suffix "suffix" }}`,
 			},
-			gt: &model.GoTemplate{
+			gt: &spec.GoTemplate{
 				Paths: modelStrings([]string{"."}),
 			},
 			want: map[string]string{

--- a/templates/commands/render/render_action_include.go
+++ b/templates/commands/render/render_action_include.go
@@ -24,10 +24,11 @@ import (
 	"strings"
 
 	"github.com/abcxyz/abc/templates/model"
+	"github.com/abcxyz/abc/templates/model/spec"
 	"golang.org/x/exp/maps"
 )
 
-func actionInclude(ctx context.Context, inc *model.Include, sp *stepParams) error {
+func actionInclude(ctx context.Context, inc *spec.Include, sp *stepParams) error {
 	for _, path := range inc.Paths {
 		if err := includePath(ctx, path, sp); err != nil {
 			return err
@@ -36,7 +37,7 @@ func actionInclude(ctx context.Context, inc *model.Include, sp *stepParams) erro
 	return nil
 }
 
-func includePath(ctx context.Context, inc *model.IncludePath, sp *stepParams) error {
+func includePath(ctx context.Context, inc *spec.IncludePath, sp *stepParams) error {
 	stripPrefixStr, err := parseAndExecuteGoTmpl(inc.StripPrefix.Pos, inc.StripPrefix.Val, sp.scope)
 	if err != nil {
 		return err

--- a/templates/commands/render/render_action_include_test.go
+++ b/templates/commands/render/render_action_include_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/abcxyz/abc/templates/common"
 	"github.com/abcxyz/abc/templates/model"
+	"github.com/abcxyz/abc/templates/model/spec"
 	"github.com/abcxyz/pkg/logging"
 	"github.com/abcxyz/pkg/testutil"
 	"github.com/google/go-cmp/cmp"
@@ -32,7 +33,7 @@ func TestActionInclude(t *testing.T) {
 
 	cases := []struct {
 		name                 string
-		include              *model.Include
+		include              *spec.Include
 		templateContents     map[string]modeAndContents
 		destDirContents      map[string]modeAndContents
 		inputs               map[string]string
@@ -43,8 +44,8 @@ func TestActionInclude(t *testing.T) {
 	}{
 		{
 			name: "simple_success",
-			include: &model.Include{
-				Paths: []*model.IncludePath{
+			include: &spec.Include{
+				Paths: []*spec.IncludePath{
 					{
 						Paths: modelStrings([]string{"myfile.txt"}),
 					},
@@ -59,8 +60,8 @@ func TestActionInclude(t *testing.T) {
 		},
 		{
 			name: "absolute_path_treated_as_relative",
-			include: &model.Include{
-				Paths: []*model.IncludePath{
+			include: &spec.Include{
+				Paths: []*spec.IncludePath{
 					{
 						Paths: modelStrings([]string{"/myfile.txt"}),
 					},
@@ -75,8 +76,8 @@ func TestActionInclude(t *testing.T) {
 		},
 		{
 			name: "reject_dot_dot",
-			include: &model.Include{
-				Paths: []*model.IncludePath{
+			include: &spec.Include{
+				Paths: []*spec.IncludePath{
 					{
 						Paths: modelStrings([]string{"../file.txt"}),
 					},
@@ -86,8 +87,8 @@ func TestActionInclude(t *testing.T) {
 		},
 		{
 			name: "templated_filename_success",
-			include: &model.Include{
-				Paths: []*model.IncludePath{
+			include: &spec.Include{
+				Paths: []*spec.IncludePath{
 					{
 						Paths: modelStrings([]string{"{{.my_dir}}/{{.my_file}}"}),
 					},
@@ -106,8 +107,8 @@ func TestActionInclude(t *testing.T) {
 		},
 		{
 			name: "including_multiple_times_should_succeed",
-			include: &model.Include{
-				Paths: []*model.IncludePath{
+			include: &spec.Include{
+				Paths: []*spec.IncludePath{
 					{
 						Paths: modelStrings([]string{"myfile.txt", "myfile.txt"}),
 					},
@@ -122,8 +123,8 @@ func TestActionInclude(t *testing.T) {
 		},
 		{
 			name: "including_multiple_times_should_succeed",
-			include: &model.Include{
-				Paths: []*model.IncludePath{
+			include: &spec.Include{
+				Paths: []*spec.IncludePath{
 					{
 						Paths: modelStrings([]string{"foo/myfile.txt", "foo/", "foo/myfile.txt"}),
 					},
@@ -138,8 +139,8 @@ func TestActionInclude(t *testing.T) {
 		},
 		{
 			name: "templated_filename_nonexistent_input_var_should_fail",
-			include: &model.Include{
-				Paths: []*model.IncludePath{
+			include: &spec.Include{
+				Paths: []*spec.IncludePath{
 					{
 						Paths: modelStrings([]string{"{{.filename}}"}),
 					},
@@ -153,8 +154,8 @@ func TestActionInclude(t *testing.T) {
 		},
 		{
 			name: "nonexistent_source_should_fail",
-			include: &model.Include{
-				Paths: []*model.IncludePath{
+			include: &spec.Include{
+				Paths: []*spec.IncludePath{
 					{
 						Paths: modelStrings([]string{"nonexistent"}),
 					},
@@ -169,8 +170,8 @@ func TestActionInclude(t *testing.T) {
 			// Note: we don't exhaustively test every possible FS error here. That's
 			// already done in the tests for the underlying copyRecursive function.
 			name: "filesystem_error_should_be_returned",
-			include: &model.Include{
-				Paths: []*model.IncludePath{
+			include: &spec.Include{
+				Paths: []*spec.IncludePath{
 					{
 						Paths: modelStrings([]string{"myfile.txt"}),
 					},
@@ -184,8 +185,8 @@ func TestActionInclude(t *testing.T) {
 		},
 		{
 			name: "strip_prefix_from_file",
-			include: &model.Include{
-				Paths: []*model.IncludePath{
+			include: &spec.Include{
+				Paths: []*spec.IncludePath{
 					{
 						Paths:       modelStrings([]string{"a/deep/subdir/hello.txt"}),
 						StripPrefix: model.String{Val: "a/deep/subdir"},
@@ -201,8 +202,8 @@ func TestActionInclude(t *testing.T) {
 		},
 		{
 			name: "strip_prefix_from_dir",
-			include: &model.Include{
-				Paths: []*model.IncludePath{
+			include: &spec.Include{
+				Paths: []*spec.IncludePath{
 					{
 						Paths:       modelStrings([]string{"a/deep/subdir/hello.txt"}),
 						StripPrefix: model.String{Val: "a/deep"},
@@ -218,8 +219,8 @@ func TestActionInclude(t *testing.T) {
 		},
 		{
 			name: "strip_and_add_prefix_together_with_templates",
-			include: &model.Include{
-				Paths: []*model.IncludePath{
+			include: &spec.Include{
+				Paths: []*spec.IncludePath{
 					{
 						Paths:       modelStrings([]string{"a/deep/subdir/hello.txt"}),
 						StripPrefix: model.String{Val: "{{.ay}}/"},
@@ -240,8 +241,8 @@ func TestActionInclude(t *testing.T) {
 		},
 		{
 			name: "as_with_single_path",
-			include: &model.Include{
-				Paths: []*model.IncludePath{
+			include: &spec.Include{
+				Paths: []*spec.IncludePath{
 					{
 						Paths: modelStrings([]string{"dir1/file1.txt"}),
 						As:    modelStrings([]string{"dir2/file2.txt"}),
@@ -257,8 +258,8 @@ func TestActionInclude(t *testing.T) {
 		},
 		{
 			name: "as_with_multiple_paths_and_templates",
-			include: &model.Include{
-				Paths: []*model.IncludePath{
+			include: &spec.Include{
+				Paths: []*spec.IncludePath{
 					{
 						Paths: modelStrings([]string{"file{{.one}}.txt", "file{{.two}}.txt"}),
 						As:    modelStrings([]string{"file{{.three}}.txt", "file{{.four}}.txt"}),
@@ -282,8 +283,8 @@ func TestActionInclude(t *testing.T) {
 		},
 		{
 			name: "strip_prefix_doesnt_find_prefix",
-			include: &model.Include{
-				Paths: []*model.IncludePath{
+			include: &spec.Include{
+				Paths: []*spec.IncludePath{
 					{
 						Paths:       modelStrings([]string{"a/b/c"}),
 						StripPrefix: model.String{Val: "x/"},
@@ -297,8 +298,8 @@ func TestActionInclude(t *testing.T) {
 		},
 		{
 			name: "spec_yaml_should_be_skipped",
-			include: &model.Include{
-				Paths: []*model.IncludePath{
+			include: &spec.Include{
+				Paths: []*spec.IncludePath{
 					{
 						Paths: modelStrings([]string{"."}),
 					},
@@ -314,8 +315,8 @@ func TestActionInclude(t *testing.T) {
 		},
 		{
 			name: "spec_yaml_in_subdir_should_not_be_skipped",
-			include: &model.Include{
-				Paths: []*model.IncludePath{
+			include: &spec.Include{
+				Paths: []*spec.IncludePath{
 					{
 						Paths: modelStrings([]string{"."}),
 					},
@@ -332,8 +333,8 @@ func TestActionInclude(t *testing.T) {
 		},
 		{
 			name: "include_dot_from_destination",
-			include: &model.Include{
-				Paths: []*model.IncludePath{
+			include: &spec.Include{
+				Paths: []*spec.IncludePath{
 					{
 						Paths: modelStrings([]string{"."}),
 						From:  model.String{Val: "destination"},
@@ -353,8 +354,8 @@ func TestActionInclude(t *testing.T) {
 		},
 		{
 			name: "include_subdir_from_destination",
-			include: &model.Include{
-				Paths: []*model.IncludePath{
+			include: &spec.Include{
+				Paths: []*spec.IncludePath{
 					{
 						Paths: modelStrings([]string{"subdir"}),
 						From:  model.String{Val: "destination"},
@@ -375,8 +376,8 @@ func TestActionInclude(t *testing.T) {
 		},
 		{
 			name: "include_individual_files_from_destination",
-			include: &model.Include{
-				Paths: []*model.IncludePath{
+			include: &spec.Include{
+				Paths: []*spec.IncludePath{
 					{
 						Paths: modelStrings([]string{"file1.txt", "subdir/file2.txt"}),
 						From:  model.String{Val: "destination"},

--- a/templates/commands/render/render_action_print.go
+++ b/templates/commands/render/render_action_print.go
@@ -19,10 +19,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/abcxyz/abc/templates/model"
+	"github.com/abcxyz/abc/templates/model/spec"
 )
 
-func actionPrint(ctx context.Context, p *model.Print, sp *stepParams) error {
+func actionPrint(ctx context.Context, p *spec.Print, sp *stepParams) error {
 	scope := sp.scope.With(flagsForTemplate(sp.flags))
 
 	msg, err := parseAndExecuteGoTmpl(p.Message.Pos, p.Message.Val, scope)

--- a/templates/commands/render/render_action_print_test.go
+++ b/templates/commands/render/render_action_print_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/abcxyz/abc/templates/common"
 	"github.com/abcxyz/abc/templates/model"
+	"github.com/abcxyz/abc/templates/model/spec"
 	"github.com/abcxyz/pkg/logging"
 	"github.com/abcxyz/pkg/testutil"
 	"github.com/google/go-cmp/cmp"
@@ -83,7 +84,7 @@ func TestActionPrint(t *testing.T) {
 				scope:  common.NewScope(tc.inputs),
 				flags:  &tc.flags,
 			}
-			pr := &model.Print{
+			pr := &spec.Print{
 				Message: model.String{
 					Val: tc.in,
 					Pos: &model.ConfigPos{},

--- a/templates/commands/render/render_action_regexnamelookup.go
+++ b/templates/commands/render/render_action_regexnamelookup.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/abcxyz/abc/templates/common"
 	"github.com/abcxyz/abc/templates/model"
+	"github.com/abcxyz/abc/templates/model/spec"
 	"golang.org/x/exp/maps"
 )
 
@@ -33,7 +34,7 @@ import (
 //	file contents: "Hello, __insert_here__"
 //
 // Then the output would be "Hello, Alice".
-func actionRegexNameLookup(ctx context.Context, rn *model.RegexNameLookup, sp *stepParams) error {
+func actionRegexNameLookup(ctx context.Context, rn *spec.RegexNameLookup, sp *stepParams) error {
 	uncompiled := make([]model.String, len(rn.Replacements))
 	for i, rp := range rn.Replacements {
 		uncompiled[i] = rp.Regex
@@ -70,7 +71,7 @@ func actionRegexNameLookup(ctx context.Context, rn *model.RegexNameLookup, sp *s
 	return nil
 }
 
-func replaceWithNameLookup(allMatches [][]int, b []byte, rn *model.RegexNameLookupEntry, re *regexp.Regexp, scope *common.Scope) ([]byte, error) {
+func replaceWithNameLookup(allMatches [][]int, b []byte, rn *spec.RegexNameLookupEntry, re *regexp.Regexp, scope *common.Scope) ([]byte, error) {
 	for i := 1; i < len(re.SubexpNames()); i++ { // skip group 0, which is always unnamed because it's "the whole regex match"
 		if re.SubexpNames()[i] == "" {
 			return nil, rn.Regex.Pos.Errorf(`all capturing groups in a regex_name_lookup must be named, like (?P<myinputvar>myregex), not like (myregex)`)

--- a/templates/commands/render/render_action_regexnamelookup_test.go
+++ b/templates/commands/render/render_action_regexnamelookup_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/abcxyz/abc/templates/common"
 	"github.com/abcxyz/abc/templates/model"
+	"github.com/abcxyz/abc/templates/model/spec"
 	"github.com/abcxyz/pkg/testutil"
 	"github.com/google/go-cmp/cmp"
 )
@@ -31,7 +32,7 @@ func TestActionRegexNameLookup(t *testing.T) {
 		name         string
 		inputs       map[string]string
 		initContents map[string]string
-		rr           *model.RegexNameLookup
+		rr           *spec.RegexNameLookup
 		want         map[string]string
 		wantErr      string
 	}{
@@ -43,9 +44,9 @@ func TestActionRegexNameLookup(t *testing.T) {
 			inputs: map[string]string{
 				"my_input": "foo",
 			},
-			rr: &model.RegexNameLookup{
+			rr: &spec.RegexNameLookup{
 				Paths: modelStrings([]string{"."}),
-				Replacements: []*model.RegexNameLookupEntry{
+				Replacements: []*spec.RegexNameLookupEntry{
 					{
 						Regex: model.String{Val: `\b(?P<my_input>b...) (?P<my_input>g....)`},
 					},
@@ -63,9 +64,9 @@ func TestActionRegexNameLookup(t *testing.T) {
 			inputs: map[string]string{
 				"my_input": "foofoo",
 			},
-			rr: &model.RegexNameLookup{
+			rr: &spec.RegexNameLookup{
 				Paths: modelStrings([]string{"."}),
-				Replacements: []*model.RegexNameLookupEntry{
+				Replacements: []*spec.RegexNameLookupEntry{
 					{
 						Regex: model.String{Val: `(?P<my_input>foo)`},
 					},
@@ -81,9 +82,9 @@ func TestActionRegexNameLookup(t *testing.T) {
 				"a.txt": "alpha beta gamma",
 			},
 			inputs: map[string]string{},
-			rr: &model.RegexNameLookup{
+			rr: &spec.RegexNameLookup{
 				Paths: modelStrings([]string{"."}),
-				Replacements: []*model.RegexNameLookupEntry{
+				Replacements: []*spec.RegexNameLookupEntry{
 					{
 						Regex: model.String{Val: "(?P<mysubgroup>beta)"},
 					},
@@ -102,9 +103,9 @@ func TestActionRegexNameLookup(t *testing.T) {
 			inputs: map[string]string{
 				"my_input": "foo",
 			},
-			rr: &model.RegexNameLookup{
+			rr: &spec.RegexNameLookup{
 				Paths: modelStrings([]string{"."}),
-				Replacements: []*model.RegexNameLookupEntry{
+				Replacements: []*spec.RegexNameLookupEntry{
 					{
 						Regex: model.String{Val: `\b(?P<my_input>b...) (g....)`},
 					},
@@ -125,9 +126,9 @@ func TestActionRegexNameLookup(t *testing.T) {
 				"group_name":     "mygroup",
 				"mygroup":        "omega",
 			},
-			rr: &model.RegexNameLookup{
+			rr: &spec.RegexNameLookup{
 				Paths: modelStrings([]string{"."}),
-				Replacements: []*model.RegexNameLookupEntry{
+				Replacements: []*spec.RegexNameLookupEntry{
 					{
 						Regex: model.String{Val: `(?P<{{.group_name}}>{{.regex_to_match}})`},
 					},
@@ -146,9 +147,9 @@ func TestActionRegexNameLookup(t *testing.T) {
 			inputs: map[string]string{
 				"my_input": "foo",
 			},
-			rr: &model.RegexNameLookup{
+			rr: &spec.RegexNameLookup{
 				Paths: modelStrings([]string{"."}),
-				Replacements: []*model.RegexNameLookupEntry{
+				Replacements: []*spec.RegexNameLookupEntry{
 					{
 						Regex: model.String{Val: `\b(?P<my_input>b...) (?P<my_input>g....)`},
 					},
@@ -164,9 +165,9 @@ func TestActionRegexNameLookup(t *testing.T) {
 			initContents: map[string]string{
 				"a.txt": "alpha beta gamma",
 			},
-			rr: &model.RegexNameLookup{
+			rr: &spec.RegexNameLookup{
 				Paths: modelStrings([]string{"{{.filename}}"}),
-				Replacements: []*model.RegexNameLookupEntry{
+				Replacements: []*spec.RegexNameLookupEntry{
 					{
 						Regex: model.String{Val: "(?P<cake>beta)"},
 					},

--- a/templates/commands/render/render_action_regexreplace.go
+++ b/templates/commands/render/render_action_regexreplace.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/abcxyz/abc/templates/common"
 	"github.com/abcxyz/abc/templates/model"
+	"github.com/abcxyz/abc/templates/model/spec"
 )
 
 // The regex_replace action replaces a regex match (or a subgroup thereof) with
@@ -32,7 +33,7 @@ import (
 //
 // This would transform a file containing "Hello, cool world!" to "Hello, fresh
 // world!".
-func actionRegexReplace(ctx context.Context, rr *model.RegexReplace, sp *stepParams) error {
+func actionRegexReplace(ctx context.Context, rr *spec.RegexReplace, sp *stepParams) error {
 	uncompiled := make([]model.String, len(rr.Replacements))
 	for i, rp := range rr.Replacements {
 		uncompiled[i] = rp.Regex
@@ -94,7 +95,7 @@ func actionRegexReplace(ctx context.Context, rr *model.RegexReplace, sp *stepPar
 	return nil
 }
 
-func replaceWithTemplate(allMatches [][]int, b []byte, rr *model.RegexReplaceEntry, re *regexp.Regexp, scope *common.Scope) ([]byte, error) {
+func replaceWithTemplate(allMatches [][]int, b []byte, rr *spec.RegexReplaceEntry, re *regexp.Regexp, scope *common.Scope) ([]byte, error) {
 	// Why iterate in reverse? We have to replace starting at the end of the
 	// file working toward the beginning, so when we replace part of
 	// the buffer it doesn't invalidate the indices of the other

--- a/templates/commands/render/render_action_regexreplace_test.go
+++ b/templates/commands/render/render_action_regexreplace_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/abcxyz/abc/templates/common"
 	"github.com/abcxyz/abc/templates/model"
+	"github.com/abcxyz/abc/templates/model/spec"
 	"github.com/abcxyz/pkg/testutil"
 	"github.com/google/go-cmp/cmp"
 )
@@ -31,7 +32,7 @@ func TestActionRegexReplace(t *testing.T) {
 		name         string
 		inputs       map[string]string
 		initContents map[string]string
-		rr           *model.RegexReplace
+		rr           *spec.RegexReplace
 		want         map[string]string
 		wantErr      string
 	}{
@@ -40,9 +41,9 @@ func TestActionRegexReplace(t *testing.T) {
 			initContents: map[string]string{
 				"a.txt": "alpha foo gamma",
 			},
-			rr: &model.RegexReplace{
+			rr: &spec.RegexReplace{
 				Paths: modelStrings([]string{"."}),
-				Replacements: []*model.RegexReplaceEntry{
+				Replacements: []*spec.RegexReplaceEntry{
 					{
 						Regex: model.String{Val: "foo"},
 						With:  model.String{Val: "bar"},
@@ -58,9 +59,9 @@ func TestActionRegexReplace(t *testing.T) {
 			initContents: map[string]string{
 				"a.txt": "alpha foo gamma",
 			},
-			rr: &model.RegexReplace{
+			rr: &spec.RegexReplace{
 				Paths: modelStrings([]string{"a.txt", ".", "a.txt"}),
-				Replacements: []*model.RegexReplaceEntry{
+				Replacements: []*spec.RegexReplaceEntry{
 					{
 						Regex: model.String{Val: "foo"},
 						With:  model.String{Val: "foofoo"},
@@ -76,9 +77,9 @@ func TestActionRegexReplace(t *testing.T) {
 			initContents: map[string]string{
 				"a.txt": "apple banana\nbanana apple\napple apple\n", //nolint:dupword
 			},
-			rr: &model.RegexReplace{
+			rr: &spec.RegexReplace{
 				Paths: modelStrings([]string{"."}),
-				Replacements: []*model.RegexReplaceEntry{
+				Replacements: []*spec.RegexReplaceEntry{
 					{
 						Regex: model.String{Val: "\\n$"},
 						With:  model.String{Val: ""},
@@ -94,9 +95,9 @@ func TestActionRegexReplace(t *testing.T) {
 			initContents: map[string]string{
 				"a.txt": "apple banana\nbanana apple\napple apple\n", //nolint:dupword
 			},
-			rr: &model.RegexReplace{
+			rr: &spec.RegexReplace{
 				Paths: modelStrings([]string{"."}),
-				Replacements: []*model.RegexReplaceEntry{
+				Replacements: []*spec.RegexReplaceEntry{
 					{
 						Regex: model.String{Val: "(?m:apple$)"},
 						With:  model.String{Val: "apple."},
@@ -112,9 +113,9 @@ func TestActionRegexReplace(t *testing.T) {
 			initContents: map[string]string{
 				"a.txt": "alpha foo gamma foo",
 			},
-			rr: &model.RegexReplace{
+			rr: &spec.RegexReplace{
 				Paths: modelStrings([]string{"."}),
-				Replacements: []*model.RegexReplaceEntry{
+				Replacements: []*spec.RegexReplaceEntry{
 					{
 						Regex: model.String{Val: "foo"},
 						With:  model.String{Val: "bar"},
@@ -131,9 +132,9 @@ func TestActionRegexReplace(t *testing.T) {
 				"a.txt": "alpha beta gamma delta",
 			},
 			inputs: map[string]string{},
-			rr: &model.RegexReplace{
+			rr: &spec.RegexReplace{
 				Paths: modelStrings([]string{"."}),
-				Replacements: []*model.RegexReplaceEntry{
+				Replacements: []*spec.RegexReplaceEntry{
 					{
 						Regex: model.String{Val: `\b(?P<my_first_input>b...) (?P<my_second_input>g....)`},
 						With:  model.String{Val: "${my_second_input} ${my_first_input}"},
@@ -152,9 +153,9 @@ func TestActionRegexReplace(t *testing.T) {
 			inputs: map[string]string{
 				"foo": "bar",
 			},
-			rr: &model.RegexReplace{
+			rr: &spec.RegexReplace{
 				Paths: modelStrings([]string{"."}),
-				Replacements: []*model.RegexReplaceEntry{
+				Replacements: []*spec.RegexReplaceEntry{
 					{
 						Regex: model.String{Val: "template_(?P<mygroup>[a-z]+)"},
 						With:  model.String{Val: "{{.$1}}"},
@@ -174,9 +175,9 @@ func TestActionRegexReplace(t *testing.T) {
 			inputs: map[string]string{
 				"foo": "bar",
 			},
-			rr: &model.RegexReplace{
+			rr: &spec.RegexReplace{
 				Paths: modelStrings([]string{"."}),
-				Replacements: []*model.RegexReplaceEntry{
+				Replacements: []*spec.RegexReplaceEntry{
 					{
 						Regex: model.String{Val: "template_(?P<mysubgroup>[a-z]+)"},
 						With:  model.String{Val: "{{.${mysubgroup}}}"},
@@ -195,9 +196,9 @@ func TestActionRegexReplace(t *testing.T) {
 			inputs: map[string]string{
 				"cool_beta": "BETA",
 			},
-			rr: &model.RegexReplace{
+			rr: &spec.RegexReplace{
 				Paths: modelStrings([]string{"."}),
-				Replacements: []*model.RegexReplaceEntry{
+				Replacements: []*spec.RegexReplaceEntry{
 					{
 						Regex: model.String{Val: `\b(?P<mysubgroup>be..)\b`},
 						With:  model.String{Val: "{{.cool_${mysubgroup}}}"},
@@ -216,9 +217,9 @@ func TestActionRegexReplace(t *testing.T) {
 			inputs: map[string]string{
 				"cool_beta": "BETA",
 			},
-			rr: &model.RegexReplace{
+			rr: &spec.RegexReplace{
 				Paths: modelStrings([]string{"."}),
-				Replacements: []*model.RegexReplaceEntry{
+				Replacements: []*spec.RegexReplaceEntry{
 					{
 						Regex: model.String{Val: `\b(?P<mygroup>be..)\b`},
 						With:  model.String{Val: "{{.cool_${1}}}"},
@@ -239,9 +240,9 @@ func TestActionRegexReplace(t *testing.T) {
 				"to_replace":   "beta",
 				"replace_with": "BETA!",
 			},
-			rr: &model.RegexReplace{
+			rr: &spec.RegexReplace{
 				Paths: modelStrings([]string{"."}),
-				Replacements: []*model.RegexReplaceEntry{
+				Replacements: []*spec.RegexReplaceEntry{
 					{
 						Regex: model.String{Val: `\b{{.to_replace}}`},
 						With:  model.String{Val: `{{.replace_with}}`},
@@ -260,9 +261,9 @@ func TestActionRegexReplace(t *testing.T) {
 			inputs: map[string]string{
 				"myinput": "alligator",
 			},
-			rr: &model.RegexReplace{
+			rr: &spec.RegexReplace{
 				Paths: modelStrings([]string{"."}),
-				Replacements: []*model.RegexReplaceEntry{
+				Replacements: []*spec.RegexReplaceEntry{
 					{
 						Regex:             model.String{Val: `alpha (?P<mygroup>beta) gamma`},
 						With:              model.String{Val: `{{.myinput}}`},
@@ -283,9 +284,9 @@ func TestActionRegexReplace(t *testing.T) {
 				"reptile": "alligator",
 				"tree":    "maple",
 			},
-			rr: &model.RegexReplace{
+			rr: &spec.RegexReplace{
 				Paths: modelStrings([]string{"."}),
-				Replacements: []*model.RegexReplaceEntry{
+				Replacements: []*spec.RegexReplaceEntry{
 					{
 						Regex:             model.String{Val: `alpha (?P<mygroup>beta) gamma`},
 						With:              model.String{Val: `{{.reptile}}`},
@@ -309,9 +310,9 @@ func TestActionRegexReplace(t *testing.T) {
 beta
 gamma`,
 			},
-			rr: &model.RegexReplace{
+			rr: &spec.RegexReplace{
 				Paths: modelStrings([]string{"."}),
-				Replacements: []*model.RegexReplaceEntry{
+				Replacements: []*spec.RegexReplaceEntry{
 					{
 						Regex: model.String{Val: "^beta$"},
 						With:  model.String{Val: "shouldnt_appear"},
@@ -331,9 +332,9 @@ gamma`,
 beta
 gamma`,
 			},
-			rr: &model.RegexReplace{
+			rr: &spec.RegexReplace{
 				Paths: modelStrings([]string{"."}),
-				Replacements: []*model.RegexReplaceEntry{
+				Replacements: []*spec.RegexReplaceEntry{
 					{
 						Regex: model.String{Val: "(?m:^beta$)"},
 						With:  model.String{Val: "brontosaurus"},
@@ -352,9 +353,9 @@ gamma`,
 				"a.txt": "alpha foo gamma",
 				"b.txt": "sigma foo chi",
 			},
-			rr: &model.RegexReplace{
+			rr: &spec.RegexReplace{
 				Paths: modelStrings([]string{"."}),
-				Replacements: []*model.RegexReplaceEntry{
+				Replacements: []*spec.RegexReplaceEntry{
 					{
 						Regex: model.String{Val: "foo"},
 						With:  model.String{Val: "bar"},
@@ -371,9 +372,9 @@ gamma`,
 			initContents: map[string]string{
 				"a.txt": "alpha foo gamma",
 			},
-			rr: &model.RegexReplace{
+			rr: &spec.RegexReplace{
 				Paths: modelStrings([]string{"{{.filename}}"}),
-				Replacements: []*model.RegexReplaceEntry{
+				Replacements: []*spec.RegexReplaceEntry{
 					{
 						Regex: model.String{Val: "foo"},
 						With:  model.String{Val: "bar"},

--- a/templates/commands/render/render_action_stringreplace.go
+++ b/templates/commands/render/render_action_stringreplace.go
@@ -19,9 +19,10 @@ import (
 	"strings"
 
 	"github.com/abcxyz/abc/templates/model"
+	"github.com/abcxyz/abc/templates/model/spec"
 )
 
-func actionStringReplace(ctx context.Context, sr *model.StringReplace, sp *stepParams) error {
+func actionStringReplace(ctx context.Context, sr *spec.StringReplace, sp *stepParams) error {
 	var replacerArgs []string //nolint:prealloc // strings.NewReplacer has a weird input slice, it's less confusing to append rather than preallocate.
 	for _, r := range sr.Replacements {
 		toReplace, err := parseAndExecuteGoTmpl(r.ToReplace.Pos, r.ToReplace.Val, sp.scope)

--- a/templates/commands/render/render_action_stringreplace_test.go
+++ b/templates/commands/render/render_action_stringreplace_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/abcxyz/abc/templates/common"
 	"github.com/abcxyz/abc/templates/model"
+	"github.com/abcxyz/abc/templates/model/spec"
 	"github.com/abcxyz/pkg/testutil"
 	"github.com/google/go-cmp/cmp"
 )
@@ -33,7 +34,7 @@ func TestActionStringReplace(t *testing.T) {
 	cases := []struct {
 		name         string
 		paths        []string
-		replacements []*model.StringReplacement
+		replacements []*spec.StringReplacement
 		inputs       map[string]string
 
 		initialContents map[string]string
@@ -45,7 +46,7 @@ func TestActionStringReplace(t *testing.T) {
 		{
 			name:  "simple_success",
 			paths: []string{"my_file.txt"},
-			replacements: []*model.StringReplacement{
+			replacements: []*spec.StringReplacement{
 				{
 					ToReplace: model.String{Val: "foo"},
 					With:      model.String{Val: "bar"},
@@ -61,7 +62,7 @@ func TestActionStringReplace(t *testing.T) {
 		{
 			name:  "same_file_only_processed_once",
 			paths: []string{"my_file.txt", ".", "my_file.txt"},
-			replacements: []*model.StringReplacement{
+			replacements: []*spec.StringReplacement{
 				{
 					ToReplace: model.String{Val: "foo"},
 					With:      model.String{Val: "foofoo"},
@@ -77,7 +78,7 @@ func TestActionStringReplace(t *testing.T) {
 		{
 			name:  "multiple_files_should_work",
 			paths: []string{""},
-			replacements: []*model.StringReplacement{
+			replacements: []*spec.StringReplacement{
 				{
 					ToReplace: model.String{Val: "foo"},
 					With:      model.String{Val: "bar"},
@@ -95,7 +96,7 @@ func TestActionStringReplace(t *testing.T) {
 		{
 			name:  "no_replacement_needed_should_noop",
 			paths: []string{""},
-			replacements: []*model.StringReplacement{
+			replacements: []*spec.StringReplacement{
 				{
 					ToReplace: model.String{Val: "foo"},
 					With:      model.String{Val: "bar"},
@@ -111,7 +112,7 @@ func TestActionStringReplace(t *testing.T) {
 		{
 			name:  "empty_file_should_noop",
 			paths: []string{""},
-			replacements: []*model.StringReplacement{
+			replacements: []*spec.StringReplacement{
 				{
 					ToReplace: model.String{Val: "foo"},
 					With:      model.String{Val: "bar"},
@@ -127,7 +128,7 @@ func TestActionStringReplace(t *testing.T) {
 		{
 			name:  "templated_replacement_should_succeed",
 			paths: []string{"my_{{.filename_adjective}}_file.txt"},
-			replacements: []*model.StringReplacement{
+			replacements: []*spec.StringReplacement{
 				{
 					ToReplace: model.String{Val: "sand{{.old_suffix}}"},
 					With:      model.String{Val: "hot{{.new_suffix}}"},
@@ -150,7 +151,7 @@ func TestActionStringReplace(t *testing.T) {
 		{
 			name:  "templated_filename_missing_input_should_fail",
 			paths: []string{"{{.myinput}}"},
-			replacements: []*model.StringReplacement{
+			replacements: []*spec.StringReplacement{
 				{
 					ToReplace: model.String{Val: "foo"},
 					With:      model.String{Val: "bar"},
@@ -168,7 +169,7 @@ func TestActionStringReplace(t *testing.T) {
 		{
 			name:  "templated_toreplace_missing_input_should_fail",
 			paths: []string{""},
-			replacements: []*model.StringReplacement{
+			replacements: []*spec.StringReplacement{
 				{
 					ToReplace: model.String{Val: "{{.myinput}}"},
 					With:      model.String{Val: "bar"},
@@ -186,7 +187,7 @@ func TestActionStringReplace(t *testing.T) {
 		{
 			name:  "templated_with_missing_input_should_fail",
 			paths: []string{""},
-			replacements: []*model.StringReplacement{
+			replacements: []*spec.StringReplacement{
 				{
 					ToReplace: model.String{Val: "foo"},
 					With:      model.String{Val: "{{.myinput}}"},
@@ -204,7 +205,7 @@ func TestActionStringReplace(t *testing.T) {
 		{
 			name:  "fs_errors_should_be_returned",
 			paths: []string{"my_file.txt"},
-			replacements: []*model.StringReplacement{
+			replacements: []*spec.StringReplacement{
 				{
 					ToReplace: model.String{Val: "foo"},
 					With:      model.String{Val: "bar"},
@@ -235,7 +236,7 @@ func TestActionStringReplace(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			sr := &model.StringReplace{
+			sr := &spec.StringReplace{
 				Paths:        modelStrings(tc.paths),
 				Replacements: tc.replacements,
 			}

--- a/templates/commands/render/render_test.go
+++ b/templates/commands/render/render_test.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/abcxyz/abc/templates/model"
+	"github.com/abcxyz/abc/templates/model/spec"
 	"github.com/abcxyz/pkg/cli"
 	"github.com/abcxyz/pkg/logging"
 	"github.com/abcxyz/pkg/testutil"
@@ -746,7 +747,7 @@ func TestPromptForInputs(t *testing.T) {
 	}
 	cases := []struct {
 		name          string
-		inputs        []*model.Input
+		inputs        []*spec.Input
 		flagInputVals map[string]string // Simulates some inputs having already been provided by flags, like --input=foo=bar means we shouldn't prompt for "foo"
 		dialog        []dialogStep
 		want          map[string]string
@@ -754,7 +755,7 @@ func TestPromptForInputs(t *testing.T) {
 	}{
 		{
 			name: "single_input_prompt",
-			inputs: []*model.Input{
+			inputs: []*spec.Input{
 				{
 					Name: model.String{Val: "animal"},
 					Desc: model.String{Val: "your favorite animal"},
@@ -776,11 +777,11 @@ Enter value: `,
 		},
 		{
 			name: "single_input_prompt_with_single_validation_rule",
-			inputs: []*model.Input{
+			inputs: []*spec.Input{
 				{
 					Name: model.String{Val: "animal"},
 					Desc: model.String{Val: "your favorite animal"},
-					Rules: []*model.InputRule{
+					Rules: []*spec.InputRule{
 						{
 							Rule:    model.String{Val: "size(animal) > 1"},
 							Message: model.String{Val: "length must be greater than 1"},
@@ -806,11 +807,11 @@ Enter value: `,
 		},
 		{
 			name: "single_input_prompt_with_multiple_validation_rules",
-			inputs: []*model.Input{
+			inputs: []*spec.Input{
 				{
 					Name: model.String{Val: "animal"},
 					Desc: model.String{Val: "your favorite animal"},
-					Rules: []*model.InputRule{
+					Rules: []*spec.InputRule{
 						{
 							Rule:    model.String{Val: "size(animal) > 1"},
 							Message: model.String{Val: "length must be greater than 1"},
@@ -842,7 +843,7 @@ Enter value: `,
 		},
 		{
 			name: "multiple_input_prompts",
-			inputs: []*model.Input{
+			inputs: []*spec.Input{
 				{
 					Name: model.String{Val: "animal"},
 					Desc: model.String{Val: "your favorite animal"},
@@ -877,7 +878,7 @@ Enter value: `,
 		},
 		{
 			name: "single_input_should_not_be_prompted_if_provided_by_command_line_flags",
-			inputs: []*model.Input{
+			inputs: []*spec.Input{
 				{
 					Name: model.String{Val: "animal"},
 					Desc: model.String{Val: "your favorite animal"},
@@ -893,7 +894,7 @@ Enter value: `,
 		},
 		{
 			name: "two_inputs_of_which_one_is_provided_and_one_prompted",
-			inputs: []*model.Input{
+			inputs: []*spec.Input{
 				{
 					Name: model.String{Val: "animal"},
 					Desc: model.String{Val: "your favorite animal"},
@@ -923,11 +924,11 @@ Enter value: `,
 		},
 		{
 			name:   "template_has_no_inputs",
-			inputs: []*model.Input{},
+			inputs: []*spec.Input{},
 		},
 		{
 			name: "single_input_with_default_accepted",
-			inputs: []*model.Input{
+			inputs: []*spec.Input{
 				{
 					Name:    model.String{Val: "animal"},
 					Desc:    model.String{Val: "your favorite animal"},
@@ -951,7 +952,7 @@ Enter value, or leave empty to accept default: `,
 		},
 		{
 			name: "single_input_with_default_not_accepted",
-			inputs: []*model.Input{
+			inputs: []*spec.Input{
 				{
 					Name:    model.String{Val: "animal"},
 					Desc:    model.String{Val: "your favorite animal"},
@@ -975,7 +976,7 @@ Enter value, or leave empty to accept default: `,
 		},
 		{
 			name: "default_empty_string_should_be_printed_quoted",
-			inputs: []*model.Input{
+			inputs: []*spec.Input{
 				{
 					Name:    model.String{Val: "animal"},
 					Desc:    model.String{Val: "your favorite animal"},
@@ -1027,7 +1028,7 @@ Enter value, or leave empty to accept default: `,
 			errCh := make(chan error)
 			go func() {
 				defer close(errCh)
-				errCh <- cmd.promptForInputs(ctx, &model.Spec{
+				errCh <- cmd.promptForInputs(ctx, &spec.Spec{
 					Inputs: tc.inputs,
 				})
 			}()
@@ -1074,8 +1075,8 @@ func TestPromptForInputs_CanceledContext(t *testing.T) {
 	errCh := make(chan error)
 	go func() {
 		defer close(errCh)
-		errCh <- cmd.promptForInputs(ctx, &model.Spec{
-			Inputs: []*model.Input{
+		errCh <- cmd.promptForInputs(ctx, &spec.Spec{
+			Inputs: []*spec.Input{
 				{
 					Name: model.String{Val: "my_input"},
 				},
@@ -1112,13 +1113,13 @@ func TestValidateInputs(t *testing.T) {
 
 	cases := []struct {
 		name        string
-		inputModels []*model.Input
+		inputModels []*spec.Input
 		inputVals   map[string]string
 		want        string
 	}{
 		{
 			name: "no-validation-rule",
-			inputModels: []*model.Input{
+			inputModels: []*spec.Input{
 				{
 					Name: model.String{Val: "my_input"},
 				},
@@ -1129,10 +1130,10 @@ func TestValidateInputs(t *testing.T) {
 		},
 		{
 			name: "single-passing-validation-rule",
-			inputModels: []*model.Input{
+			inputModels: []*spec.Input{
 				{
 					Name: model.String{Val: "my_input"},
-					Rules: []*model.InputRule{
+					Rules: []*spec.InputRule{
 						{
 							Rule:    model.String{Val: `size(my_input) < 5`},
 							Message: model.String{Val: "Length must be less than 5"},
@@ -1146,10 +1147,10 @@ func TestValidateInputs(t *testing.T) {
 		},
 		{
 			name: "single-failing-validation-rule",
-			inputModels: []*model.Input{
+			inputModels: []*spec.Input{
 				{
 					Name: model.String{Val: "my_input"},
-					Rules: []*model.InputRule{
+					Rules: []*spec.InputRule{
 						{
 							Rule:    model.String{Val: `size(my_input) < 3`},
 							Message: model.String{Val: "Length must be less than 3"},
@@ -1169,10 +1170,10 @@ Rule msg:     Length must be less than 3`,
 		},
 		{
 			name: "multiple-passing-validation-rules",
-			inputModels: []*model.Input{
+			inputModels: []*spec.Input{
 				{
 					Name: model.String{Val: "my_input"},
-					Rules: []*model.InputRule{
+					Rules: []*spec.InputRule{
 						{
 							Rule:    model.String{Val: `size(my_input) < 5`},
 							Message: model.String{Val: "Length must be less than 5"},
@@ -1194,10 +1195,10 @@ Rule msg:     Length must be less than 3`,
 		},
 		{
 			name: "multiple-passing-validation-rules-one-failing",
-			inputModels: []*model.Input{
+			inputModels: []*spec.Input{
 				{
 					Name: model.String{Val: "my_input"},
-					Rules: []*model.InputRule{
+					Rules: []*spec.InputRule{
 						{
 							Rule:    model.String{Val: `size(my_input) < 3`},
 							Message: model.String{Val: "Length must be less than 3"},
@@ -1225,10 +1226,10 @@ Rule msg:     Length must be less than 3`,
 		},
 		{
 			name: "multiple-failing-validation-rules",
-			inputModels: []*model.Input{
+			inputModels: []*spec.Input{
 				{
 					Name: model.String{Val: "my_input"},
-					Rules: []*model.InputRule{
+					Rules: []*spec.InputRule{
 						{
 							Rule:    model.String{Val: `size(my_input) < 3`},
 							Message: model.String{Val: "Length must be less than 3"},
@@ -1266,10 +1267,10 @@ Rule msg:     Must contain "shoe"`,
 		},
 		{
 			name: "cel-syntax-error",
-			inputModels: []*model.Input{
+			inputModels: []*spec.Input{
 				{
 					Name: model.String{Val: "my_input"},
-					Rules: []*model.InputRule{
+					Rules: []*spec.InputRule{
 						{
 							Rule: model.String{Val: `(`},
 						},
@@ -1288,10 +1289,10 @@ CEL error:    failed compiling CEL expression: ERROR: <input>:1:2: Syntax error:
 		},
 		{
 			name: "cel-type-conversion-error",
-			inputModels: []*model.Input{
+			inputModels: []*spec.Input{
 				{
 					Name: model.String{Val: "my_input"},
-					Rules: []*model.InputRule{
+					Rules: []*spec.InputRule{
 						{
 							Rule: model.String{Val: `bool(42)`},
 						},
@@ -1310,10 +1311,10 @@ CEL error:    failed compiling CEL expression: ERROR: <input>:1:5: found no matc
 		},
 		{
 			name: "cel-output-type-conversion-error",
-			inputModels: []*model.Input{
+			inputModels: []*spec.Input{
 				{
 					Name: model.String{Val: "my_input"},
-					Rules: []*model.InputRule{
+					Rules: []*spec.InputRule{
 						{
 							Rule: model.String{Val: `42`},
 						},
@@ -1332,10 +1333,10 @@ CEL error:    CEL expression result couldn't be converted to bool. The CEL engin
 		},
 		{
 			name: "multi-input-validation",
-			inputModels: []*model.Input{
+			inputModels: []*spec.Input{
 				{
 					Name: model.String{Val: "my_input"},
-					Rules: []*model.InputRule{
+					Rules: []*spec.InputRule{
 						{
 							Rule: model.String{Val: `my_input + my_other_input == "sharknado"`},
 						},
@@ -1343,7 +1344,7 @@ CEL error:    CEL expression result couldn't be converted to bool. The CEL engin
 				},
 				{
 					Name: model.String{Val: "my_other_input"},
-					Rules: []*model.InputRule{
+					Rules: []*spec.InputRule{
 						{
 							Rule: model.String{Val: `"tor" + my_other_input + my_input == "tornadoshark"`},
 						},

--- a/templates/model/pos.go
+++ b/templates/model/pos.go
@@ -33,8 +33,8 @@ type ConfigPos struct {
 	Column int
 }
 
-// yamlPos constructs a position struct based on a YAML parse cursor.
-func yamlPos(n *yaml.Node) *ConfigPos {
+// YAMLPos constructs a position struct based on a YAML parse cursor.
+func YAMLPos(n *yaml.Node) *ConfigPos {
 	return &ConfigPos{
 		Line:   n.Line,
 		Column: n.Column,

--- a/templates/model/primitive.go
+++ b/templates/model/primitive.go
@@ -40,6 +40,6 @@ func (v *valWithPos[T]) UnmarshalYAML(n *yaml.Node) error {
 	if err := n.Decode(&v.Val); err != nil {
 		return err //nolint:wrapcheck
 	}
-	v.Pos = yamlPos(n)
+	v.Pos = YAMLPos(n)
 	return nil
 }

--- a/templates/model/spec/spec.go
+++ b/templates/model/spec/spec.go
@@ -15,7 +15,7 @@
 // Package model contains the structs for unmarshaled YAML files.
 //
 //nolint:wrapcheck // We don't want to excessively wrap errors, like "yaml error: yaml error: ..."
-package model
+package spec
 
 import (
 	"errors"
@@ -23,17 +23,18 @@ import (
 	"io"
 	"strings"
 
+	"github.com/abcxyz/abc/templates/model"
 	"golang.org/x/exp/slices"
 	"gopkg.in/yaml.v3"
 )
 
-// DecodeSpec unmarshals the YAML Spec from r. This function exists so we can
+// Decode unmarshals the YAML Spec from r. This function exists so we can
 // validate the Spec model before providing it to the caller; we don't want the
 // caller to forget, and thereby introduce bugs.
 //
 // If the Spec parses successfully but then fails validation, the spec will be
 // returned along with the validation error.
-func DecodeSpec(r io.Reader) (*Spec, error) {
+func Decode(r io.Reader) (*Spec, error) {
 	dec := newDecoder(r)
 	var spec Spec
 	if err := dec.Decode(&spec); err != nil {
@@ -52,47 +53,47 @@ func newDecoder(r io.Reader) *yaml.Decoder {
 // Spec represents a parsed spec.yaml file describing a template.
 type Spec struct {
 	// Pos is the YAML file location where this object started.
-	Pos ConfigPos `yaml:"-"`
+	Pos model.ConfigPos `yaml:"-"`
 
-	APIVersion String `yaml:"apiVersion"`
-	Kind       String `yaml:"kind"`
+	APIVersion model.String `yaml:"apiVersion"`
+	Kind       model.String `yaml:"kind"`
 
-	Desc   String   `yaml:"desc"`
-	Inputs []*Input `yaml:"inputs"`
-	Steps  []*Step  `yaml:"steps"`
+	Desc   model.String `yaml:"desc"`
+	Inputs []*Input     `yaml:"inputs"`
+	Steps  []*Step      `yaml:"steps"`
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler.
 func (s *Spec) UnmarshalYAML(n *yaml.Node) error {
-	return unmarshalPlain(n, s, &s.Pos)
+	return model.UnmarshalPlain(n, s, &s.Pos)
 }
 
 // Validate implements Validator.
 func (s *Spec) Validate() error {
 	return errors.Join(
-		oneOf(&s.Pos, s.APIVersion, []string{"cli.abcxyz.dev/v1alpha1"}, "apiVersion"),
-		oneOf(&s.Pos, s.Kind, []string{"Template"}, "kind"),
-		notZeroModel(&s.Pos, s.Desc, "desc"),
-		nonEmptySlice(&s.Pos, s.Steps, "steps"),
-		validateEach(s.Inputs),
-		validateEach(s.Steps),
+		model.OneOf(&s.Pos, s.APIVersion, []string{"cli.abcxyz.dev/v1alpha1"}, "apiVersion"),
+		model.OneOf(&s.Pos, s.Kind, []string{"Template"}, "kind"),
+		model.NotZeroModel(&s.Pos, s.Desc, "desc"),
+		model.NonEmptySlice(&s.Pos, s.Steps, "steps"),
+		model.ValidateEach(s.Inputs),
+		model.ValidateEach(s.Steps),
 	)
 }
 
 // Input represents one of the parsed "input" fields from the spec.yaml file.
 type Input struct {
 	// Pos is the YAML file location where this object started.
-	Pos ConfigPos `yaml:"-"`
+	Pos model.ConfigPos `yaml:"-"`
 
-	Name    String       `yaml:"name"`
-	Desc    String       `yaml:"desc"`
-	Default *String      `yaml:"default,omitempty"`
-	Rules   []*InputRule `yaml:"rules"`
+	Name    model.String  `yaml:"name"`
+	Desc    model.String  `yaml:"desc"`
+	Default *model.String `yaml:"default,omitempty"`
+	Rules   []*InputRule  `yaml:"rules"`
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler.
 func (i *Input) UnmarshalYAML(n *yaml.Node) error {
-	return unmarshalPlain(n, i, &i.Pos)
+	return model.UnmarshalPlain(n, i, &i.Pos)
 }
 
 // Validate implements Validator.
@@ -103,38 +104,38 @@ func (i *Input) Validate() error {
 	}
 
 	return errors.Join(
-		notZeroModel(&i.Pos, i.Name, "name"),
-		notZeroModel(&i.Pos, i.Desc, "desc"),
+		model.NotZeroModel(&i.Pos, i.Name, "name"),
+		model.NotZeroModel(&i.Pos, i.Desc, "desc"),
 		reservedNameErr,
-		validateEach(i.Rules),
+		model.ValidateEach(i.Rules),
 	)
 }
 
 // InputRule represents a validation rule attached to an input.
 type InputRule struct {
-	Pos ConfigPos `yaml:"-"`
+	Pos model.ConfigPos `yaml:"-"`
 
-	Rule    String `yaml:"rule"`
-	Message String `yaml:"message"` // optional
+	Rule    model.String `yaml:"rule"`
+	Message model.String `yaml:"message"` // optional
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler.
 func (i *InputRule) UnmarshalYAML(n *yaml.Node) error {
-	return unmarshalPlain(n, i, &i.Pos)
+	return model.UnmarshalPlain(n, i, &i.Pos)
 }
 
 // Validate implements Validator.
 func (i *InputRule) Validate() error {
-	return notZeroModel(&i.Pos, i.Rule, "rule")
+	return model.NotZeroModel(&i.Pos, i.Rule, "rule")
 }
 
 // Step represents one of the work steps involved in rendering a template.
 type Step struct {
 	// Pos is the YAML file location where this object started.
-	Pos ConfigPos `yaml:"-"`
+	Pos model.ConfigPos `yaml:"-"`
 
-	Desc   String `yaml:"desc"`
-	Action String `yaml:"action"`
+	Desc   model.String `yaml:"desc"`
+	Action model.String `yaml:"action"`
 
 	// Each action type has a field below. Only one of these will be set.
 	Append          *Append          `yaml:"-"`
@@ -149,7 +150,7 @@ type Step struct {
 
 // UnmarshalYAML implements yaml.Unmarshaler.
 func (s *Step) UnmarshalYAML(n *yaml.Node) error {
-	if err := unmarshalPlain(n, s, &s.Pos, "params"); err != nil {
+	if err := model.UnmarshalPlain(n, s, &s.Pos, "params"); err != nil {
 		return nil
 	}
 
@@ -211,42 +212,42 @@ func (s *Step) UnmarshalYAML(n *yaml.Node) error {
 func (s *Step) Validate() error {
 	// The "action" field is implicitly validated by UnmarshalYAML, so not included here.
 	return errors.Join(
-		notZeroModel(&s.Pos, s.Desc, "desc"),
-		validateUnlessNil(s.Append),
-		validateUnlessNil(s.ForEach),
-		validateUnlessNil(s.GoTemplate),
-		validateUnlessNil(s.Include),
-		validateUnlessNil(s.Print),
-		validateUnlessNil(s.RegexNameLookup),
-		validateUnlessNil(s.RegexReplace),
-		validateUnlessNil(s.StringReplace),
+		model.NotZeroModel(&s.Pos, s.Desc, "desc"),
+		model.ValidateUnlessNil(s.Append),
+		model.ValidateUnlessNil(s.ForEach),
+		model.ValidateUnlessNil(s.GoTemplate),
+		model.ValidateUnlessNil(s.Include),
+		model.ValidateUnlessNil(s.Print),
+		model.ValidateUnlessNil(s.RegexNameLookup),
+		model.ValidateUnlessNil(s.RegexReplace),
+		model.ValidateUnlessNil(s.StringReplace),
 	)
 }
 
 // Print is an action that prints a message to standard output.
 type Print struct {
 	// Pos is the YAML file location where this object started.
-	Pos ConfigPos `yaml:"-"`
+	Pos model.ConfigPos `yaml:"-"`
 
-	Message String `yaml:"message"`
+	Message model.String `yaml:"message"`
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler.
 func (p *Print) UnmarshalYAML(n *yaml.Node) error {
-	return unmarshalPlain(n, p, &p.Pos)
+	return model.UnmarshalPlain(n, p, &p.Pos)
 }
 
 // Validate implements Validator.
 func (p *Print) Validate() error {
 	return errors.Join(
-		notZeroModel(&p.Pos, p.Message, "message"),
+		model.NotZeroModel(&p.Pos, p.Message, "message"),
 	)
 }
 
 // Include is an action that places files into the output directory.
 type Include struct {
 	// Pos is the YAML file location where this object started.
-	Pos ConfigPos `yaml:"-"`
+	Pos model.ConfigPos `yaml:"-"`
 
 	Paths []*IncludePath `yaml:"paths"`
 }
@@ -267,20 +268,20 @@ func (i *Include) UnmarshalYAML(n *yaml.Node) error {
 
 	nodesMap := map[string]yaml.Node{}
 	if err := n.Decode(nodesMap); err != nil {
-		return yamlPos(n).Errorf("%w", err)
+		return model.YAMLPos(n).Errorf("%w", err)
 	}
 
 	pathsNode, ok := nodesMap["paths"]
 	if !ok {
-		return yamlPos(n).Errorf(`field "paths" is required`)
+		return model.YAMLPos(n).Errorf(`field "paths" is required`)
 	}
 	if pathsNode.Kind != yaml.SequenceNode {
-		return yamlPos(&pathsNode).Errorf("paths must be a YAML list")
+		return model.YAMLPos(&pathsNode).Errorf("paths must be a YAML list")
 	}
 	var listElemKind, zeroKind yaml.Kind
 	for _, elemNode := range pathsNode.Content {
 		if listElemKind != zeroKind && elemNode.Kind != listElemKind {
-			return yamlPos(&pathsNode).Errorf("Lists of paths must be homogeneous, either all strings or all objects")
+			return model.YAMLPos(&pathsNode).Errorf("Lists of paths must be homogeneous, either all strings or all objects")
 		}
 		listElemKind = elemNode.Kind
 	}
@@ -289,37 +290,37 @@ func (i *Include) UnmarshalYAML(n *yaml.Node) error {
 		ip := &IncludePath{}
 		i.Paths = []*IncludePath{ip}
 		// Subtle point: in case 1 ("old-style"), we unmarshal the incoming YAML object as an "IncludePath" struct.
-		return unmarshalPlain(n, ip, &ip.Pos)
+		return model.UnmarshalPlain(n, ip, &ip.Pos)
 	}
 
 	// Otherwise we're in case 2, we just unmarshal the incoming YAML object as an "Include: struct.
-	return unmarshalPlain(n, i, &i.Pos)
+	return model.UnmarshalPlain(n, i, &i.Pos)
 }
 
 // Validate implements Validator.
 func (i *Include) Validate() error {
 	return errors.Join(
-		validateEach(i.Paths),
-		nonEmptySlice(&i.Pos, i.Paths, "paths"),
+		model.ValidateEach(i.Paths),
+		model.NonEmptySlice(&i.Pos, i.Paths, "paths"),
 	)
 }
 
 // IncludePath represents an object for controlling the behavior of included files.
 type IncludePath struct {
-	Pos ConfigPos `yaml:"-"`
+	Pos model.ConfigPos `yaml:"-"`
 
-	AddPrefix   String   `yaml:"add_prefix"`
-	As          []String `yaml:"as"`
-	From        String   `yaml:"from"`
-	OnConflict  String   `yaml:"on_conflict"`
-	Paths       []String `yaml:"paths"`
-	Skip        []String `yaml:"skip"`
-	StripPrefix String   `yaml:"strip_prefix"`
+	AddPrefix   model.String   `yaml:"add_prefix"`
+	As          []model.String `yaml:"as"`
+	From        model.String   `yaml:"from"`
+	OnConflict  model.String   `yaml:"on_conflict"`
+	Paths       []model.String `yaml:"paths"`
+	Skip        []model.String `yaml:"skip"`
+	StripPrefix model.String   `yaml:"strip_prefix"`
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler.
 func (i *IncludePath) UnmarshalYAML(n *yaml.Node) error {
-	return unmarshalPlain(n, i, &i.Pos)
+	return model.UnmarshalPlain(n, i, &i.Pos)
 }
 
 // Validate implements Validator.
@@ -341,7 +342,7 @@ func (i *IncludePath) Validate() error {
 	}
 
 	return errors.Join(
-		nonEmptySlice(&i.Pos, i.Paths, "paths"),
+		model.NonEmptySlice(&i.Pos, i.Paths, "paths"),
 		exclusivityErr,
 		fromErr,
 	)
@@ -351,32 +352,32 @@ func (i *IncludePath) Validate() error {
 // template expression.
 type RegexReplace struct {
 	// Pos is the YAML file location where this object started.
-	Pos ConfigPos `yaml:"-"`
+	Pos model.ConfigPos `yaml:"-"`
 
-	Paths        []String             `yaml:"paths"`
+	Paths        []model.String       `yaml:"paths"`
 	Replacements []*RegexReplaceEntry `yaml:"replacements"`
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler.
 func (r *RegexReplace) UnmarshalYAML(n *yaml.Node) error {
-	return unmarshalPlain(n, r, &r.Pos)
+	return model.UnmarshalPlain(n, r, &r.Pos)
 }
 
 // Validate implements Validator.
 func (r *RegexReplace) Validate() error {
 	return errors.Join(
-		nonEmptySlice(&r.Pos, r.Paths, "paths"),
-		nonEmptySlice(&r.Pos, r.Replacements, "replacements"),
-		validateEach(r.Replacements),
+		model.NonEmptySlice(&r.Pos, r.Paths, "paths"),
+		model.NonEmptySlice(&r.Pos, r.Replacements, "replacements"),
+		model.ValidateEach(r.Replacements),
 	)
 }
 
 // RegexReplaceEntry is one of potentially many regex replacements to be applied.
 type RegexReplaceEntry struct {
-	Pos               ConfigPos `yaml:"-"`
-	Regex             String    `yaml:"regex"`
-	SubgroupToReplace String    `yaml:"subgroup_to_replace"`
-	With              String    `yaml:"with"`
+	Pos               model.ConfigPos `yaml:"-"`
+	Regex             model.String    `yaml:"regex"`
+	SubgroupToReplace model.String    `yaml:"subgroup_to_replace"`
+	With              model.String    `yaml:"with"`
 }
 
 // Validate implements Validator.
@@ -388,75 +389,75 @@ func (r *RegexReplaceEntry) Validate() error {
 
 	var subgroupErr error
 	if r.SubgroupToReplace.Val != "" {
-		subgroupErr = isValidRegexGroupName(r.SubgroupToReplace, "subgroup")
+		subgroupErr = model.IsValidRegexGroupName(r.SubgroupToReplace, "subgroup")
 	}
 
 	return errors.Join(
-		notZeroModel(&r.Pos, r.Regex, "regex"),
-		notZeroModel(&r.Pos, r.With, "with"),
+		model.NotZeroModel(&r.Pos, r.Regex, "regex"),
+		model.NotZeroModel(&r.Pos, r.With, "with"),
 		subgroupErr,
 	)
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler.
 func (r *RegexReplaceEntry) UnmarshalYAML(n *yaml.Node) error {
-	return unmarshalPlain(n, r, &r.Pos)
+	return model.UnmarshalPlain(n, r, &r.Pos)
 }
 
 // RegexNameLookup is an action that replaces named regex capturing groups with
 // the template variable of the same name.
 type RegexNameLookup struct {
 	// Pos is the YAML file location where this object started.
-	Pos ConfigPos `yaml:"-"`
+	Pos model.ConfigPos `yaml:"-"`
 
-	Paths        []String                `yaml:"paths"`
+	Paths        []model.String          `yaml:"paths"`
 	Replacements []*RegexNameLookupEntry `yaml:"replacements"`
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler.
 func (r *RegexNameLookup) UnmarshalYAML(n *yaml.Node) error {
-	return unmarshalPlain(n, r, &r.Pos)
+	return model.UnmarshalPlain(n, r, &r.Pos)
 }
 
 // Validate implements Validator.
 func (r *RegexNameLookup) Validate() error {
 	return errors.Join(
-		nonEmptySlice(&r.Pos, r.Paths, "paths"),
-		nonEmptySlice(&r.Pos, r.Replacements, "replacements"),
-		validateEach(r.Replacements),
+		model.NonEmptySlice(&r.Pos, r.Paths, "paths"),
+		model.NonEmptySlice(&r.Pos, r.Replacements, "replacements"),
+		model.ValidateEach(r.Replacements),
 	)
 }
 
 // RegexNameLookupEntry is one of potentially many regex replacements to be applied.
 type RegexNameLookupEntry struct {
-	Pos   ConfigPos `yaml:"-"`
-	Regex String    `yaml:"regex"`
+	Pos   model.ConfigPos `yaml:"-"`
+	Regex model.String    `yaml:"regex"`
 }
 
 // Validate implements Validator.
 func (r *RegexNameLookupEntry) Validate() error {
 	return errors.Join(
-		notZeroModel(&r.Pos, r.Regex, "regex"),
+		model.NotZeroModel(&r.Pos, r.Regex, "regex"),
 	)
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler.
 func (r *RegexNameLookupEntry) UnmarshalYAML(n *yaml.Node) error {
-	return unmarshalPlain(n, r, &r.Pos)
+	return model.UnmarshalPlain(n, r, &r.Pos)
 }
 
 // StringReplace is an action that replaces a string with a template expression.
 type StringReplace struct {
 	// Pos is the YAML file location where this object started.
-	Pos ConfigPos `yaml:"-"`
+	Pos model.ConfigPos `yaml:"-"`
 
-	Paths        []String             `yaml:"paths"`
+	Paths        []model.String       `yaml:"paths"`
 	Replacements []*StringReplacement `yaml:"replacements"`
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler.
 func (s *StringReplace) UnmarshalYAML(n *yaml.Node) error {
-	return unmarshalPlain(n, s, &s.Pos)
+	return model.UnmarshalPlain(n, s, &s.Pos)
 }
 
 // Validate implements Validator.
@@ -467,51 +468,51 @@ func (s *StringReplace) Validate() error {
 	//  - Validating that the subgroup number is actually a valid subgroup in
 	//    the regex
 	return errors.Join(
-		nonEmptySlice(&s.Pos, s.Paths, "paths"),
-		nonEmptySlice(&s.Pos, s.Replacements, "replacements"),
-		validateEach(s.Replacements),
+		model.NonEmptySlice(&s.Pos, s.Paths, "paths"),
+		model.NonEmptySlice(&s.Pos, s.Replacements, "replacements"),
+		model.ValidateEach(s.Replacements),
 	)
 }
 
 type StringReplacement struct {
-	Pos ConfigPos `yaml:"-"`
+	Pos model.ConfigPos `yaml:"-"`
 
-	ToReplace String `yaml:"to_replace"`
-	With      String `yaml:"with"`
+	ToReplace model.String `yaml:"to_replace"`
+	With      model.String `yaml:"with"`
 }
 
 func (s *StringReplacement) Validate() error {
 	return errors.Join(
-		notZeroModel(&s.Pos, s.ToReplace, "to_replace"),
-		notZeroModel(&s.Pos, s.With, "with"),
+		model.NotZeroModel(&s.Pos, s.ToReplace, "to_replace"),
+		model.NotZeroModel(&s.Pos, s.With, "with"),
 	)
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler.
 func (s *StringReplacement) UnmarshalYAML(n *yaml.Node) error {
-	return unmarshalPlain(n, s, &s.Pos)
+	return model.UnmarshalPlain(n, s, &s.Pos)
 }
 
 // Append is an action that appends some output to the end of the file.
 type Append struct {
 	// Pos is the YAML file location where this object started.
-	Pos ConfigPos `yaml:"-"`
+	Pos model.ConfigPos `yaml:"-"`
 
-	Paths             []String `yaml:"paths"`
-	With              String   `yaml:"with"`
-	SkipEnsureNewline Bool     `yaml:"skip_ensure_newline"`
+	Paths             []model.String `yaml:"paths"`
+	With              model.String   `yaml:"with"`
+	SkipEnsureNewline model.Bool     `yaml:"skip_ensure_newline"`
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler.
 func (a *Append) UnmarshalYAML(n *yaml.Node) error {
-	return unmarshalPlain(n, a, &a.Pos)
+	return model.UnmarshalPlain(n, a, &a.Pos)
 }
 
 // Validate implements Validator.
 func (a *Append) Validate() error {
 	return errors.Join(
-		nonEmptySlice(&a.Pos, a.Paths, "paths"),
-		notZeroModel(&a.Pos, a.With, "with"),
+		model.NonEmptySlice(&a.Pos, a.Paths, "paths"),
+		model.NotZeroModel(&a.Pos, a.With, "with"),
 	)
 }
 
@@ -519,25 +520,25 @@ func (a *Append) Validate() error {
 // replacing each one with its template output.
 type GoTemplate struct {
 	// Pos is the YAML file location where this object started.
-	Pos ConfigPos `yaml:"-"`
+	Pos model.ConfigPos `yaml:"-"`
 
-	Paths []String `yaml:"paths"`
+	Paths []model.String `yaml:"paths"`
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler.
 func (g *GoTemplate) UnmarshalYAML(n *yaml.Node) error {
-	return unmarshalPlain(n, g, &g.Pos)
+	return model.UnmarshalPlain(n, g, &g.Pos)
 }
 
 // Validate implements Validator.
 func (g *GoTemplate) Validate() error {
 	// Checking that the input paths are valid will happen later.
-	return errors.Join(nonEmptySlice(&g.Pos, g.Paths, "paths"))
+	return errors.Join(model.NonEmptySlice(&g.Pos, g.Paths, "paths"))
 }
 
 type ForEach struct {
 	// Pos is the YAML file location where this object started.
-	Pos ConfigPos `yaml:"-"`
+	Pos model.ConfigPos `yaml:"-"`
 
 	Iterator *ForEachIterator `yaml:"iterator"`
 	Steps    []*Step          `yaml:"steps"`
@@ -545,36 +546,36 @@ type ForEach struct {
 
 // UnmarshalYAML implements yaml.Unmarshaler.
 func (f *ForEach) UnmarshalYAML(n *yaml.Node) error {
-	return unmarshalPlain(n, f, &f.Pos)
+	return model.UnmarshalPlain(n, f, &f.Pos)
 }
 
 func (f *ForEach) Validate() error {
 	return errors.Join(
-		notZero(&f.Pos, f.Iterator, "iterator"),
-		nonEmptySlice(&f.Pos, f.Steps, "steps"),
-		validateUnlessNil(f.Iterator),
-		validateEach(f.Steps),
+		model.NotZero(&f.Pos, f.Iterator, "iterator"),
+		model.NonEmptySlice(&f.Pos, f.Steps, "steps"),
+		model.ValidateUnlessNil(f.Iterator),
+		model.ValidateEach(f.Steps),
 	)
 }
 
 type ForEachIterator struct {
 	// Pos is the YAML file location where this object started.
-	Pos ConfigPos `yaml:"-"`
+	Pos model.ConfigPos `yaml:"-"`
 
 	// The name by which the range value is accessed.
-	Key String `yaml:"key"`
+	Key model.String `yaml:"key"`
 
 	// Exactly one of the following fields must be set.
 
 	// Values is a list to range over, e.g. ["dev", "prod"]
-	Values []String `yaml:"values"`
+	Values []model.String `yaml:"values"`
 	// ValuesFrom is a CEL expression returning a list of strings to range over.
-	ValuesFrom *String `yaml:"values_from"`
+	ValuesFrom *model.String `yaml:"values_from"`
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler.
 func (f *ForEachIterator) UnmarshalYAML(n *yaml.Node) error {
-	return unmarshalPlain(n, f, &f.Pos)
+	return model.UnmarshalPlain(n, f, &f.Pos)
 }
 
 func (f *ForEachIterator) Validate() error {
@@ -584,7 +585,7 @@ func (f *ForEachIterator) Validate() error {
 	}
 
 	return errors.Join(
-		notZeroModel(&f.Pos, f.Key, "key"),
+		model.NotZeroModel(&f.Pos, f.Key, "key"),
 		exclusivityErr,
 	)
 }

--- a/templates/model/spec/spec_test.go
+++ b/templates/model/spec/spec_test.go
@@ -12,12 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package model
+package spec
 
 import (
 	"strings"
 	"testing"
 
+	"github.com/abcxyz/abc/templates/model"
 	"github.com/abcxyz/pkg/testutil"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -50,23 +51,23 @@ steps:
   params:
     message: 'Hello, {{.or .person_name "World"}}'`,
 			want: &Spec{
-				APIVersion: String{Val: "cli.abcxyz.dev/v1alpha1"},
-				Kind:       String{Val: "Template"},
+				APIVersion: model.String{Val: "cli.abcxyz.dev/v1alpha1"},
+				Kind:       model.String{Val: "Template"},
 
-				Desc: String{Val: "A simple template that just prints and exits"},
+				Desc: model.String{Val: "A simple template that just prints and exits"},
 				Inputs: []*Input{
 					{
-						Name:    String{Val: "person_name"},
-						Desc:    String{Val: "An optional name of a person to greet"},
-						Default: &String{Val: "default value"},
+						Name:    model.String{Val: "person_name"},
+						Desc:    model.String{Val: "An optional name of a person to greet"},
+						Default: &model.String{Val: "default value"},
 					},
 				},
 				Steps: []*Step{
 					{
-						Desc:   String{Val: "Print a message"},
-						Action: String{Val: "print"},
+						Desc:   model.String{Val: "Print a message"},
+						Action: model.String{Val: "print"},
 						Print: &Print{
-							Message: String{Val: `Hello, {{.or .person_name "World"}}`},
+							Message: model.String{Val: `Hello, {{.or .person_name "World"}}`},
 						},
 					},
 				},
@@ -136,7 +137,7 @@ steps:
 				return
 			}
 
-			opt := cmpopts.IgnoreTypes(&ConfigPos{}, ConfigPos{}) // don't force test authors to assert the line and column numbers
+			opt := cmpopts.IgnoreTypes(&model.ConfigPos{}, model.ConfigPos{}) // don't force test authors to assert the line and column numbers
 			if diff := cmp.Diff(got, tc.want, opt); diff != "" {
 				t.Errorf("unmarshaling didn't yield expected struct. Diff (-got +want): %s", diff)
 			}
@@ -160,9 +161,9 @@ func TestUnmarshalInput(t *testing.T) {
 desc: "The name of a person to greet"
 default: "default"`,
 			want: &Input{
-				Name:    String{Val: "person_name"},
-				Desc:    String{Val: "The name of a person to greet"},
-				Default: &String{Val: "default"},
+				Name:    model.String{Val: "person_name"},
+				Desc:    model.String{Val: "The name of a person to greet"},
+				Default: &model.String{Val: "default"},
 			},
 		},
 		{
@@ -170,8 +171,8 @@ default: "default"`,
 			in: `name: 'person_name'
 desc: "The name of a person to greet"`,
 			want: &Input{
-				Name:    String{Val: "person_name"},
-				Desc:    String{Val: "The name of a person to greet"},
+				Name:    model.String{Val: "person_name"},
+				Desc:    model.String{Val: "The name of a person to greet"},
 				Default: nil,
 			},
 		},
@@ -201,12 +202,12 @@ rules:
   - rule: 'size(a) > 5'
     message: 'my message'`,
 			want: &Input{
-				Name: String{Val: "a"},
-				Desc: String{Val: "foo"},
+				Name: model.String{Val: "a"},
+				Desc: model.String{Val: "foo"},
 				Rules: []*InputRule{
 					{
-						Rule:    String{Val: "size(a) > 5"},
-						Message: String{Val: "my message"},
+						Rule:    model.String{Val: "size(a) > 5"},
+						Message: model.String{Val: "my message"},
 					},
 				},
 			},
@@ -218,11 +219,11 @@ name: 'a'
 rules:
   - rule: 'size(a) > 5'`,
 			want: &Input{
-				Name: String{Val: "a"},
-				Desc: String{Val: "foo"},
+				Name: model.String{Val: "a"},
+				Desc: model.String{Val: "foo"},
 				Rules: []*InputRule{
 					{
-						Rule: String{Val: "size(a) > 5"},
+						Rule: model.String{Val: "size(a) > 5"},
 					},
 				},
 			},
@@ -237,16 +238,16 @@ rules:
   - rule: 'size(a) < 100'
     message: 'my other message'`,
 			want: &Input{
-				Name: String{Val: "a"},
-				Desc: String{Val: "foo"},
+				Name: model.String{Val: "a"},
+				Desc: model.String{Val: "foo"},
 				Rules: []*InputRule{
 					{
-						Rule:    String{Val: "size(a) > 5"},
-						Message: String{Val: "my message"},
+						Rule:    model.String{Val: "size(a) > 5"},
+						Message: model.String{Val: "my message"},
 					},
 					{
-						Rule:    String{Val: "size(a) < 100"},
-						Message: String{Val: "my other message"},
+						Rule:    model.String{Val: "size(a) < 100"},
+						Message: model.String{Val: "my other message"},
 					},
 				},
 			},
@@ -275,7 +276,7 @@ rules:
 				return
 			}
 
-			if diff := cmp.Diff(got, tc.want, cmpopts.IgnoreTypes(&ConfigPos{}, ConfigPos{})); diff != "" {
+			if diff := cmp.Diff(got, tc.want, cmpopts.IgnoreTypes(&model.ConfigPos{}, model.ConfigPos{})); diff != "" {
 				t.Errorf("unmarshaling didn't yield expected struct. Diff (-got +want): %s", diff)
 			}
 		})
@@ -301,15 +302,15 @@ params:
   with: 'jkl'
   skip_ensure_newline: true`,
 			want: &Step{
-				Desc:   String{Val: "mydesc"},
-				Action: String{Val: "append"},
+				Desc:   model.String{Val: "mydesc"},
+				Action: model.String{Val: "append"},
 				Append: &Append{
-					Paths: []String{
+					Paths: []model.String{
 						{Val: "a.txt"},
 						{Val: "b.txt"},
 					},
-					With:              String{Val: "jkl"},
-					SkipEnsureNewline: Bool{Val: true},
+					With:              model.String{Val: "jkl"},
+					SkipEnsureNewline: model.Bool{Val: true},
 				},
 			},
 		},
@@ -346,10 +347,10 @@ action: 'print'
 params:
   message: 'Hello'`,
 			want: &Step{
-				Desc:   String{Val: "Print a message"},
-				Action: String{Val: "print"},
+				Desc:   model.String{Val: "Print a message"},
+				Action: model.String{Val: "print"},
 				Print: &Print{
-					Message: String{Val: "Hello"},
+					Message: model.String{Val: "Hello"},
 				},
 			},
 		},
@@ -385,13 +386,13 @@ params:
   paths: ['a/b/c', 'x/y.txt']
   from: 'destination'`,
 			want: &Step{
-				Desc:   String{Val: "mydesc"},
-				Action: String{Val: "include"},
+				Desc:   model.String{Val: "mydesc"},
+				Action: model.String{Val: "include"},
 				Include: &Include{
 					Paths: []*IncludePath{
 						{
-							From: String{Val: "destination"},
-							Paths: []String{
+							From: model.String{Val: "destination"},
+							Paths: []model.String{
 								{
 									Val: "a/b/c",
 								},
@@ -413,13 +414,13 @@ params:
   - paths: ['a/b/c', 'x/y.txt']
     from: 'destination'`,
 			want: &Step{
-				Desc:   String{Val: "mydesc"},
-				Action: String{Val: "include"},
+				Desc:   model.String{Val: "mydesc"},
+				Action: model.String{Val: "include"},
 				Include: &Include{
 					Paths: []*IncludePath{
 						{
-							From: String{Val: "destination"},
-							Paths: []String{
+							From: model.String{Val: "destination"},
+							Paths: []model.String{
 								{
 									Val: "a/b/c",
 								},
@@ -442,12 +443,12 @@ params:
       strip_prefix: 'a/b'
       add_prefix: 'c/d'`,
 			want: &Step{
-				Desc:   String{Val: "mydesc"},
-				Action: String{Val: "include"},
+				Desc:   model.String{Val: "mydesc"},
+				Action: model.String{Val: "include"},
 				Include: &Include{
 					Paths: []*IncludePath{
 						{
-							Paths: []String{
+							Paths: []model.String{
 								{
 									Val: "a/b/c",
 								},
@@ -455,8 +456,8 @@ params:
 									Val: "x/y.txt",
 								},
 							},
-							StripPrefix: String{Val: "a/b"},
-							AddPrefix:   String{Val: "c/d"},
+							StripPrefix: model.String{Val: "a/b"},
+							AddPrefix:   model.String{Val: "c/d"},
 						},
 					},
 				},
@@ -471,12 +472,12 @@ params:
     - paths: ['a/b/c', 'd/e/f']
       as: ['x/y/z', 'q/r/s']`,
 			want: &Step{
-				Desc:   String{Val: "mydesc"},
-				Action: String{Val: "include"},
+				Desc:   model.String{Val: "mydesc"},
+				Action: model.String{Val: "include"},
 				Include: &Include{
 					Paths: []*IncludePath{
 						{
-							Paths: []String{
+							Paths: []model.String{
 								{
 									Val: "a/b/c",
 								},
@@ -484,7 +485,7 @@ params:
 									Val: "d/e/f",
 								},
 							},
-							As: []String{
+							As: []model.String{
 								{
 									Val: "x/y/z",
 								},
@@ -506,17 +507,17 @@ params:
     - paths: ['.']
       skip: ['x/y']`,
 			want: &Step{
-				Desc:   String{Val: "mydesc"},
-				Action: String{Val: "include"},
+				Desc:   model.String{Val: "mydesc"},
+				Action: model.String{Val: "include"},
 				Include: &Include{
 					Paths: []*IncludePath{
 						{
-							Paths: []String{
+							Paths: []model.String{
 								{
 									Val: ".",
 								},
 							},
-							Skip: []String{
+							Skip: []model.String{
 								{
 									Val: "x/y",
 								},
@@ -535,17 +536,17 @@ params:
     - paths: ['.']
       from: 'destination'`,
 			want: &Step{
-				Desc:   String{Val: "mydesc"},
-				Action: String{Val: "include"},
+				Desc:   model.String{Val: "mydesc"},
+				Action: model.String{Val: "include"},
 				Include: &Include{
 					Paths: []*IncludePath{
 						{
-							Paths: []String{
+							Paths: []model.String{
 								{
 									Val: ".",
 								},
 							},
-							From: String{
+							From: model.String{
 								Val: "destination",
 							},
 						},
@@ -583,17 +584,17 @@ params:
     - paths: ['.']
       from: 'invalid'`,
 			want: &Step{
-				Desc:   String{Val: "mydesc"},
-				Action: String{Val: "include"},
+				Desc:   model.String{Val: "mydesc"},
+				Action: model.String{Val: "include"},
 				Include: &Include{
 					Paths: []*IncludePath{
 						{
-							Paths: []String{
+							Paths: []model.String{
 								{
 									Val: ".",
 								},
 							},
-							From: String{
+							From: model.String{
 								Val: "invalid",
 							},
 						},
@@ -611,12 +612,12 @@ params:
     - paths: ['a/b/c', 'd/e/f']
       as: ['x/y/z', 'q/r/s', 't/u/v']`,
 			want: &Step{
-				Desc:   String{Val: "mydesc"},
-				Action: String{Val: "include"},
+				Desc:   model.String{Val: "mydesc"},
+				Action: model.String{Val: "include"},
 				Include: &Include{
 					Paths: []*IncludePath{
 						{
-							Paths: []String{
+							Paths: []model.String{
 								{
 									Val: "a/b/c",
 								},
@@ -624,7 +625,7 @@ params:
 									Val: "d/e/f",
 								},
 							},
-							As: []String{
+							As: []model.String{
 								{
 									Val: "x/y/z",
 								},
@@ -687,22 +688,22 @@ params:
   - regex: 'my_other_regex'
     with: 'whatever'`,
 			want: &Step{
-				Desc:   String{Val: "mydesc"},
-				Action: String{Val: "regex_replace"},
+				Desc:   model.String{Val: "mydesc"},
+				Action: model.String{Val: "regex_replace"},
 				RegexReplace: &RegexReplace{
-					Paths: []String{
+					Paths: []model.String{
 						{Val: "a.txt"},
 						{Val: "b.txt"},
 					},
 					Replacements: []*RegexReplaceEntry{
 						{
-							Regex:             String{Val: "my_(?P<groupname>regex)"},
-							SubgroupToReplace: String{Val: "groupname"},
-							With:              String{Val: "some_template"},
+							Regex:             model.String{Val: "my_(?P<groupname>regex)"},
+							SubgroupToReplace: model.String{Val: "groupname"},
+							With:              model.String{Val: "some_template"},
 						},
 						{
-							Regex: String{Val: "my_other_regex"},
-							With:  String{Val: "whatever"},
+							Regex: model.String{Val: "my_other_regex"},
+							With:  model.String{Val: "whatever"},
 						},
 					},
 				},
@@ -766,16 +767,16 @@ params:
   - regex: '(?P<mygroup>myregex'
   - regex: '(?P<myothergroup>myotherregex'`,
 			want: &Step{
-				Desc:   String{Val: "mydesc"},
-				Action: String{Val: "regex_name_lookup"},
+				Desc:   model.String{Val: "mydesc"},
+				Action: model.String{Val: "regex_name_lookup"},
 				RegexNameLookup: &RegexNameLookup{
-					Paths: []String{
+					Paths: []model.String{
 						{Val: "a.txt"},
 						{Val: "b.txt"},
 					},
 					Replacements: []*RegexNameLookupEntry{
-						{Regex: String{Val: "(?P<mygroup>myregex"}},
-						{Regex: String{Val: "(?P<myothergroup>myotherregex"}},
+						{Regex: model.String{Val: "(?P<mygroup>myregex"}},
+						{Regex: model.String{Val: "(?P<myothergroup>myotherregex"}},
 					},
 				},
 			},
@@ -802,21 +803,21 @@ params:
   - to_replace: 'ghi'
     with: 'jkl'`,
 			want: &Step{
-				Desc:   String{Val: "mydesc"},
-				Action: String{Val: "string_replace"},
+				Desc:   model.String{Val: "mydesc"},
+				Action: model.String{Val: "string_replace"},
 				StringReplace: &StringReplace{
-					Paths: []String{
+					Paths: []model.String{
 						{Val: "a.txt"},
 						{Val: "b.txt"},
 					},
 					Replacements: []*StringReplacement{
 						{
-							ToReplace: String{Val: "abc"},
-							With:      String{Val: "def"},
+							ToReplace: model.String{Val: "abc"},
+							With:      model.String{Val: "def"},
 						},
 						{
-							ToReplace: String{Val: "ghi"},
-							With:      String{Val: "jkl"},
+							ToReplace: model.String{Val: "ghi"},
+							With:      model.String{Val: "jkl"},
 						},
 					},
 				},
@@ -847,10 +848,10 @@ action: 'go_template'
 params:
   paths: ['my/path/1', 'my/path/2']`,
 			want: &Step{
-				Desc:   String{Val: "mydesc"},
-				Action: String{Val: "go_template"},
+				Desc:   model.String{Val: "mydesc"},
+				Action: model.String{Val: "go_template"},
 				GoTemplate: &GoTemplate{
-					Paths: []String{
+					Paths: []model.String{
 						{Val: "my/path/1"},
 						{Val: "my/path/2"},
 					},
@@ -884,29 +885,29 @@ params:
         message: 'yet another message'
 `,
 			want: &Step{
-				Desc:   String{Val: "mydesc"},
-				Action: String{Val: "for_each"},
+				Desc:   model.String{Val: "mydesc"},
+				Action: model.String{Val: "for_each"},
 				ForEach: &ForEach{
 					Iterator: &ForEachIterator{
-						Key: String{Val: "environment"},
-						Values: []String{
+						Key: model.String{Val: "environment"},
+						Values: []model.String{
 							{Val: "dev"},
 							{Val: "prod"},
 						},
 					},
 					Steps: []*Step{
 						{
-							Desc:   String{Val: "print some stuff"},
-							Action: String{Val: "print"},
+							Desc:   model.String{Val: "print some stuff"},
+							Action: model.String{Val: "print"},
 							Print: &Print{
-								Message: String{Val: `Hello, {{.name}}`},
+								Message: model.String{Val: `Hello, {{.name}}`},
 							},
 						},
 						{
-							Desc:   String{Val: "another action"},
-							Action: String{Val: "print"},
+							Desc:   model.String{Val: "another action"},
+							Action: model.String{Val: "print"},
 							Print: &Print{
-								Message: String{Val: "yet another message"},
+								Message: model.String{Val: "yet another message"},
 							},
 						},
 					},
@@ -932,26 +933,26 @@ params:
         message: 'yet another message'
 `,
 			want: &Step{
-				Desc:   String{Val: "mydesc"},
-				Action: String{Val: "for_each"},
+				Desc:   model.String{Val: "mydesc"},
+				Action: model.String{Val: "for_each"},
 				ForEach: &ForEach{
 					Iterator: &ForEachIterator{
-						Key:        String{Val: "environment"},
-						ValuesFrom: &String{Val: "my_cel_expression"},
+						Key:        model.String{Val: "environment"},
+						ValuesFrom: &model.String{Val: "my_cel_expression"},
 					},
 					Steps: []*Step{
 						{
-							Desc:   String{Val: "print some stuff"},
-							Action: String{Val: "print"},
+							Desc:   model.String{Val: "print some stuff"},
+							Action: model.String{Val: "print"},
 							Print: &Print{
-								Message: String{Val: `Hello, {{.name}}`},
+								Message: model.String{Val: `Hello, {{.name}}`},
 							},
 						},
 						{
-							Desc:   String{Val: "another action"},
-							Action: String{Val: "print"},
+							Desc:   model.String{Val: "another action"},
+							Action: model.String{Val: "print"},
 							Print: &Print{
-								Message: String{Val: "yet another message"},
+								Message: model.String{Val: "yet another message"},
 							},
 						},
 					},
@@ -1087,7 +1088,7 @@ params:
 				return
 			}
 
-			opt := cmpopts.IgnoreTypes(&ConfigPos{}, ConfigPos{}) // don't force test authors to assert the line and column numbers
+			opt := cmpopts.IgnoreTypes(&model.ConfigPos{}, model.ConfigPos{}) // don't force test authors to assert the line and column numbers
 			if diff := cmp.Diff(got, tc.want, opt); diff != "" {
 				t.Errorf("unmarshaling didn't yield expected struct. Diff (-got +want): %s", diff)
 			}

--- a/templates/model/test/test.go
+++ b/templates/model/test/test.go
@@ -36,7 +36,7 @@ type InputValue struct {
 
 // UnmarshalYAML implements yaml.Unmarshaler.
 func (i *InputValue) UnmarshalYAML(n *yaml.Node) error {
-	return model.UnmarshalPlain(n, i, &i.Pos)
+	return model.UnmarshalPlain(n, i, &i.Pos) //nolint:wrapcheck
 }
 
 func (i *InputValue) Validate() error {
@@ -58,7 +58,7 @@ type Test struct {
 
 // UnmarshalYAML implements yaml.Unmarshaler.
 func (i *Test) UnmarshalYAML(n *yaml.Node) error {
-	return model.UnmarshalPlain(n, i, &i.Pos)
+	return model.UnmarshalPlain(n, i, &i.Pos) //nolint:wrapcheck
 }
 
 // DecodeTest unmarshals the YAML Spec from r.

--- a/templates/model/test/test.go
+++ b/templates/model/test/test.go
@@ -12,13 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package model
+package test
 
 import (
 	"errors"
 	"fmt"
 	"io"
 
+	"github.com/abcxyz/abc/templates/model"
 	"gopkg.in/yaml.v3"
 )
 
@@ -27,37 +28,37 @@ import (
 // InputValue represents one of the parsed "input" fields from the inputs.yaml file.
 type InputValue struct {
 	// Pos is the YAML file location where this object started.
-	Pos ConfigPos `yaml:"-"`
+	Pos model.ConfigPos `yaml:"-"`
 
-	Name  String `yaml:"name"`
-	Value String `yaml:"value"`
+	Name  model.String `yaml:"name"`
+	Value model.String `yaml:"value"`
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler.
 func (i *InputValue) UnmarshalYAML(n *yaml.Node) error {
-	return unmarshalPlain(n, i, &i.Pos)
+	return model.UnmarshalPlain(n, i, &i.Pos)
 }
 
 func (i *InputValue) Validate() error {
 	return errors.Join(
-		notZeroModel(&i.Pos, i.Name, "name"),
-		notZeroModel(&i.Pos, i.Value, "value"),
+		model.NotZeroModel(&i.Pos, i.Name, "name"),
+		model.NotZeroModel(&i.Pos, i.Value, "value"),
 	)
 }
 
 // Test represents a parsed test.yaml describing test configs.
 type Test struct {
 	// Pos is the YAML file location where this object started.
-	Pos ConfigPos `yaml:"-"`
+	Pos model.ConfigPos `yaml:"-"`
 
-	APIVersion String `yaml:"apiVersion"`
+	APIVersion model.String `yaml:"apiVersion"`
 
 	Inputs []*InputValue `yaml:"inputs"`
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler.
 func (i *Test) UnmarshalYAML(n *yaml.Node) error {
-	return unmarshalPlain(n, i, &i.Pos)
+	return model.UnmarshalPlain(n, i, &i.Pos)
 }
 
 // DecodeTest unmarshals the YAML Spec from r.
@@ -71,7 +72,7 @@ func DecodeTest(r io.Reader) (*Test, error) {
 	}
 
 	return &test, errors.Join(
-		oneOf(&test.Pos, test.APIVersion, []string{"cli.abcxyz.dev/v1alpha1"}, "apiVersion"),
-		validateEach(test.Inputs),
+		model.OneOf(&test.Pos, test.APIVersion, []string{"cli.abcxyz.dev/v1alpha1"}, "apiVersion"),
+		model.ValidateEach(test.Inputs),
 	)
 }

--- a/templates/model/test/test_test.go
+++ b/templates/model/test/test_test.go
@@ -12,12 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package model
+package test
 
 import (
 	"strings"
 	"testing"
 
+	"github.com/abcxyz/abc/templates/model"
 	"github.com/abcxyz/pkg/testutil"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -41,15 +42,15 @@ inputs:
 - name: 'dog_name'
   value: 'iron_dog'`,
 			want: &Test{
-				APIVersion: String{Val: "cli.abcxyz.dev/v1alpha1"},
+				APIVersion: model.String{Val: "cli.abcxyz.dev/v1alpha1"},
 				Inputs: []*InputValue{
 					{
-						Name:  String{Val: "person_name"},
-						Value: String{Val: "iron_man"},
+						Name:  model.String{Val: "person_name"},
+						Value: model.String{Val: "iron_man"},
 					},
 					{
-						Name:  String{Val: "dog_name"},
-						Value: String{Val: "iron_dog"},
+						Name:  model.String{Val: "dog_name"},
+						Value: model.String{Val: "iron_dog"},
 					},
 				},
 			},
@@ -91,7 +92,7 @@ inputs:
 				return
 			}
 
-			opt := cmpopts.IgnoreTypes(&ConfigPos{}, ConfigPos{})
+			opt := cmpopts.IgnoreTypes(&model.ConfigPos{}, model.ConfigPos{})
 			if diff := cmp.Diff(got, tc.want, opt); diff != "" {
 				t.Fatalf("unmarshaling didn't yield expected struct. Diff (-got +want): %s", diff)
 			}

--- a/templates/model/unmarshal.go
+++ b/templates/model/unmarshal.go
@@ -32,7 +32,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// unmarshalPlain unmarshals the yaml node n into the struct pointer outPtr, as
+// UnmarshalPlain unmarshals the yaml node n into the struct pointer outPtr, as
 // if it did not have an UnmarshalYAML method. This lets you still use the
 // default unmarshaling logic to populate the fields of your struct, while
 // adding custom logic before and after.
@@ -46,7 +46,7 @@ import (
 // valid fields. Unexpected fields in the yaml are treated as an error. To allow
 // extra yaml fields that don't correspond to a field of outPtr, provide their
 // names in extraYAMLFields. This allows some fields to be handled specially.
-func unmarshalPlain(n *yaml.Node, outPtr any, outPos *ConfigPos, extraYAMLFields ...string) error {
+func UnmarshalPlain(n *yaml.Node, outPtr any, outPos *ConfigPos, extraYAMLFields ...string) error {
 	fields := reflect.VisibleFields(reflect.TypeOf(outPtr).Elem())
 
 	// Calculate the set of allowed/known field names in the YAML.
@@ -83,6 +83,6 @@ func unmarshalPlain(n *yaml.Node, outPtr any, outPos *ConfigPos, extraYAMLFields
 	// to the actual output struct.
 	reflect.ValueOf(outPtr).Elem().Set(shadow.Elem())
 
-	*outPos = *yamlPos(n)
+	*outPos = *YAMLPos(n)
 	return nil
 }

--- a/templates/model/validate.go
+++ b/templates/model/validate.go
@@ -34,13 +34,13 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// Returns error if the given model's value is equal to the zero value for type T.
-func notZeroModel[T comparable](pos *ConfigPos, x valWithPos[T], fieldName string) error {
-	return notZero(pos, x.Val, fieldName)
+// NotZeroModel returns error if the given model's value is equal to the zero value for type T.
+func NotZeroModel[T comparable](pos *ConfigPos, x valWithPos[T], fieldName string) error {
+	return NotZero(pos, x.Val, fieldName)
 }
 
-// Returns error if the given value is equal to the zero value for type T.
-func notZero[T comparable](pos *ConfigPos, t T, fieldName string) error {
+// NotZero returns error if the given value is equal to the zero value for type T.
+func NotZero[T comparable](pos *ConfigPos, t T, fieldName string) error {
 	var zero T
 	if t == zero {
 		return pos.Errorf("field %q is required", fieldName)
@@ -48,8 +48,8 @@ func notZero[T comparable](pos *ConfigPos, t T, fieldName string) error {
 	return nil
 }
 
-// Returns error if the given slice is empty.
-func nonEmptySlice[T any](pos *ConfigPos, s []T, fieldName string) error {
+// NonEmptySlice returns error if the given slice is empty.
+func NonEmptySlice[T any](pos *ConfigPos, s []T, fieldName string) error {
 	if len(s) == 0 {
 		return pos.Errorf("field %q is required", fieldName)
 	}
@@ -60,24 +60,26 @@ func nonEmptySlice[T any](pos *ConfigPos, s []T, fieldName string) error {
 // or more alphanumerics.
 var validRegexGroupName = regexp.MustCompile(`[a-zA-Z][a-zA-Z0-9]*`)
 
-func isValidRegexGroupName(s String, fieldName string) error {
+// IsValidRegexGroupName returns whether the given string will be accepted by
+// the regexp library as an RE2 group name.
+func IsValidRegexGroupName(s String, fieldName string) error {
 	if !validRegexGroupName.MatchString(s.Val) {
 		return s.Pos.Errorf("subgroup name must be a letter followed by zero or more alphanumerics")
 	}
 	return nil
 }
 
-// Returns error if x.Val is not one of the given allowed choices.
-func oneOf[T comparable](pos *ConfigPos, x valWithPos[T], allowed []T, fieldName string) error {
+// OneOf returns error if x.Val is not one of the given allowed choices.
+func OneOf[T comparable](pos *ConfigPos, x valWithPos[T], allowed []T, fieldName string) error {
 	if slices.Contains(allowed, x.Val) {
 		return nil
 	}
 	return pos.Errorf("field %q value must be one of %v", fieldName, allowed)
 }
 
-// Fail if any unexpected fields are seen. The input must be a mapping/object; anything else will
-// result in an error.
-// This is a workaround for the brokenness of KnownFields in the upstream yaml lib
+// extrafields returns error if any unexpected fields are seen. The input must
+// be a mapping/object; anything else will result in an error. This is a
+// workaround for a bug in KnownFields in the upstream yaml lib
 // (https://github.com/go-yaml/yaml/issues/460).
 func extraFields(n *yaml.Node, knownFields []string) error {
 	if n.Kind != yaml.MappingNode {
@@ -101,36 +103,40 @@ func extraFields(n *yaml.Node, knownFields []string) error {
 	}
 
 	// Now we have to find the position within the YAML of the unknown field.
-	pos := yamlPos(n) // Fallback is to report position of parent node
+	pos := YAMLPos(n) // Fallback is to report position of parent node
 	// This can return a false location if some other token in the token stream
 	// happens to be equal to unknownField, but that should be rare. The
 	// consequences are not serious, just a mis-reported position.
 	for _, c := range n.Content {
 		if c.Value == unknownField {
-			pos = yamlPos(c)
+			pos = YAMLPos(c)
 		}
 	}
 
 	return pos.Errorf("unknown field name %q; valid choices are %v", unknownField, knownFields)
 }
 
-type validator interface {
+// Validator is any model struct that has a validate method. It's useful for
+// "higher order" validation functions like "validate each entry in a list."
+type Validator interface {
 	Validate() error
 }
 
-// validateUnlessNil is intended to be used in a model Validate() method.
+// ValidateUnlessNil is intended to be used in a model Validate() method.
 // Semantically it means "if this model field is present (non-nil), then
 // validate it. If not present, then skip validation." This is useful for
 // polymorphic models like Step that have many possible child types, only one
 // of which will be set.
-func validateUnlessNil(v validator) error {
+func ValidateUnlessNil(v Validator) error {
 	if v == nil || reflect.ValueOf(v).IsNil() {
 		return nil
 	}
 	return v.Validate() //nolint:wrapcheck
 }
 
-func validateEach[T validator](s []T) error {
+// ValidateEach calls Validate() on each element of the input and returns all
+// errors encountered.
+func ValidateEach[T Validator](s []T) error {
 	var merr error
 	for _, v := range s {
 		merr = errors.Join(merr, v.Validate())

--- a/templates/model/validate.go
+++ b/templates/model/validate.go
@@ -117,7 +117,7 @@ func extraFields(n *yaml.Node, knownFields []string) error {
 }
 
 // Validator is any model struct that has a validate method. It's useful for
-// "higher order" validation functions like "validate each entry in a list."
+// "higher order" validation functions like "validate each entry in a list".
 type Validator interface {
 	Validate() error
 }


### PR DESCRIPTION
We used to just have one set of YAML models for the spec file. Recently we introduced another set of models for the golden test YAML files, and another one is coming for manifest files. This refactor will help avoid the model package becoming a mess.

The new structure is one package per YAML file: one package for spec files, one for test.yaml files, and (coming soon) one for manifest files.

All of the changes here are trivial: we're only moving files, changing capitalization, and changing comments.