### PR TITLE
Rollback breaking apiVersion->api_version change

### DIFF
--- a/examples/templates/render/for_each_dynamic/spec.yaml
+++ b/examples/templates/render/for_each_dynamic/spec.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-api_version: 'cli.abcxyz.dev/v1alpha1'
+apiVersion: 'cli.abcxyz.dev/v1alpha1'
 kind: 'Template'
 
 desc: 'An example of for_each running an action repeatedly'

--- a/examples/templates/render/for_each_hardcoded/spec.yaml
+++ b/examples/templates/render/for_each_hardcoded/spec.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-api_version: 'cli.abcxyz.dev/v1alpha1'
+apiVersion: 'cli.abcxyz.dev/v1alpha1'
 kind: 'Template'
 
 desc: 'An example of for_each running an action repeatedly'

--- a/examples/templates/render/hello_jupiter/spec.yaml
+++ b/examples/templates/render/hello_jupiter/spec.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-api_version: 'cli.abcxyz.dev/v1alpha1'
+apiVersion: 'cli.abcxyz.dev/v1alpha1'
 kind: 'Template'
 
 desc:

--- a/examples/templates/render/inputs/spec.yaml
+++ b/examples/templates/render/inputs/spec.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-api_version: 'cli.abcxyz.dev/v1alpha1'
+apiVersion: 'cli.abcxyz.dev/v1alpha1'
 kind: 'Template'
 
 desc: 'An example template that demonstrates all kinds of template inputs'

--- a/examples/templates/render/print/spec.yaml
+++ b/examples/templates/render/print/spec.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-api_version: 'cli.abcxyz.dev/v1alpha1'
+apiVersion: 'cli.abcxyz.dev/v1alpha1'
 kind: 'Template'
 
 desc: 'An example template that demonstrates the "print" action'

--- a/t/data_migration_pipeline/spec.yaml
+++ b/t/data_migration_pipeline/spec.yaml
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-api_version: 'cli.abcxyz.dev/v1alpha1'
+apiVersion: 'cli.abcxyz.dev/v1alpha1'
 kind: 'Template'
 
-desc: 'An example template for a simple MySQL to Spanner migration pipeline.'
+desc:
+  'An example template for a simple MySQL to Spanner migration pipeline.'
 steps:
   - desc: 'Include some files and directories'
     action: 'include'
@@ -25,6 +26,4 @@ steps:
     action: 'print'
     params:
       message:
-        'Please go to the main.go and replace the the data model (hint text:
-        "Your data model goes here.") and the data processing logic (hint text:
-        "Your data parsing logic goes here.")'
+        'Please go to the main.go and replace the the data model (hint text: "Your data model goes here.") and the data processing logic (hint text: "Your data parsing logic goes here.")'

--- a/t/react_template/spec.yaml
+++ b/t/react_template/spec.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-api_version: 'cli.abcxyz.dev/v1alpha1'
+apiVersion: 'cli.abcxyz.dev/v1alpha1'
 kind: 'Template'
 desc: 'An example template using React library'
 inputs:

--- a/t/rest_server/spec.yaml
+++ b/t/rest_server/spec.yaml
@@ -12,18 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-api_version: 'cli.abcxyz.dev/v1alpha1'
+apiVersion: 'cli.abcxyz.dev/v1alpha1'
 kind: 'Template'
 desc: 'A template for a simple HTTP/JSON REST server.'
 inputs:
   - name: 'automation_service_account'
-    desc:
-      'Automation Service Account (ex:
-      [account_name]@[project_id].iam.gserviceaccount.com)'
+    desc: 'Automation Service Account (ex: [account_name]@[project_id].iam.gserviceaccount.com)'
   - name: 'wif_provider'
-    desc:
-      'Workload Identity Federation Provider (ex:
-      projects/[project_id]/locations/global/workloadIdentityPools/[WIF_pool_name]/providers/[provider_name])'
+    desc: 'Workload Identity Federation Provider (ex: projects/[project_id]/locations/global/workloadIdentityPools/[WIF_pool_name]/providers/[provider_name])'
   - name: 'ar_repository'
     desc: 'Artifact Registry Repository (ex: ci-images)'
   - name: 'ar_location'


### PR DESCRIPTION
This caused an outage, which is currently happening. People cannot use the existing online templates with their locally-installed abc cli. We should have bumped the schema version, which would have required people to update their abc CLI.