### PR TITLE
Untangle tech debt re file separators in tests

### DIFF
--- a/templates/commands/goldentest/record_test.go
+++ b/templates/commands/goldentest/record_test.go
@@ -59,9 +59,9 @@ kind: 'GoldenTest'`
 				"testdata/golden/test/test.yaml": testYaml,
 			},
 			expectedGoldenContent: map[string]string{
-				filepath.Join("test", "test.yaml"):  testYaml,
-				filepath.Join("test/data", "a.txt"): "file A content",
-				filepath.Join("test/data", "b.txt"): "file B content",
+				"test/test.yaml":  testYaml,
+				"test/data/a.txt": "file A content",
+				"test/data/b.txt": "file B content",
 			},
 		},
 		{
@@ -73,10 +73,10 @@ kind: 'GoldenTest'`
 				"testdata/golden/test2/test.yaml": testYaml,
 			},
 			expectedGoldenContent: map[string]string{
-				filepath.Join("test1", "test.yaml"):  testYaml,
-				filepath.Join("test1/data", "a.txt"): "file A content",
-				filepath.Join("test2", "test.yaml"):  testYaml,
-				filepath.Join("test2/data", "a.txt"): "file A content",
+				"test1/test.yaml":  testYaml,
+				"test1/data/a.txt": "file A content",
+				"test2/test.yaml":  testYaml,
+				"test2/data/a.txt": "file A content",
 			},
 		},
 		{
@@ -88,8 +88,8 @@ kind: 'GoldenTest'`
 				"testdata/golden/test/data/outdated.txt": "outdated file",
 			},
 			expectedGoldenContent: map[string]string{
-				filepath.Join("test", "test.yaml"):  testYaml,
-				filepath.Join("test/data", "a.txt"): "file A content",
+				"test/test.yaml":  testYaml,
+				"test/data/a.txt": "file A content",
 			},
 		},
 		{
@@ -101,8 +101,8 @@ kind: 'GoldenTest'`
 				"testdata/golden/test/data/a.txt": "old content",
 			},
 			expectedGoldenContent: map[string]string{
-				filepath.Join("test", "test.yaml"):  testYaml,
-				filepath.Join("test/data", "a.txt"): "new content",
+				"test/test.yaml":  testYaml,
+				"test/data/a.txt": "new content",
 			},
 		},
 		{
@@ -114,8 +114,8 @@ kind: 'GoldenTest'`
 				"testdata/golden/test/unexpected_file.txt": "oh",
 			},
 			expectedGoldenContent: map[string]string{
-				filepath.Join("test", "test.yaml"):  testYaml,
-				filepath.Join("test/data", "a.txt"): "file A content",
+				"test/test.yaml":  testYaml,
+				"test/data/a.txt": "file A content",
 			},
 		},
 		{
@@ -128,9 +128,9 @@ kind: 'GoldenTest'`
 				"testdata/golden/test2/test.yaml": testYaml,
 			},
 			expectedGoldenContent: map[string]string{
-				filepath.Join("test1", "test.yaml"):  testYaml,
-				filepath.Join("test1/data", "a.txt"): "file A content",
-				filepath.Join("test2", "test.yaml"):  testYaml,
+				"test1/test.yaml":  testYaml,
+				"test1/data/a.txt": "file A content",
+				"test2/test.yaml":  testYaml,
 			},
 		},
 		{
@@ -142,8 +142,8 @@ kind: 'GoldenTest'`
 				"testdata/golden/test2/test.yaml": "broken yaml",
 			},
 			expectedGoldenContent: map[string]string{
-				filepath.Join("test1", "test.yaml"): "broken yaml",
-				filepath.Join("test2", "test.yaml"): "broken yaml",
+				"test1/test.yaml": "broken yaml",
+				"test2/test.yaml": "broken yaml",
 			},
 			wantErr: "failed to parse golden test",
 		},
@@ -157,9 +157,7 @@ kind: 'GoldenTest'`
 
 			tempDir := t.TempDir()
 
-			if err := common.WriteAllDefaultMode(tempDir, tc.filesContent); err != nil {
-				t.Fatal(err)
-			}
+			common.WriteAllDefaultMode(t, tempDir, tc.filesContent)
 
 			ctx := logging.WithLogger(context.Background(), logging.TestLogger(t))
 			args := []string{"--location", tempDir}

--- a/templates/commands/goldentest/test_funcs_test.go
+++ b/templates/commands/goldentest/test_funcs_test.go
@@ -129,9 +129,7 @@ kind: 'GoldenTest'`
 
 			tempDir := t.TempDir()
 
-			if err := common.WriteAllDefaultMode(tempDir, tc.filesContent); err != nil {
-				t.Fatal(err)
-			}
+			common.WriteAllDefaultMode(t, tempDir, tc.filesContent)
 
 			ctx := context.Background()
 			got, err := parseTestCases(ctx, tempDir, tc.testName)
@@ -189,9 +187,7 @@ func TestClearTestDir(t *testing.T) {
 
 			tempDir := t.TempDir()
 
-			if err := common.WriteAllDefaultMode(tempDir, tc.filesContent); err != nil {
-				t.Fatal(err)
-			}
+			common.WriteAllDefaultMode(t, tempDir, tc.filesContent)
 
 			if err := clearTestDir(tempDir); err != nil {
 				t.Fatal(err)
@@ -249,9 +245,9 @@ steps:
 				"testdata/golden/test/test.yaml": "yaml",
 			},
 			expectedGoldenContent: map[string]string{
-				"test.yaml":                    "yaml",
-				filepath.Join("data", "a.txt"): "file A content",
-				filepath.Join("data", "b.txt"): "file B content",
+				"test.yaml":  "yaml",
+				"data/a.txt": "file A content",
+				"data/b.txt": "file B content",
 			},
 		},
 		{
@@ -278,9 +274,9 @@ steps:
 				"testdata/golden/test/test.yaml": "yaml",
 			},
 			expectedGoldenContent: map[string]string{
-				"test.yaml":                    "yaml",
-				filepath.Join("data", "a.txt"): "file A content",
-				filepath.Join("data", "b.txt"): "file B content",
+				"test.yaml":  "yaml",
+				"data/a.txt": "file A content",
+				"data/b.txt": "file B content",
 			},
 		},
 	}
@@ -293,9 +289,7 @@ steps:
 
 			tempDir := t.TempDir()
 
-			if err := common.WriteAllDefaultMode(tempDir, tc.filesContent); err != nil {
-				t.Fatal(err)
-			}
+			common.WriteAllDefaultMode(t, tempDir, tc.filesContent)
 
 			err := renderTestCase(tempDir, tempDir, tc.testCase)
 			if err != nil {

--- a/templates/commands/render/action_append_test.go
+++ b/templates/commands/render/action_append_test.go
@@ -163,13 +163,8 @@ func TestActionAppend(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			// Convert to OS-specific paths
-			convertKeysToPlatformPaths(tc.want)
-
 			scratchDir := t.TempDir()
-			if err := common.WriteAllDefaultMode(scratchDir, tc.initialContents); err != nil {
-				t.Fatal(err)
-			}
+			common.WriteAllDefaultMode(t, scratchDir, tc.initialContents)
 
 			sr := &spec.Append{
 				Paths: modelStrings(tc.paths),

--- a/templates/commands/render/action_gotemplate_test.go
+++ b/templates/commands/render/action_gotemplate_test.go
@@ -161,13 +161,8 @@ func TestActionGoTemplate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			// Convert to OS-specific paths
-			convertKeysToPlatformPaths(tc.want)
-
 			scratchDir := t.TempDir()
-			if err := common.WriteAllDefaultMode(scratchDir, tc.initContents); err != nil {
-				t.Fatal(err)
-			}
+			common.WriteAllDefaultMode(t, scratchDir, tc.initContents)
 
 			ctx := context.Background()
 			sp := &stepParams{

--- a/templates/commands/render/action_include_test.go
+++ b/templates/commands/render/action_include_test.go
@@ -447,10 +447,6 @@ func TestActionInclude(t *testing.T) {
 			ctx := logging.WithLogger(context.Background(), logging.TestLogger(t))
 
 			// Convert to OS-specific paths
-			convertKeysToPlatformPaths(
-				tc.templateContents,
-				tc.wantScratchContents,
-			)
 			toPlatformPaths(tc.wantIncludedFromDest)
 
 			tempDir := t.TempDir()
@@ -458,14 +454,10 @@ func TestActionInclude(t *testing.T) {
 			scratchDir := filepath.Join(tempDir, scratchDirNamePart)
 			destDir := filepath.Join(tempDir, "dest")
 
-			if err := common.WriteAll(templateDir, tc.templateContents); err != nil {
-				t.Fatal(err)
-			}
+			common.WriteAll(t, templateDir, tc.templateContents)
 
 			// For testing "include from destination"
-			if err := common.WriteAll(destDir, tc.destDirContents); err != nil {
-				t.Fatal(err)
-			}
+			common.WriteAll(t, destDir, tc.destDirContents)
 
 			sp := &stepParams{
 				flags: &RenderFlags{

--- a/templates/commands/render/action_regexnamelookup_test.go
+++ b/templates/commands/render/action_regexnamelookup_test.go
@@ -189,13 +189,8 @@ func TestActionRegexNameLookup(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			// Convert to OS-specific paths
-			convertKeysToPlatformPaths(tc.want)
-
 			scratchDir := t.TempDir()
-			if err := common.WriteAllDefaultMode(scratchDir, tc.initContents); err != nil {
-				t.Fatal(err)
-			}
+			common.WriteAllDefaultMode(t, scratchDir, tc.initContents)
 
 			ctx := context.Background()
 			sp := &stepParams{

--- a/templates/commands/render/action_regexreplace_test.go
+++ b/templates/commands/render/action_regexreplace_test.go
@@ -396,13 +396,8 @@ gamma`,
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			// Convert to OS-specific paths
-			convertKeysToPlatformPaths(tc.want)
-
 			scratchDir := t.TempDir()
-			if err := common.WriteAllDefaultMode(scratchDir, tc.initContents); err != nil {
-				t.Fatal(err)
-			}
+			common.WriteAllDefaultMode(t, scratchDir, tc.initContents)
 
 			ctx := context.Background()
 			sp := &stepParams{

--- a/templates/commands/render/action_stringreplace_test.go
+++ b/templates/commands/render/action_stringreplace_test.go
@@ -228,13 +228,8 @@ func TestActionStringReplace(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			// Convert to OS-specific paths
-			convertKeysToPlatformPaths(tc.want)
-
 			scratchDir := t.TempDir()
-			if err := common.WriteAllDefaultMode(scratchDir, tc.initialContents); err != nil {
-				t.Fatal(err)
-			}
+			common.WriteAllDefaultMode(t, scratchDir, tc.initialContents)
 
 			sr := &spec.StringReplace{
 				Paths:        modelStrings(tc.paths),

--- a/templates/commands/render/action_test.go
+++ b/templates/commands/render/action_test.go
@@ -219,13 +219,8 @@ func TestWalkAndModify(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			// Convert to OS-specific paths
-			convertKeysToPlatformPaths(tc.initialContents, tc.want)
-
 			scratchDir := t.TempDir()
-			if err := common.WriteAllDefaultMode(scratchDir, tc.initialContents); err != nil {
-				t.Fatal(err)
-			}
+			common.WriteAllDefaultMode(t, scratchDir, tc.initialContents)
 
 			sp := &stepParams{
 				fs: &errorFS{
@@ -575,17 +570,7 @@ func TestCopyRecursive(t *testing.T) {
 			toDir := filepath.Join(tempDir, "to_dir")
 			backupDir := filepath.Join(tempDir, "backups")
 
-			// Convert to OS-specific paths
-			convertKeysToPlatformPaths(
-				tc.srcDirContents,
-				tc.dstDirInitialContents,
-				tc.want,
-				tc.wantBackups,
-			)
-
-			if err := common.WriteAll(fromDir, tc.srcDirContents); err != nil {
-				t.Fatal(err)
-			}
+			common.WriteAll(t, fromDir, tc.srcDirContents)
 
 			from := fromDir
 			to := toDir
@@ -593,9 +578,7 @@ func TestCopyRecursive(t *testing.T) {
 				from = filepath.Join(fromDir, tc.suffix)
 				to = filepath.Join(toDir, tc.suffix)
 			}
-			if err := common.WriteAll(toDir, tc.dstDirInitialContents); err != nil {
-				t.Fatal(err)
-			}
+			common.WriteAll(t, toDir, tc.dstDirInitialContents)
 			fs := &errorFS{
 				FS: &common.RealFS{},
 
@@ -1057,10 +1040,7 @@ func TestProcessGlobs(t *testing.T) {
 
 			// pre-populate dir contents
 			tempDir := t.TempDir()
-			convertKeysToPlatformPaths(tc.dirContents) // Convert to OS-specific paths
-			if err := common.WriteAll(tempDir, tc.dirContents); err != nil {
-				t.Fatal(err)
-			}
+			common.WriteAll(t, tempDir, tc.dirContents)
 
 			ctx := context.Background()
 			gotPaths, err := processGlobs(ctx, tc.paths, tempDir)

--- a/templates/commands/render/render_test.go
+++ b/templates/commands/render/render_test.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -590,27 +591,16 @@ steps:
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			// Convert to OS-specific paths
-			convertKeysToPlatformPaths(
-				tc.templateContents,
-				tc.existingDestContents,
-				tc.wantBackupContents,
-				tc.wantDestContents,
-				tc.wantScratchContents,
-				tc.wantTemplateContents,
-			)
-
 			tempDir := t.TempDir()
 			dest := filepath.Join(tempDir, "dest")
-			if err := common.WriteAllDefaultMode(dest, tc.existingDestContents); err != nil {
-				t.Fatal(err)
-			}
+			common.WriteAllDefaultMode(t, dest, tc.existingDestContents)
 			tempDirNamer := func(namePart string) (string, error) {
 				return filepath.Join(tempDir, namePart), nil
 			}
 			backupDir := filepath.Join(tempDir, "backups")
 			rfs := &common.RealFS{}
 			fg := &fakeGetter{
+				t:      t,
 				err:    tc.getterErr,
 				output: tc.templateContents,
 			}
@@ -681,13 +671,13 @@ steps:
 }
 
 // Since os.MkdirTemp adds an extra random token, we strip it back out to get
-// determistic results.
+// determistic results. Input map keys should use forward slash separator.
 func stripFirstPathElem(m map[string]string) map[string]string {
 	out := map[string]string{}
 	for k, v := range m {
 		// Panic in the case where k has no slashes; this is just a test helper.
-		elems := strings.Split(k, string(filepath.Separator))
-		newKey := filepath.Join(elems[1:]...)
+		elems := strings.Split(k, "/")
+		newKey := path.Join(elems[1:]...)
 		out[newKey] = v
 	}
 	return out
@@ -1550,6 +1540,7 @@ func (e *errorFS) WriteFile(name string, data []byte, perm os.FileMode) error {
 }
 
 type fakeGetter struct {
+	t         *testing.T
 	gotSource string
 	output    map[string]string
 	err       error
@@ -1560,23 +1551,8 @@ func (f *fakeGetter) Get(ctx context.Context, req *getter.Request) (*getter.GetR
 	if f.err != nil {
 		return nil, f.err
 	}
-	if err := common.WriteAllDefaultMode(req.Dst, f.output); err != nil {
-		return nil, err
-	}
+	common.WriteAllDefaultMode(f.t, req.Dst, f.output)
 	return &getter.GetResult{Dst: req.Dst}, nil
-}
-
-// convertKeysToPlatformPaths is a helper that converts the keys in all of the
-// given maps to a platform-specific file path. The maps are modified in place.
-func convertKeysToPlatformPaths[T any](maps ...map[string]T) {
-	for _, m := range maps {
-		for k, v := range m {
-			if newKey := filepath.FromSlash(k); newKey != k {
-				m[newKey] = v
-				delete(m, k)
-			}
-		}
-	}
 }
 
 // toPlatformPaths converts each element of each input slice from a/b/c style


### PR DESCRIPTION
There are a bunch of tests that deal with converting file path separators, but this can all be cleaned way up by moving it down into the helper functions that are already being used.

Also, make `WriteAll*` call `t.Fatalf` instead of returning error, to be consistent with `LoadAll*` and save boilerplate in tests.