### PR TITLE
Add git CLI wrappers for cloning and listing tags

### DIFF
--- a/templates/common/exec.go
+++ b/templates/common/exec.go
@@ -1,0 +1,28 @@
+package common
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+)
+
+// Exec is a wrapper around exec.CommandContext that captures stdout and stderr
+// as strings. The input args must have len>=1.
+//
+// If the command fails, the error message will include the contents of stdout
+// and stderr. This saves boilerplate in the caller.
+func Exec(ctx context.Context, args ...string) (stdout, stderr string, _ error) {
+	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
+	stdoutBuf := &bytes.Buffer{}
+	stderrBuf := &bytes.Buffer{}
+	cmd.Stdout = stdoutBuf
+	cmd.Stderr = stderrBuf
+
+	err := cmd.Run()
+	stdout, stderr = stdoutBuf.String(), stderrBuf.String()
+	if err != nil {
+		err = fmt.Errorf("exec of %v failed: %w\nstdout: %s\nstderr: %s", args, err, cmd.Stdout, cmd.Stderr)
+	}
+	return stdout, stderr, err
+}

--- a/templates/common/exec.go
+++ b/templates/common/exec.go
@@ -19,7 +19,13 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
+	"time"
 )
+
+// DefaultRunTimeout is how long we'll wait for commands to run in the case
+// where the context doesn't already have a timeout. This was chosen
+// arbitrarily.
+const DefaultRunTimeout = time.Minute
 
 // Run is a wrapper around exec.CommandContext and Run() that captures stdout
 // and stderr as strings. The input args must have len>=1.
@@ -30,9 +36,17 @@ import (
 // This doesn't execute a shell (unless of course args[0] is the name of a shell
 // binary).
 //
+// If the incoming context doesn't already have a timeout, then a default
+// timeout will be added (see DefaultRunTimeout).
+//
 // If the command fails, the error message will include the contents of stdout
 // and stderr. This saves boilerplate in the caller.
 func Run(ctx context.Context, args ...string) (stdout, stderr string, _ error) {
+	if _, ok := ctx.Deadline(); !ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, DefaultRunTimeout)
+		defer cancel()
+	}
 	cmd := exec.CommandContext(ctx, args[0], args[1:]...) //nolint:gosec // exec'ing the input args is fundamentally the whole point
 
 	stdoutBuf := &bytes.Buffer{}

--- a/templates/common/exec.go
+++ b/templates/common/exec.go
@@ -1,3 +1,17 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package common
 
 import (
@@ -13,7 +27,7 @@ import (
 // If the command fails, the error message will include the contents of stdout
 // and stderr. This saves boilerplate in the caller.
 func Exec(ctx context.Context, args ...string) (stdout, stderr string, _ error) {
-	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
+	cmd := exec.CommandContext(ctx, args[0], args[1:]...) //nolint:gosec // exec'ing the input args is fundamentally the whole point
 	stdoutBuf := &bytes.Buffer{}
 	stderrBuf := &bytes.Buffer{}
 	cmd.Stdout = stdoutBuf

--- a/templates/common/exec_test.go
+++ b/templates/common/exec_test.go
@@ -51,10 +51,10 @@ func TestExec(t *testing.T) {
 		},
 		{
 			name:        "windows_simple_stderr",
-			args:        []string{"dir", "/nonexistent"},
+			args:        []string{"ipconfig", "/nonexistent"},
 			windowsOnly: true,
-			wantErr:     "exec of [dir /nonexistent] failed",
-			wantStderr:  `Parameter format not correct - "nonexistent"`,
+			wantErr:     "exec of [ipconfig /nonexistent] failed",
+			wantStderr:  `Error: unrecognized or incomplete command line`,
 		},
 		{
 			name:    "nonexistent_cmd",

--- a/templates/common/exec_test.go
+++ b/templates/common/exec_test.go
@@ -59,7 +59,7 @@ func TestExec(t *testing.T) {
 		{
 			name:    "nonexistent_cmd",
 			args:    []string{"nonexistent-cmd"},
-			wantErr: `exec: "nonexistent-cmd": executable file not found in $PATH`,
+			wantErr: `exec: "nonexistent-cmd": executable file not found`,
 		},
 		{
 			name:    "timeout",

--- a/templates/common/exec_test.go
+++ b/templates/common/exec_test.go
@@ -1,3 +1,17 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package common
 
 import (

--- a/templates/common/exec_test.go
+++ b/templates/common/exec_test.go
@@ -53,7 +53,6 @@ func TestExec(t *testing.T) {
 			name:        "windows_simple_stderr",
 			args:        []string{"cmd", "/c", `echo hello 1>&2`},
 			windowsOnly: true,
-			wantErr:     "exec of [cmd /c echo hello 1>&2] failed",
 			wantStderr:  "hello",
 		},
 		{

--- a/templates/common/exec_test.go
+++ b/templates/common/exec_test.go
@@ -51,10 +51,10 @@ func TestExec(t *testing.T) {
 		},
 		{
 			name:        "windows_simple_stderr",
-			args:        []string{"ipconfig", "/nonexistent"},
+			args:        []string{"cmd", "/c", `echo hello 1>&2`},
 			windowsOnly: true,
-			wantErr:     "exec of [ipconfig /nonexistent] failed",
-			wantStderr:  `Error: unrecognized or incomplete command line`,
+			wantErr:     "exec of [cmd /c echo hello 1>&2] failed",
+			wantStderr:  "hello",
 		},
 		{
 			name:    "nonexistent_cmd",
@@ -96,7 +96,7 @@ func TestExec(t *testing.T) {
 			}
 
 			if len(tc.wantStderr) > 0 && !strings.Contains(stderr, tc.wantStderr) {
-				t.Errorf("got stderr:\n%q\nbut wanted stderr to contain: %q", stdout, tc.wantStderr)
+				t.Errorf("got stderr:\n%q\nbut wanted stderr to contain: %q", stderr, tc.wantStderr)
 			}
 		})
 	}

--- a/templates/common/exec_test.go
+++ b/templates/common/exec_test.go
@@ -1,0 +1,76 @@
+package common
+
+import (
+	"context"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/abcxyz/pkg/testutil"
+)
+
+func TestExec(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name           string
+		args           []string
+		windowsOnly    bool
+		nonWindowsOnly bool
+		wantStdout     string
+		wantStderr     string
+		wantErr        string
+	}{
+		{
+			name:       "multi_args",
+			args:       []string{"echo", "hello", "world"},
+			wantStdout: "hello world",
+		},
+		{
+			name:           "nonwindows_simple_stderr",
+			args:           []string{"ls", "--nonexistent"},
+			nonWindowsOnly: true,
+			wantErr:        "exec of [ls --nonexistent] failed",
+			wantStderr:     "ls: unrecognized option",
+		},
+		{
+			name:        "windows_simple_stderr",
+			args:        []string{"dir", "/nonexistent"},
+			windowsOnly: true,
+			wantErr:     "exec of [dir /nonexistent] failed",
+			wantStderr:  `Parameter format not correct - "nonexistent"`,
+		},
+		{
+			name:    "nonexistent_cmd",
+			args:    []string{"nonexistent-cmd"},
+			wantErr: `exec: "nonexistent-cmd": executable file not found in $PATH`,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if tc.nonWindowsOnly && runtime.GOOS == "windows" {
+				return
+			}
+			if tc.windowsOnly && runtime.GOOS != "windows" {
+				return
+			}
+
+			ctx := context.Background()
+			stdout, stderr, err := Exec(ctx, tc.args...)
+			if diff := testutil.DiffErrString(err, tc.wantErr); diff != "" {
+				t.Fatal(diff)
+			}
+			if len(tc.wantStdout) > 0 && !strings.Contains(stdout, tc.wantStdout) {
+				t.Errorf("got stdout:\n%q\nbut wanted stdout to contain: %q", stdout, tc.wantStdout)
+			}
+
+			if len(tc.wantStderr) > 0 && !strings.Contains(stderr, tc.wantStderr) {
+				t.Errorf("got stderr:\n%q\nbut wanted stderr to contain: %q", stdout, tc.wantStderr)
+			}
+		})
+	}
+}

--- a/templates/common/git/git.go
+++ b/templates/common/git/git.go
@@ -1,0 +1,98 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package git
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// Clone checks out the given branch or tag from the given repo. It uses the git
+// CLI already installed on the system.
+//
+// To optimize storage and bandwidth, the full git history is not fetched.
+//
+// "remote" may be any format accepted by git, such as
+// https://github.com/abcxyz/abc.git or git@github.com:abcxyz/abc.git .
+func Clone(ctx context.Context, remote, branchOrTag, outDir string) error {
+	cmd := exec.CommandContext(ctx, "git", "clone", "--depth", "1", "--branch", branchOrTag, remote, outDir)
+	cmd.Stderr = &bytes.Buffer{}
+	cmd.Stdout = &bytes.Buffer{}
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("git exec of %v failed: %w\nstdout: %s\nstderr: %s", cmd.Args, err, cmd.Stdout, cmd.Stderr)
+	}
+
+	// Make sure there are no symlinks.
+	if err := filepath.WalkDir(outDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err // There was some filesystem error while crawling.
+		}
+		if path == filepath.Join(outDir, ".git") {
+			return nil // skip crawling the git directory to save time.
+		}
+		fi, err := os.Lstat(path)
+		if err != nil {
+			return fmt.Errorf("Lstat(): %w", err)
+		}
+		if fi.Mode()&os.ModeSymlink == 0 {
+			return nil
+		}
+		relPathToSymlink, err := filepath.Rel(outDir, path)
+		if err != nil {
+			return fmt.Errorf("Rel(): %w", err)
+		}
+		return fmt.Errorf("a symlink was found in %q at %q; for security reasons and to support windows, git repos containing symlinks are not allowed", remote, relPathToSymlink)
+	}); err != nil {
+		return err //nolint:wrapcheck
+	}
+
+	return nil
+}
+
+// Tags looks up the tags in the given remote repo.
+//
+// "remote" may be any format accepted by git, such as
+// https://github.com/abcxyz/abc.git or git@github.com:abcxyz/abc.git .
+func Tags(ctx context.Context, remote string) ([]string, error) {
+	cmd := exec.CommandContext(ctx, "git", "ls-remote", "--tags", remote)
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	cmd.Stdout, cmd.Stderr = stdout, stderr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("git exec of %v failed: %w\nstdout: %s\nstderr: %s", cmd.Args, err, cmd.Stdout, cmd.Stderr)
+	}
+	lineScanner := bufio.NewScanner(stdout)
+	var tags []string
+	for lineScanner.Scan() {
+		line := lineScanner.Text()
+		fields := strings.Fields(line)
+		prefixedTag := fields[len(fields)-1]
+		if strings.HasSuffix(prefixedTag, "^{}") {
+			// Skip the weird extra duplicate tags ending with "^{}" that git
+			// prints for some reason.
+			continue
+		}
+		tag := strings.TrimPrefix(prefixedTag, "refs/tags/")
+		tags = append(tags, tag)
+	}
+
+	return tags, nil
+}

--- a/templates/common/git/git.go
+++ b/templates/common/git/git.go
@@ -22,13 +22,9 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/abcxyz/abc/templates/common"
 )
-
-// How long to wait for git operations. This was chosen arbitrarily.
-var gitTimeout = time.Minute
 
 // Clone checks out the given branch or tag from the given repo. It uses the git
 // CLI already installed on the system.
@@ -38,8 +34,6 @@ var gitTimeout = time.Minute
 // "remote" may be any format accepted by git, such as
 // https://github.com/abcxyz/abc.git or git@github.com:abcxyz/abc.git .
 func Clone(ctx context.Context, remote, branchOrTag, outDir string) error {
-	ctx, cancel := context.WithTimeout(ctx, gitTimeout)
-	defer cancel()
 	_, _, err := common.Run(ctx, "git", "clone", "--depth", "1", "--branch", branchOrTag, remote, outDir)
 	if err != nil {
 		return err //nolint:wrapcheck
@@ -91,9 +85,6 @@ func findSymlinks(dir string) ([]string, error) {
 // "remote" may be any format accepted by git, such as
 // https://github.com/abcxyz/abc.git or git@github.com:abcxyz/abc.git .
 func Tags(ctx context.Context, remote string) ([]string, error) {
-	ctx, cancel := context.WithTimeout(ctx, gitTimeout)
-	defer cancel()
-
 	stdout, _, err := common.Run(ctx, "git", "ls-remote", "--tags", remote)
 	if err != nil {
 		return nil, err //nolint:wrapcheck

--- a/templates/common/git/git_test.go
+++ b/templates/common/git/git_test.go
@@ -218,7 +218,11 @@ func TestFindSymlinks(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if !slices.Equal(got, tc.want) {
+			want := make([]string, 0, len(tc.want))
+			for _, w := range tc.want {
+				want = append(want, filepath.FromSlash(w))
+			}
+			if !slices.Equal(got, want) {
 				t.Errorf("got %v, want %v", got, tc.want)
 			}
 		})

--- a/templates/common/git/git_test.go
+++ b/templates/common/git/git_test.go
@@ -1,0 +1,144 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package git
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/abcxyz/pkg/testutil"
+	"golang.org/x/exp/slices"
+)
+
+// To actually run the tests in this file, you'll need to set this environment
+// variable.
+//
+// For example:
+//
+//	$ ABC_TEST_NON_HERMETIC=true go test ./...
+const envName = "ABC_TEST_NON_HERMETIC"
+
+func skipUnlessEnvEnabled(t *testing.T) {
+	t.Helper()
+	if os.Getenv(envName) == "" {
+		t.Skipf("skipping test because env var %q isn't set", envName)
+	}
+}
+
+func TestTags(t *testing.T) {
+	skipUnlessEnvEnabled(t)
+
+	t.Parallel()
+
+	ctx := context.Background()
+	tags, err := Tags(ctx, "https://github.com/abcxyz/abc.git")
+	if err != nil {
+		t.Error(err)
+	}
+	wantTag := "v0.2.0"
+	if !slices.Contains(tags, wantTag) {
+		t.Errorf("got versions %v, but wanted a list of versions containing %v", tags, wantTag)
+	}
+}
+
+func TestClone(t *testing.T) {
+	skipUnlessEnvEnabled(t)
+
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		remote      string
+		branchOrTag string
+		wantErr     string
+	}{
+		{
+			name:        "clone_tag",
+			remote:      "https://github.com/abcxyz/abc.git",
+			branchOrTag: "v0.2.0",
+		},
+		{
+			name:        "alternative_tag_format_fails",
+			remote:      "https://github.com/abcxyz/abc.git",
+			branchOrTag: "refs/tags/v0.2.0",
+			wantErr:     "refs/tags/v0.2.0 not found",
+		},
+		{
+			name:        "clone_branch",
+			remote:      "https://github.com/abcxyz/abc.git",
+			branchOrTag: "main",
+		},
+		{
+			name:        "alternative_branch_format_fails",
+			remote:      "https://github.com/abcxyz/abc.git",
+			branchOrTag: "refs/heads/v0.2.0",
+			wantErr:     "refs/heads/v0.2.0 not found",
+		},
+		{
+			name:        "long_commit_not_supported",
+			remote:      "https://github.com/abcxyz/abc.git",
+			branchOrTag: "b6687471f424efd125f9a3e156c68ed78b9d3b47",
+			wantErr:     "Could not find remote branch b6687471f424efd125f9a3e156c68ed78b9d3b47 to clone",
+		},
+		{
+			name:        "short_commit_not_supported",
+			remote:      "https://github.com/abcxyz/abc.git",
+			branchOrTag: "b668747",
+			wantErr:     "Could not find remote branch b668747 to clone",
+		},
+		{
+			name:    "nonexistent_remote",
+			remote:  "https://example.com/foo/bar",
+			wantErr: "repository 'https://example.com/foo/bar/' not found",
+		},
+		{
+			name:        "symlinks_forbidden",
+			remote:      "https://github.com/abcxyz/abc.git",
+			branchOrTag: "drevell/forbidden-symlink-for-test",
+			wantErr:     `a symlink was found in "https://github.com/abcxyz/abc.git" at "example-symlink"`,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			outDir := t.TempDir()
+			err := Clone(ctx, tc.remote, tc.branchOrTag, outDir)
+			if diff := testutil.DiffErrString(err, tc.wantErr); diff != "" {
+				t.Fatal(diff)
+			}
+			if tc.wantErr != "" {
+				return
+			}
+
+			// We check for an arbitrary file to ensure that the clone really happened.
+			wantFile := "README.md"
+			_, err = os.Stat(filepath.Join(outDir, wantFile))
+			if err != nil {
+				if errors.Is(err, os.ErrNotExist) {
+					t.Fatalf("git clone seemed to work but the output didn't contain %q, something weird happened", wantFile)
+				}
+				t.Error(err)
+			}
+		})
+	}
+}

--- a/templates/common/git/git_test.go
+++ b/templates/common/git/git_test.go
@@ -199,7 +199,7 @@ func TestFindSymlinks(t *testing.T) {
 
 			for _, r := range tc.regularFiles {
 				path := filepath.Join(tempDir, filepath.FromSlash(r))
-				if err := os.WriteFile(path, []byte("my-contents"), 0o744); err != nil {
+				if err := os.WriteFile(path, []byte("my-contents"), 0o644); err != nil { //nolint:gosec
 					t.Fatal(err)
 				}
 			}


### PR DESCRIPTION
This is PR 1/N for supporting semantic-versioned templates. Eventually, we'll replace the go-getter library with our own git CLI wrapper (see internal design doc).

The operations we need to support are:
  - Download a template (git clone)
  - Discover what versions are available (git ls-remote); versions are git tags