### PR TITLE
Return a more helpful error when the subdirectory looks wrong

### DIFF
--- a/templates/commands/render/templatesource/git.go
+++ b/templates/commands/render/templatesource/git.go
@@ -150,7 +150,7 @@ func (g *gitDownloader) Download(ctx context.Context, outDir string) error {
 		if errors.Is(err, os.ErrNotExist) {
 			return fmt.Errorf(`the repo %q at tag %q doesn't contain a subdirectory named %q; it's possible that the template exists in the "main" branch but is not part of the release %q`, g.remote, branchOrTag, subdir, branchOrTag)
 		}
-		return err
+		return err //nolint:wrapcheck // Stat() returns a decently informative error
 	}
 	if !fi.IsDir() {
 		return fmt.Errorf("the path %q is not a directory", subdir)

--- a/templates/commands/render/templatesource/git.go
+++ b/templates/commands/render/templatesource/git.go
@@ -148,7 +148,7 @@ func (g *gitDownloader) Download(ctx context.Context, outDir string) error {
 	fi, err := os.Stat(subdirToCopy)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return fmt.Errorf("the repo %q at tag %q doesn't contain a subdirectory named %q", g.remote, branchOrTag, subdir)
+			return fmt.Errorf(`the repo %q at tag %q doesn't contain a subdirectory named %q; it's possible that the template exists in the "main" branch but is not part of the release %q`, g.remote, branchOrTag, subdir, branchOrTag)
 		}
 		return err
 	}

--- a/templates/commands/render/templatesource/git.go
+++ b/templates/commands/render/templatesource/git.go
@@ -16,6 +16,7 @@ package templatesource
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -142,6 +143,17 @@ func (g *gitDownloader) Download(ctx context.Context, outDir string) error {
 
 	if err := g.cloner.Clone(ctx, g.remote, branchOrTag, tmpDir); err != nil {
 		return fmt.Errorf("Clone(): %w", err)
+	}
+
+	fi, err := os.Stat(subdirToCopy)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("the repo %q at tag %q doesn't contain a subdirectory named %q", g.remote, branchOrTag, subdir)
+		}
+		return err
+	}
+	if !fi.IsDir() {
+		return fmt.Errorf("the path %q is not a directory", subdir)
 	}
 
 	logger.DebugContext(ctx, "cloned repo", "remote", g.remote, "branchOrTag", branchOrTag)

--- a/templates/commands/render/templatesource/git_test.go
+++ b/templates/commands/render/templatesource/git_test.go
@@ -126,6 +126,38 @@ func TestGitDownloader_Download(t *testing.T) {
 			wantErr: `must not contain ".."`,
 			want:    map[string]string{},
 		},
+		{
+			name: "missing_subdir",
+			dl: &gitDownloader{
+				remote:  "fake-remote",
+				subdir:  "nonexistent",
+				version: "v1.2.3",
+				cloner: &fakeCloner{
+					t:               t,
+					out:             basicFiles,
+					wantRemote:      "fake-remote",
+					wantBranchOrTag: "v1.2.3",
+				},
+			},
+			wantErr: `doesn't contain a subdirectory named "nonexistent"`,
+			want:    map[string]string{},
+		},
+		{
+			name: "file_instead_of_dir",
+			dl: &gitDownloader{
+				remote:  "fake-remote",
+				subdir:  "file1.txt",
+				version: "v1.2.3",
+				cloner: &fakeCloner{
+					t:               t,
+					out:             basicFiles,
+					wantRemote:      "fake-remote",
+					wantBranchOrTag: "v1.2.3",
+				},
+			},
+			wantErr: "is not a directory",
+			want:    map[string]string{},
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
This needs to be a particularly helpful error message because users will see this in the case where they try to use a template that's committed to main but not part of a tagged release. I recently had this happen to me and was confused for a bit.