### PR TITLE
Allow parallelizing ParseSource tests

### DIFF
--- a/templates/commands/render/templatesource/git.go
+++ b/templates/commands/render/templatesource/git.go
@@ -30,6 +30,8 @@ import (
 	"golang.org/x/exp/slices"
 )
 
+var _ sourceParser = (*gitSourceParser)(nil)
+
 // gitSourceParser implements sourceParser for downloading templates from a
 // remote git repo.
 type gitSourceParser struct {
@@ -60,7 +62,7 @@ type gitSourceParser struct {
 	warning string
 }
 
-func (g *gitSourceParser) sourceParse(ctx context.Context, src, protocol string) (Downloader, bool, error) {
+func (g *gitSourceParser) sourceParse(ctx context.Context, cwd, src, protocol string) (Downloader, bool, error) {
 	logger := logging.FromContext(ctx).With("logger", "gitSourceParser.sourceParse")
 
 	match := g.re.FindStringSubmatchIndex(src)

--- a/templates/commands/render/templatesource/source.go
+++ b/templates/commands/render/templatesource/source.go
@@ -17,6 +17,7 @@ package templatesource
 import (
 	"context"
 	"fmt"
+	"os"
 	"regexp"
 )
 
@@ -26,7 +27,7 @@ type sourceParser interface {
 	// sourceParse attempts to parse the given src. If the src is recognized as
 	// being downloadable by this sourceParser, then it returns true, along with
 	// a downloader that can download that template.
-	sourceParse(ctx context.Context, src, protocol string) (Downloader, bool, error)
+	sourceParse(ctx context.Context, cwd, src, protocol string) (Downloader, bool, error)
 }
 
 // A Downloader is returned by a sourceParser, and offers the ability to
@@ -86,17 +87,17 @@ var realSourceParsers = []sourceParser{
 	},
 }
 
-// ParseSource maps the input template source to a particular kind of source
-// (e.g. git) and returns a downloader that will download that source.
+// parseSourceWithCwd maps the input template source to a particular kind of
+// source (e.g. git) and returns a downloader that will download that source.
 //
-// source is a template location, like "github.com/foo/bar@v1.2.3". protocol
-// is the value of the --protocol flag, like "https".
+// source is a template location, like "github.com/foo/bar@v1.2.3". protocol is
+// the value of the --protocol flag, like "https".
 //
 // A list of sourceParsers is accepted as input for the purpose of testing,
 // rather than hardcoding the real list of sourceParsers.
-func ParseSource(ctx context.Context, source, protocol string) (Downloader, error) {
+func parseSourceWithCwd(ctx context.Context, cwd, source, protocol string) (Downloader, error) {
 	for _, sp := range realSourceParsers {
-		downloader, ok, err := sp.sourceParse(ctx, source, protocol)
+		downloader, ok, err := sp.sourceParse(ctx, cwd, source, protocol)
 		if err != nil {
 			return nil, err //nolint:wrapcheck
 		}
@@ -105,4 +106,14 @@ func ParseSource(ctx context.Context, source, protocol string) (Downloader, erro
 		}
 	}
 	return nil, fmt.Errorf(`template source %q isn't a valid template name or doesn't exist; examples of valid names are: "github.com/myorg/myrepo/subdir@v1.2.3", "github.com/myorg/myrepo/subdir@latest", "./my-local-directory"`, source)
+}
+
+// ParseSource is the same as [ParseSourceWithWorkingDir], but it uses the
+// current working directory [os.Getwd] as the base path.
+func ParseSource(ctx context.Context, source, protocol string) (Downloader, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get current working directory: %w", err)
+	}
+	return parseSourceWithCwd(ctx, cwd, source, protocol)
 }


### PR DESCRIPTION
This removes the global dependency on $PWD.

- Refs https://github.com/abcxyz/abc/pull/266