### PR TITLE
Use errors.As over type assertion

### DIFF
--- a/templates/commands/render/templatesource/localsource.go
+++ b/templates/commands/render/templatesource/localsource.go
@@ -44,11 +44,9 @@ func (l *localSourceParser) sourceParse(ctx context.Context, src, protocol strin
 
 	_, err := os.Stat(src)
 	if err != nil {
-		// We'd like to use errors.Is(), but it doesn't work with *fs.PathError
-		// because fs.PathError has unpredictable field contents.
-		_, isPathError := err.(*fs.PathError) //nolint:errorlint
+		var pathErrPtr *fs.PathError
 
-		if errors.Is(err, fs.ErrNotExist) || errors.Is(err, fs.ErrInvalid) || isPathError {
+		if errors.Is(err, fs.ErrNotExist) || errors.Is(err, fs.ErrInvalid) || errors.As(err, &pathErrPtr) {
 			logger.WarnContext(ctx, "won't treat src as a local path because that path doesn't exist", "src", src)
 			return nil, false, nil
 		}


### PR DESCRIPTION
When I wrote the old code I wasn't aware of how to use errors.As() correctly.