### PR TITLE
When --keep-temp-dirs=true, log dir locations at level warn instead of debug

### DIFF
--- a/templates/commands/render/render.go
+++ b/templates/commands/render/render.go
@@ -647,7 +647,7 @@ func (c *Command) copyTemplate(ctx context.Context, rp *runParams) (string, erro
 func (c *Command) maybeRemoveTempDirs(ctx context.Context, fs common.FS, tempDirs ...string) error {
 	logger := logging.FromContext(ctx)
 	if c.flags.KeepTempDirs {
-		logger.DebugContext(ctx, "keeping temporary directories due to --keep-temp-dirs",
+		logger.WarnContext(ctx, "keeping temporary directories due to --keep-temp-dirs",
 			"paths", tempDirs)
 		return nil
 	}


### PR DESCRIPTION
Why? Because if the user passed --keep-temp-dirs, they definitely care about the directory paths, and we shouldn't make them set ABC_LOG_LEVEL=debug and sort through a huge pile of irrelevant logs. Also, it makes sense to "warn" the user that we're cluttering their filesystem.