### PR TITLE
Add a sourceParser that reads a template from a local dir

### DIFF
--- a/templates/commands/render/action_regexreplace.go
+++ b/templates/commands/render/action_regexreplace.go
@@ -129,7 +129,7 @@ var subGroupExtractRegex = regexp.MustCompile(`(?P<dollars>\$+)` + // some numbe
 	`[{]?` + // then optionally has a brace character
 	`[0-9]+`) // and then has some number of decimal digits (as a capturing group)
 
-// Given a string that will be passed to Regexp.Expand(), make sure it that it
+// Given a string that will be passed to Regexp.Expand(), make sure that it
 // doesn't use any numbered subgroup expansions (like ${1}). Named subgroup
 // expansions are allowed (like ${mygroup}). This is a policy decision because
 // we consider the numbered form to be harder to read.

--- a/templates/commands/render/templatesource/localsource.go
+++ b/templates/commands/render/templatesource/localsource.go
@@ -1,0 +1,75 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package render implements the template rendering related subcommands.
+package templatesource
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+
+	"github.com/abcxyz/abc/templates/common"
+	"github.com/abcxyz/pkg/logging"
+)
+
+// localSourceParser implements sourceParser for reading a template from a local
+// directory.
+type localSourceParser struct{}
+
+func (l *localSourceParser) sourceParse(ctx context.Context, src, protocol string) (templateDownloader, bool, error) {
+	logger := logging.FromContext(ctx).With("logger", "localSourceParser.sourceParse")
+
+	// Design decision: we could try to look at src and guess whether it looks
+	// like a local directory name, but that's going to have false positives and
+	// false negatives (e.g. you have a directory named "github.com/..."). Instead,
+	// we'll just check if the given path actually exists, and if so, then treat
+	// src as a local directory name.
+	//
+	// This sourceParser should run after the sourceParser that recognizes remote
+	// git repos, so this code won't run if the source looks like a git repo.
+
+	_, err := os.Stat(src)
+	if err != nil {
+		_, isPathError := err.(*fs.PathError) //nolint:errorlint // we'd like to use errors.Is(), but it doesn't work with *fs.PathError
+		if errors.Is(err, fs.ErrNotExist) || errors.Is(err, fs.ErrInvalid) || isPathError {
+			logger.WarnContext(ctx, "won't treat src as a local path because that path doesn't exist", "src", src)
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("Stat(): %w", err)
+	}
+
+	logger.InfoContext(ctx, "Treating src as a local path", "src", src)
+
+	return &localDownloader{
+		srcPath: src, // Uses OS-native file separator
+	}, true, nil
+}
+
+type localDownloader struct {
+	srcPath string // uses OS-native file separator
+}
+
+func (l *localDownloader) Download(ctx context.Context, outDir string) error {
+	logger := logging.FromContext(ctx).With("logger", "localTemplateSource.Download")
+
+	logger.DebugContext(ctx, "copying local template source", "srcPath", l.srcPath, "outDir", outDir)
+	return common.CopyRecursive(ctx, nil, &common.CopyParams{ //nolint:wrapcheck
+		SrcRoot: l.srcPath,
+		DstRoot: outDir,
+		RFS:     &common.RealFS{},
+	})
+}

--- a/templates/commands/render/templatesource/localsource.go
+++ b/templates/commands/render/templatesource/localsource.go
@@ -44,7 +44,10 @@ func (l *localSourceParser) sourceParse(ctx context.Context, src, protocol strin
 
 	_, err := os.Stat(src)
 	if err != nil {
-		_, isPathError := err.(*fs.PathError) //nolint:errorlint // we'd like to use errors.Is(), but it doesn't work with *fs.PathError
+		// We'd like to use errors.Is(), but it doesn't work with *fs.PathError
+		// because fs.PathError has unpredictable field contents.
+		_, isPathError := err.(*fs.PathError) //nolint:errorlint
+
 		if errors.Is(err, fs.ErrNotExist) || errors.Is(err, fs.ErrInvalid) || isPathError {
 			logger.WarnContext(ctx, "won't treat src as a local path because that path doesn't exist", "src", src)
 			return nil, false, nil

--- a/templates/commands/render/templatesource/source.go
+++ b/templates/commands/render/templatesource/source.go
@@ -66,8 +66,9 @@ var realSourceParsers = []sourceParser{
 		versionExpansion:     `${version}`,
 	},
 
+	&localSourceParser{}, // Handles a template source that's a local directory.
+
 	// More sourceParsers are coming imminently for:
-	//  - local template directories
 	//  - go-getter-style git URLs
 }
 
@@ -89,5 +90,5 @@ func parseSource(ctx context.Context, srcParsers []sourceParser, source, protoco
 			return downloader, nil
 		}
 	}
-	return nil, fmt.Errorf("template source %q isn't something that we know how to download", source)
+	return nil, fmt.Errorf(`template source %q isn't a valid template name or doesn't exist; examples of valid names are: "github.com/myorg/myrepo/subdir@v1.2.3", "github.com/myorg/myrepo/subdir@latest", "./my-local-directory"`, source)
 }


### PR DESCRIPTION
This is part of the PR series that adds semantic versioning of templates. As part of that, we're replacing the go-getter library with our own template downloader.