### PR TITLE
Decrease log severity when source is not local dir

### DIFF
--- a/templates/commands/render/templatesource/localsource.go
+++ b/templates/commands/render/templatesource/localsource.go
@@ -47,7 +47,7 @@ func (l *localSourceParser) sourceParse(ctx context.Context, src, protocol strin
 		var pathErrPtr *fs.PathError
 
 		if errors.Is(err, fs.ErrNotExist) || errors.Is(err, fs.ErrInvalid) || errors.As(err, &pathErrPtr) {
-			logger.WarnContext(ctx, "won't treat src as a local path because that path doesn't exist", "src", src)
+			logger.DebugContext(ctx, "won't treat src as a local path because that path doesn't exist", "src", src)
 			return nil, false, nil
 		}
 		return nil, false, fmt.Errorf("Stat(): %w", err)


### PR DESCRIPTION
This message currently shows a warning every time someone renders a template using the go-getter location syntax. This is falsely alarming for users.