### PR TITLE
Support some go-getter URLs as template sources

### DIFF
--- a/templates/commands/render/templatesource/source.go
+++ b/templates/commands/render/templatesource/source.go
@@ -68,8 +68,30 @@ var realSourceParsers = []sourceParser{
 
 	&localSourceParser{}, // Handles a template source that's a local directory.
 
-	// More sourceParsers are coming imminently for:
-	//  - go-getter-style git URLs
+	&gitSourceParser{
+		// This source parser recognizes template sources like
+		// github.com/abcxyz/abc.git//t/react_template?ref=latest.
+		// This is the old template location format from abc <=0.2
+		// when we used the go-getter library. We don't attempt to
+		// handle all the cases supported by go-getter, just the
+		// ones that we know people use.
+		re: regexp.MustCompile(
+			`^` + // Anchor the start, must match the entire input
+				`(?P<host>[a-zA-Z0-9_.-]+)` +
+				`/` +
+				`(?P<org>[a-zA-Z0-9_-]+)` +
+				`/` +
+				`(?P<repo>[a-zA-Z0-9_-]+)` +
+				`\.git` +
+				`(//(?P<subdir>[^?]*))?` + // Optional subdir
+				`(\?ref=(?P<version>[a-zA-Z0-9_/.-]+))?` + // optional ?ref=branch_or_tag
+				`$`), // Anchor the end, must match the entire input
+		httpsRemoteExpansion: `https://${host}/${org}/${repo}.git`,
+		sshRemoteExpansion:   `git@${host}:${org}/${repo}.git`,
+		subdirExpansion:      `${subdir}`,
+		versionExpansion:     `${version}`,
+		warning:              `go-getter style URL support will be removed in mid-2024, please use the newer format instead, eg github.com/myorg/myrepo[/subdir]@v1.2.3 (or @latest)`,
+	},
 }
 
 // parseSource maps the input template source to a particular kind of source

--- a/templates/commands/render/templatesource/source_test.go
+++ b/templates/commands/render/templatesource/source_test.go
@@ -150,6 +150,72 @@ func TestParseSource(t *testing.T) {
 				tagser:  &realTagser{},
 			},
 		},
+		{
+			name: "go_getter_with_ref_and_subdirs",
+			in:   "github.com/myorg/myrepo.git//sub/dir?ref=latest",
+			want: &gitDownloader{
+				remote:  "https://github.com/myorg/myrepo.git",
+				subdir:  "sub/dir",
+				version: "latest",
+				cloner:  &realCloner{},
+				tagser:  &realTagser{},
+			},
+		},
+		{
+			name: "go_getter_with_ref_no_subdirs",
+			in:   "github.com/myorg/myrepo.git?ref=latest",
+			want: &gitDownloader{
+				remote:  "https://github.com/myorg/myrepo.git",
+				subdir:  "",
+				version: "latest",
+				cloner:  &realCloner{},
+				tagser:  &realTagser{},
+			},
+		},
+		{
+			name: "go_getter_no_ref_no_subdirs",
+			in:   "github.com/myorg/myrepo.git",
+			want: &gitDownloader{
+				remote:  "https://github.com/myorg/myrepo.git",
+				subdir:  "",
+				version: "",
+				cloner:  &realCloner{},
+				tagser:  &realTagser{},
+			},
+		},
+		{
+			name: "go_getter_no_ref_with_subdirs",
+			in:   "github.com/myorg/myrepo.git//sub/dir",
+			want: &gitDownloader{
+				remote:  "https://github.com/myorg/myrepo.git",
+				subdir:  "sub/dir",
+				version: "",
+				cloner:  &realCloner{},
+				tagser:  &realTagser{},
+			},
+		},
+		{
+			name: "go_getter_no_ref_single_subdir",
+			in:   "github.com/myorg/myrepo.git//subdir",
+			want: &gitDownloader{
+				remote:  "https://github.com/myorg/myrepo.git",
+				subdir:  "subdir",
+				version: "",
+				cloner:  &realCloner{},
+				tagser:  &realTagser{},
+			},
+		},
+		{
+			name: "go_getter_semver_ref",
+			in:   "github.com/myorg/myrepo.git?ref=v1.2.3",
+			want: &gitDownloader{
+				remote:  "https://github.com/myorg/myrepo.git",
+				subdir:  "",
+				version: "v1.2.3",
+				cloner:  &realCloner{},
+				tagser:  &realTagser{},
+			},
+		},
 	}
 
 	for _, tc := range cases { //nolint:paralleltest


### PR DESCRIPTION
Although we're replacing go-getter with our own git integration, we still want to accept go-getter-style template source locations so we don't break our users' workflows. We do log a warning suggesting that they change to the new format though.