### PR TITLE
Rename apiVersion YAML field to api_version

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ replaced by a user-provided string. Thus "hello, world" is transformed into
 "hello, $whatever" in `main.go`.
 
 ```yaml
-apiVersion: 'cli.abcxyz.dev/v1alpha1'
+api_version: 'cli.abcxyz.dev/v1alpha1'
 kind: 'Template'
 
 desc:
@@ -257,6 +257,10 @@ steps:
         - to_replace: 'world'
           with: '{{.whomever}}'
 ```
+
+The `api_version` field currently has only one valid value,
+`cli.abcxyz.dev/v1alpha1`. The field name `api_version` may also be named
+`apiVersion` in old templates, but the newer form `api_version` is preferred.
 
 #### Template inputs
 

--- a/examples/templates/render/for_each_dynamic/spec.yaml
+++ b/examples/templates/render/for_each_dynamic/spec.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: 'cli.abcxyz.dev/v1alpha1'
+api_version: 'cli.abcxyz.dev/v1alpha1'
 kind: 'Template'
 
 desc: 'An example of for_each running an action repeatedly'

--- a/examples/templates/render/for_each_hardcoded/spec.yaml
+++ b/examples/templates/render/for_each_hardcoded/spec.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: 'cli.abcxyz.dev/v1alpha1'
+api_version: 'cli.abcxyz.dev/v1alpha1'
 kind: 'Template'
 
 desc: 'An example of for_each running an action repeatedly'

--- a/examples/templates/render/hello_jupiter/spec.yaml
+++ b/examples/templates/render/hello_jupiter/spec.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: 'cli.abcxyz.dev/v1alpha1'
+api_version: 'cli.abcxyz.dev/v1alpha1'
 kind: 'Template'
 
 desc:

--- a/examples/templates/render/inputs/spec.yaml
+++ b/examples/templates/render/inputs/spec.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: 'cli.abcxyz.dev/v1alpha1'
+api_version: 'cli.abcxyz.dev/v1alpha1'
 kind: 'Template'
 
 desc: 'An example template that demonstrates all kinds of template inputs'

--- a/examples/templates/render/print/spec.yaml
+++ b/examples/templates/render/print/spec.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: 'cli.abcxyz.dev/v1alpha1'
+api_version: 'cli.abcxyz.dev/v1alpha1'
 kind: 'Template'
 
 desc: 'An example template that demonstrates the "print" action'

--- a/t/data_migration_pipeline/spec.yaml
+++ b/t/data_migration_pipeline/spec.yaml
@@ -12,11 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: 'cli.abcxyz.dev/v1alpha1'
+api_version: 'cli.abcxyz.dev/v1alpha1'
 kind: 'Template'
 
-desc:
-  'An example template for a simple MySQL to Spanner migration pipeline.'
+desc: 'An example template for a simple MySQL to Spanner migration pipeline.'
 steps:
   - desc: 'Include some files and directories'
     action: 'include'
@@ -26,4 +25,6 @@ steps:
     action: 'print'
     params:
       message:
-        'Please go to the main.go and replace the the data model (hint text: "Your data model goes here.") and the data processing logic (hint text: "Your data parsing logic goes here.")'
+        'Please go to the main.go and replace the the data model (hint text:
+        "Your data model goes here.") and the data processing logic (hint text:
+        "Your data parsing logic goes here.")'

--- a/t/react_template/spec.yaml
+++ b/t/react_template/spec.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: 'cli.abcxyz.dev/v1alpha1'
+api_version: 'cli.abcxyz.dev/v1alpha1'
 kind: 'Template'
 desc: 'An example template using React library'
 inputs:

--- a/t/rest_server/spec.yaml
+++ b/t/rest_server/spec.yaml
@@ -12,14 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: 'cli.abcxyz.dev/v1alpha1'
+api_version: 'cli.abcxyz.dev/v1alpha1'
 kind: 'Template'
 desc: 'A template for a simple HTTP/JSON REST server.'
 inputs:
   - name: 'automation_service_account'
-    desc: 'Automation Service Account (ex: [account_name]@[project_id].iam.gserviceaccount.com)'
+    desc:
+      'Automation Service Account (ex:
+      [account_name]@[project_id].iam.gserviceaccount.com)'
   - name: 'wif_provider'
-    desc: 'Workload Identity Federation Provider (ex: projects/[project_id]/locations/global/workloadIdentityPools/[WIF_pool_name]/providers/[provider_name])'
+    desc:
+      'Workload Identity Federation Provider (ex:
+      projects/[project_id]/locations/global/workloadIdentityPools/[WIF_pool_name]/providers/[provider_name])'
   - name: 'ar_repository'
     desc: 'Artifact Registry Repository (ex: ci-images)'
   - name: 'ar_location'

--- a/templates/commands/render/render_test.go
+++ b/templates/commands/render/render_test.go
@@ -190,7 +190,7 @@ func TestRealRun(t *testing.T) {
 
 	// Many (but not all) of the subtests use this spec.yaml.
 	specContents := `
-apiVersion: 'cli.abcxyz.dev/v1alpha1'
+api_version: 'cli.abcxyz.dev/v1alpha1'
 kind: 'Template'
 desc: 'A template for the ages'
 inputs:
@@ -429,7 +429,7 @@ steps:
 			name: "plain_destination_include",
 			templateContents: map[string]string{
 				"spec.yaml": `
-apiVersion: 'cli.abcxyz.dev/v1alpha1'
+api_version: 'cli.abcxyz.dev/v1alpha1'
 kind: 'Template'
 desc: 'my template'
 steps:
@@ -468,7 +468,7 @@ steps:
 			templateContents: map[string]string{
 				"file_b.txt": "red is my favorite color",
 				"spec.yaml": `
-apiVersion: 'cli.abcxyz.dev/v1alpha1'
+api_version: 'cli.abcxyz.dev/v1alpha1'
 kind: 'Template'
 desc: 'my template'
 steps:
@@ -505,7 +505,7 @@ steps:
 		{
 			name: "for_each",
 			templateContents: map[string]string{
-				"spec.yaml": `apiVersion: 'cli.abcxyz.dev/v1alpha1'
+				"spec.yaml": `api_version: 'cli.abcxyz.dev/v1alpha1'
 kind: 'Template'
 desc: 'A template for the ages'
 steps:
@@ -527,7 +527,7 @@ steps:
 		{
 			name: "skip_input_validation",
 			templateContents: map[string]string{
-				"spec.yaml": `apiVersion: 'cli.abcxyz.dev/v1alpha1'
+				"spec.yaml": `api_version: 'cli.abcxyz.dev/v1alpha1'
 kind: 'Template'
 desc: 'My template'
 inputs:

--- a/templates/model/spec.go
+++ b/templates/model/spec.go
@@ -69,28 +69,23 @@ func (s *Spec) UnmarshalYAML(n *yaml.Node) error {
 		return err
 	}
 
-	shim := &struct {
+	avShim := struct {
 		OldStyle String `yaml:"apiVersion"`
 		NewStyle String `yaml:"api_version"`
 	}{}
-
-	if err := n.Decode(shim); err != nil {
+	if err := n.Decode(&avShim); err != nil {
 		return err
 	}
 
-	m := map[string]any{}
-	n.Decode(m)
-	_ = m
-
-	if shim.NewStyle.Val != "" && shim.OldStyle.Val != "" {
-		return shim.OldStyle.Pos.Errorf("must not set both apiVersion and api_version, please use api_version only")
+	if avShim.NewStyle.Val != "" && avShim.OldStyle.Val != "" {
+		return avShim.OldStyle.Pos.Errorf("must not set both apiVersion and api_version, please use api_version only")
 	}
-	if shim.NewStyle.Val != "" {
-		s.APIVersion = shim.NewStyle
+	if avShim.NewStyle.Val != "" {
+		s.APIVersion = avShim.NewStyle
 		return nil
 	}
-	if shim.OldStyle.Val != "" {
-		s.APIVersion = shim.OldStyle
+	if avShim.OldStyle.Val != "" {
+		s.APIVersion = avShim.OldStyle
 	}
 	return nil
 }

--- a/templates/model/spec_test.go
+++ b/templates/model/spec_test.go
@@ -35,7 +35,7 @@ func TestSpecUnmarshal(t *testing.T) {
 	}{
 		{
 			name: "simple_template_should_succeed",
-			in: `apiVersion: 'cli.abcxyz.dev/v1alpha1'
+			in: `api_version: 'cli.abcxyz.dev/v1alpha1'
 kind: 'Template'
 
 desc: 'A simple template that just prints and exits'
@@ -73,6 +73,64 @@ steps:
 			},
 		},
 		{
+			name: "apiVersion_camel_case",
+			in: `api_version: 'cli.abcxyz.dev/v1alpha1'
+kind: 'Template'
+
+desc: 'A simple template that just prints and exits'
+inputs:
+- name: 'person_name'
+  desc: 'An optional name of a person to greet'
+  default: 'default value'
+
+steps:
+- desc: 'Print a message'
+  action: 'print'
+  params:
+    message: 'Hello, {{.or .person_name "World"}}'`,
+			want: &Spec{
+				APIVersion: String{Val: "cli.abcxyz.dev/v1alpha1"},
+				Kind:       String{Val: "Template"},
+
+				Desc: String{Val: "A simple template that just prints and exits"},
+				Inputs: []*Input{
+					{
+						Name:    String{Val: "person_name"},
+						Desc:    String{Val: "An optional name of a person to greet"},
+						Default: &String{Val: "default value"},
+					},
+				},
+				Steps: []*Step{
+					{
+						Desc:   String{Val: "Print a message"},
+						Action: String{Val: "print"},
+						Print: &Print{
+							Message: String{Val: `Hello, {{.or .person_name "World"}}`},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "api_version_both_forms",
+			in: `api_version: 'cli.abcxyz.dev/v1alpha1'
+apiVersion: 'cli.abcxyz.dev/v1alpha1'
+kind: 'Template'
+
+desc: 'A simple template that just prints and exits'
+inputs:
+- name: 'person_name'
+  desc: 'An optional name of a person to greet'
+  default: 'default value'
+
+steps:
+- desc: 'Print a message'
+  action: 'print'
+  params:
+    message: 'Hello, {{.or .person_name "World"}}'`,
+			wantUnmarshalErr: "must not set both apiVersion and api_version, please use api_version only",
+		},
+		{
 			name: "validation_of_children_should_occur_and_fail",
 			in: `desc: 'A simple template that just prints and exits'
 inputs:
@@ -88,7 +146,7 @@ steps:
 		{
 			name: "check_required_fields",
 			in:   "inputs:",
-			wantValidateErr: `at line 1 column 1: field "apiVersion" value must be one of [cli.abcxyz.dev/v1alpha1]
+			wantValidateErr: `at line 1 column 1: field "api_version" value must be one of [cli.abcxyz.dev/v1alpha1]
 at line 1 column 1: field "kind" value must be one of [Template]
 at line 1 column 1: field "desc" is required
 at line 1 column 1: field "steps" is required`,
@@ -96,7 +154,7 @@ at line 1 column 1: field "steps" is required`,
 
 		{
 			name: "unknown_field_should_fail",
-			in: `apiVersion: 'cli.abcxyz.dev/v1alpha1'
+			in: `api_version: 'cli.abcxyz.dev/v1alpha1'
 kind: 'Template'
 
 desc: 'A simple template that just prints and exits'

--- a/templates/model/test.go
+++ b/templates/model/test.go
@@ -50,7 +50,7 @@ type Test struct {
 	// Pos is the YAML file location where this object started.
 	Pos ConfigPos `yaml:"-"`
 
-	APIVersion String `yaml:"apiVersion"`
+	APIVersion String `yaml:"api_version"`
 
 	Inputs []*InputValue `yaml:"inputs"`
 }
@@ -71,7 +71,7 @@ func DecodeTest(r io.Reader) (*Test, error) {
 	}
 
 	return &test, errors.Join(
-		oneOf(&test.Pos, test.APIVersion, []string{"cli.abcxyz.dev/v1alpha1"}, "apiVersion"),
+		oneOf(&test.Pos, test.APIVersion, []string{"cli.abcxyz.dev/v1alpha1"}, "api_version"),
 		validateEach(test.Inputs),
 	)
 }

--- a/templates/model/test_test.go
+++ b/templates/model/test_test.go
@@ -34,7 +34,7 @@ func TestTestUnmarshal(t *testing.T) {
 	}{
 		{
 			name: "simple_test_should_succeed",
-			in: `apiVersion: 'cli.abcxyz.dev/v1alpha1'
+			in: `api_version: 'cli.abcxyz.dev/v1alpha1'
 inputs:
 - name: 'person_name'
   value: 'iron_man'
@@ -56,14 +56,14 @@ inputs:
 		},
 		{
 			name: "missing_field_should_fail",
-			in: `apiVersion: 'cli.abcxyz.dev/v1alpha1'
+			in: `api_version: 'cli.abcxyz.dev/v1alpha1'
 inputs:
 - name: 'person_name'`,
 			wantErr: `at line 3 column 3: field "value" is required`,
 		},
 		{
 			name: "unknown_field_should_fail",
-			in: `apiVersion: 'cli.abcxyz.dev/v1alpha1'
+			in: `api_version: 'cli.abcxyz.dev/v1alpha1'
 inputs:
 - name: 'person_name'
   value: 'iron_man'
@@ -75,7 +75,7 @@ inputs:
 			in: `inputs:
 - name: 'person_name'
   value: 'iron_man'`,
-			wantErr: `at line 1 column 1: field "apiVersion" value must be one of [cli.abcxyz.dev/v1alpha1]`,
+			wantErr: `at line 1 column 1: field "api_version" value must be one of [cli.abcxyz.dev/v1alpha1]`,
 		},
 	}
 


### PR DESCRIPTION
This is the only field that's camel case, and it should be snake case for consistency with the other fields. It was a mistake in the first place for it to be capitalized differently (oops 🫤).

For backward compatibility, we'll still accept `apiVersion`, but we'll prefer `api_version`.