### PR TITLE
Advise the user to update if api_version is unknown

### DIFF
--- a/templates/model/manifest/manifest.go
+++ b/templates/model/manifest/manifest.go
@@ -69,7 +69,7 @@ func (m *Manifest) Validate() error {
 	// Inputs and OutputHashes can legally be empty, since a template doesn't
 	// necessarily have these.
 	return errors.Join(
-		model.IsKnownSchemaVersion(&m.Pos, m.APIVersion, "api_version"),
+		model.IsKnownAPIVersion(&m.Pos, m.APIVersion, "api_version"),
 		model.NotZeroModel(&m.Pos, m.TemplateLocation, "template_location"),
 		model.NotZeroModel(&m.Pos, m.TemplateDirhash, "template_dirhash"),
 		model.ValidateEach(m.Inputs),

--- a/templates/model/spec/spec.go
+++ b/templates/model/spec/spec.go
@@ -85,7 +85,7 @@ func (s *Spec) UnmarshalYAML(n *yaml.Node) error {
 // Validate implements Validator.
 func (s *Spec) Validate() error {
 	return errors.Join(
-		model.IsKnownSchemaVersion(&s.Pos, s.APIVersion, "api_version"),
+		model.IsKnownAPIVersion(&s.Pos, s.APIVersion, "api_version"),
 		model.OneOf(&s.Pos, s.Kind, []string{"Template"}, "kind"),
 		model.NotZeroModel(&s.Pos, s.Desc, "desc"),
 		model.NonEmptySlice(&s.Pos, s.Steps, "steps"),

--- a/templates/model/test/test.go
+++ b/templates/model/test/test.go
@@ -57,7 +57,7 @@ type Test struct {
 // Validate implements model.Validator.
 func (t *Test) Validate() error {
 	return errors.Join(
-		model.IsKnownSchemaVersion(&t.Pos, t.APIVersion, "api_version"),
+		model.IsKnownAPIVersion(&t.Pos, t.APIVersion, "api_version"),
 		model.ValidateEach(t.Inputs),
 	)
 }

--- a/templates/model/test/test_test.go
+++ b/templates/model/test/test_test.go
@@ -76,7 +76,7 @@ inputs:
 			in: `inputs:
 - name: 'person_name'
   value: 'iron_man'`,
-			wantErr: `at line 1 column 1: field "api_version" value must be one of [cli.abcxyz.dev/v1alpha1]`,
+			wantErr: `at line 1 column 1: field "api_version" value was "" but must be one of`,
 		},
 	}
 

--- a/templates/model/validate.go
+++ b/templates/model/validate.go
@@ -79,19 +79,22 @@ func OneOf[T comparable](parentPos *ConfigPos, x valWithPos[T], allowed []T, fie
 		pos = parentPos
 	}
 
-	return pos.Errorf("field %q value must be one of %v", fieldName, allowed)
+	return pos.Errorf(`field %q value was "%v" but must be one of %v`, fieldName, x.Val, allowed)
 }
 
-var schemaVersions = []string{"cli.abcxyz.dev/v1alpha1"}
+var apiVersions = []string{"cli.abcxyz.dev/v1alpha1"}
 
-// IsKnownSchemaVersion returns error if the given string is not one of the
+// IsKnownAPIVersion returns error if the given string is not one of the
 // accepted abc schema versions.
 //
 // parentPos is the position of the yaml object that contains the api_version
 // field. We need this because if the api_version field is missing from the
 // YAML, then we won't have any position information for it.
-func IsKnownSchemaVersion(parentPos *ConfigPos, apiVersion String, fieldName string) error {
-	return OneOf(parentPos, apiVersion, schemaVersions, fieldName)
+func IsKnownAPIVersion(parentPos *ConfigPos, apiVersion String, fieldName string) error {
+	if err := OneOf(parentPos, apiVersion, apiVersions, fieldName); err != nil {
+		return fmt.Errorf("%w; you might need to upgrade your abc CLI. See https://github.com/abcxyz/abc/#installation", err)
+	}
+	return nil
 }
 
 // extrafields returns error if any unexpected fields are seen. The input must

--- a/templates/model/validate_test.go
+++ b/templates/model/validate_test.go
@@ -1,0 +1,64 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"testing"
+
+	"github.com/abcxyz/pkg/testutil"
+)
+
+func TestIsKnownAPIVersion(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		in      string
+		wantErr []string
+	}{
+		{
+			name: "v1alpha1_is_accepted",
+			in:   "cli.abcxyz.dev/v1alpha1",
+		},
+		{
+			name: "v2_is_unknown",
+			in:   "cli.abcxyz.dev/v2",
+			wantErr: []string{
+				`field "api_version" value was "cli.abcxyz.dev/v2" but must be one of`,
+				`you might need to upgrade your abc CLI. See https://github.com/abcxyz/abc/#installation`,
+			},
+		},
+		{
+			name:    "empty_rejected",
+			in:      "",
+			wantErr: []string{`field "api_version" value was "" but must be one of`},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := IsKnownAPIVersion(nil, String{Val: tc.in}, "api_version")
+			for _, wantErr := range tc.wantErr {
+				if diff := testutil.DiffErrString(got, wantErr); diff != "" {
+					t.Fatal(diff)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
We anticipate adding new features and YAML fields. When a template uses these new fields but the user is using an old binary, then there will be error about the api_version being unrecognized. This error might be confusing, so now we'll also tell the user to go update their binary.