### PR TITLE
Implement "canonical template sources"

### DIFF
--- a/templates/commands/render/action_include.go
+++ b/templates/commands/render/action_include.go
@@ -16,10 +16,8 @@ package render
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io/fs"
-	"os"
 	"path/filepath"
 
 	"github.com/abcxyz/abc/templates/common"
@@ -85,7 +83,7 @@ func includePath(ctx context.Context, inc *spec.IncludePath, sp *stepParams) err
 		}
 
 		if _, err := sp.fs.Stat(absSrc); err != nil {
-			if errors.Is(err, os.ErrNotExist) {
+			if common.IsStatNotExistErr(err) {
 				return p.Pos.Errorf("include path doesn't exist: %q", p.Val)
 			}
 			return fmt.Errorf("Stat(): %w", err)

--- a/templates/commands/render/render.go
+++ b/templates/commands/render/render.go
@@ -152,7 +152,7 @@ func (c *Command) realRun(ctx context.Context, rp *runParams) (outErr error) {
 		outErr = errors.Join(outErr, err)
 	}()
 
-	templateDir, err := c.copyTemplate(ctx, rp)
+	_, templateDir, err := c.copyTemplate(ctx, rp)
 	if templateDir != "" { // templateDir might be set even if there's an error
 		tempDirs = append(tempDirs, templateDir)
 	}
@@ -638,28 +638,31 @@ func loadSpecFile(ctx context.Context, fs common.FS, templateDir string) (*spec.
 // Downloads the template and returns the name of the temp directory where it
 // was saved. If error is returned, then the returned directory name may or may
 // not exist, and may or may not be empty.
-func (c *Command) copyTemplate(ctx context.Context, rp *runParams) (string, error) {
+func (c *Command) copyTemplate(ctx context.Context, rp *runParams) (*templatesource.ParsedSource, string, error) {
 	logger := logging.FromContext(ctx).With("logger", "copyTemplate")
 
 	templateDir, err := rp.fs.MkdirTemp(rp.tempDirBase, templateDirNamePart)
 	if err != nil {
-		return "", fmt.Errorf("failed to create temporary directory to use as template directory: %w", err)
+		return nil, "", fmt.Errorf("failed to create temporary directory to use as template directory: %w", err)
 	}
 	logger.DebugContext(ctx, "created temporary template directory",
 		"path", templateDir)
 
-	downloader, err := templatesource.ParseSource(ctx, c.flags.Source, c.flags.GitProtocol)
+	parsedSource, err := templatesource.ParseSource(ctx, &templatesource.ParseSourceParams{
+		Source:      c.flags.Source,
+		GitProtocol: c.flags.GitProtocol,
+	})
 	if err != nil {
-		return templateDir, err //nolint:wrapcheck
+		return nil, templateDir, err //nolint:wrapcheck
 	}
-	logger.DebugContext(ctx, "template location parse successful as", "type", reflect.TypeOf(downloader).String())
+	logger.DebugContext(ctx, "template location parse successful as", "type", reflect.TypeOf(parsedSource.Downloader).String())
 
-	if err := downloader.Download(ctx, templateDir); err != nil {
-		return templateDir, err //nolint:wrapcheck
+	if err := parsedSource.Downloader.Download(ctx, templateDir); err != nil {
+		return nil, templateDir, err //nolint:wrapcheck
 	}
 	logger.DebugContext(ctx, "copied source template temporary directory", "source", c.flags.Source, "destination", templateDir)
 
-	return templateDir, nil
+	return parsedSource, templateDir, nil
 }
 
 // Calls RemoveAll on each temp directory. A nonexistent directory is not an error.
@@ -683,7 +686,7 @@ func (c *Command) maybeRemoveTempDirs(ctx context.Context, fs common.FS, tempDir
 func destOK(fs fs.StatFS, dest string) error {
 	fi, err := fs.Stat(dest)
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
+		if common.IsStatNotExistErr(err) {
 			return nil
 		}
 		return fmt.Errorf("os.Stat(%s): %w", dest, err)

--- a/templates/commands/render/render.go
+++ b/templates/commands/render/render.go
@@ -635,9 +635,12 @@ func loadSpecFile(ctx context.Context, fs common.FS, templateDir string) (*spec.
 	return spec, nil
 }
 
-// Downloads the template and returns the name of the temp directory where it
-// was saved. If error is returned, then the returned directory name may or may
-// not exist, and may or may not be empty.
+// Downloads the template and returns:
+//   - the ParsedSource giving metadata about the template
+//   - the name of the temp directory where the template contents were saved.
+//
+// If error is returned, then the returned directory name may or may not exist,
+// and may or may not be empty.
 func (c *Command) copyTemplate(ctx context.Context, rp *runParams) (*templatesource.ParsedSource, string, error) {
 	logger := logging.FromContext(ctx).With("logger", "copyTemplate")
 

--- a/templates/commands/render/templatesource/localsource.go
+++ b/templates/commands/render/templatesource/localsource.go
@@ -31,7 +31,7 @@ var _ sourceParser = (*localSourceParser)(nil)
 // directory.
 type localSourceParser struct{}
 
-func (l *localSourceParser) sourceParse(ctx context.Context, cwd string, params *ParseSourceParams) (*ParsedSource, bool, error) {
+func (l *localSourceParser) sourceParse(ctx context.Context, cwd string, params *ParseSourceParams) (Downloader, bool, error) {
 	logger := logging.FromContext(ctx).With("logger", "localSourceParser.sourceParse")
 
 	// Design decision: we could try to look at src and guess whether it looks
@@ -44,12 +44,9 @@ func (l *localSourceParser) sourceParse(ctx context.Context, cwd string, params 
 	// git repos, so this code won't run if the source looks like a git repo.
 
 	// If the filepath was not absolute, convert it to be relative to the cwd.
-	absSource, absDest := params.Source, params.Dest
+	absSource := params.Source
 	if !filepath.IsAbs(params.Source) {
 		absSource = filepath.Join(cwd, params.Source)
-	}
-	if !filepath.IsAbs(params.Dest) {
-		absDest = filepath.Join(cwd, params.Dest)
 	}
 
 	if _, err := os.Stat(absSource); err != nil {
@@ -62,50 +59,12 @@ func (l *localSourceParser) sourceParse(ctx context.Context, cwd string, params 
 
 	logger.InfoContext(ctx, "treating src as a local path", "src", absSource)
 
-	canonicalSource, ok, err := isCanonical(ctx, absSource, absDest)
-	if err != nil {
-		return nil, false, err
-	}
-
-	return &ParsedSource{
-		CanonicalSource:    canonicalSource,
-		HasCanonicalSource: ok,
-		Downloader: &localDownloader{
-			srcPath: absSource,
-		},
+	return &localDownloader{
+		srcPath: absSource,
 	}, true, nil
 }
 
-// isCanonical determines whether the template source is a "canonical" one.
-// See ParsedSource for more info on canonical sources.
-func isCanonical(ctx context.Context, absSource, absDest string) (string, bool, error) {
-	logger := logging.FromContext(ctx).With("logger", "localsource_isCanonical")
-
-	// See the docs on ParsedSource for an explanation of why we compare the git
-	// workspaces to decide if source is canonical.
-	sourceGitWorkspace, templateIsGit, err := gitWorkspace(ctx, absSource)
-	if err != nil {
-		return "", false, err
-	}
-	destGitWorkspace, destIsGit, err := gitWorkspace(ctx, absDest)
-	if err != nil {
-		return "", false, err
-	}
-	if !templateIsGit || !destIsGit || sourceGitWorkspace != destGitWorkspace {
-		logger.DebugContext(ctx, "local template source is not canonical, template dir and dest dir do not share a git workspace",
-			"source", absSource, "dest", absDest, "source_git_workspace", sourceGitWorkspace, "dest_git_workspace", destGitWorkspace)
-		return "", false, nil
-	}
-
-	logger.DebugContext(ctx, "local template source is canonical because template dir and dest dir are both in the same git workspace",
-		"source", absSource, "dest", absDest, "git_workspace", destGitWorkspace)
-	out, err := filepath.Rel(absDest, absSource)
-	if err != nil {
-		return "", false, fmt.Errorf("filepath.Rel(%q,%q): %w", absDest, absSource, err)
-	}
-	return out, true, nil
-}
-
+// localDownloader implements Downloader.
 type localDownloader struct {
 	// This path uses the OS-native file separator and is an absolute path.
 	srcPath string
@@ -120,6 +79,39 @@ func (l *localDownloader) Download(ctx context.Context, outDir string) error {
 		DstRoot: outDir,
 		RFS:     &common.RealFS{},
 	})
+}
+
+func (l *localDownloader) CanonicalSource(ctx context.Context, cwd, dest string) (string, bool, error) {
+	logger := logging.FromContext(ctx).With("logger", "localDownloader.CanonicalSource")
+
+	absDest := dest
+	if !filepath.IsAbs(dest) {
+		absDest = filepath.Join(cwd, dest)
+	}
+
+	// See the docs on ParsedSource for an explanation of why we compare the git
+	// workspaces to decide if source is canonical.
+	sourceGitWorkspace, templateIsGit, err := gitWorkspace(ctx, l.srcPath)
+	if err != nil {
+		return "", false, err
+	}
+	destGitWorkspace, destIsGit, err := gitWorkspace(ctx, absDest)
+	if err != nil {
+		return "", false, err
+	}
+	if !templateIsGit || !destIsGit || sourceGitWorkspace != destGitWorkspace {
+		logger.DebugContext(ctx, "local template source is not canonical, template dir and dest dir do not share a git workspace",
+			"source", l.srcPath, "dest", absDest, "source_git_workspace", sourceGitWorkspace, "dest_git_workspace", destGitWorkspace)
+		return "", false, nil
+	}
+
+	logger.DebugContext(ctx, "local template source is canonical because template dir and dest dir are both in the same git workspace",
+		"source", l.srcPath, "dest", absDest, "git_workspace", destGitWorkspace)
+	out, err := filepath.Rel(absDest, l.srcPath)
+	if err != nil {
+		return "", false, fmt.Errorf("filepath.Rel(%q,%q): %w", dest, l.srcPath, err)
+	}
+	return out, true, nil
 }
 
 // gitWorkspace looks for the presence of a .git directory in parent directories

--- a/templates/commands/render/templatesource/localsource.go
+++ b/templates/commands/render/templatesource/localsource.go
@@ -17,9 +17,7 @@ package templatesource
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"io/fs"
 	"os"
 	"path/filepath"
 
@@ -33,7 +31,7 @@ var _ sourceParser = (*localSourceParser)(nil)
 // directory.
 type localSourceParser struct{}
 
-func (l *localSourceParser) sourceParse(ctx context.Context, cwd, src, protocol string) (Downloader, bool, error) {
+func (l *localSourceParser) sourceParse(ctx context.Context, cwd string, params *ParseSourceParams) (*ParsedSource, bool, error) {
 	logger := logging.FromContext(ctx).With("logger", "localSourceParser.sourceParse")
 
 	// Design decision: we could try to look at src and guess whether it looks
@@ -46,33 +44,71 @@ func (l *localSourceParser) sourceParse(ctx context.Context, cwd, src, protocol 
 	// git repos, so this code won't run if the source looks like a git repo.
 
 	// If the filepath was not absolute, convert it to be relative to the cwd.
-	originalSrc := src
-	if !filepath.IsAbs(src) {
-		src = filepath.Join(cwd, src)
-		logger.DebugContext(ctx, "source path is relative, converting to absolute path",
-			"originalSrc", originalSrc,
-			"src", src)
+	absSource, absDest := params.Source, params.Dest
+	if !filepath.IsAbs(params.Source) {
+		absSource = filepath.Join(cwd, params.Source)
+	}
+	if !filepath.IsAbs(params.Dest) {
+		absDest = filepath.Join(cwd, params.Dest)
 	}
 
-	if _, err := os.Stat(src); err != nil {
-		var pathErrPtr *fs.PathError
-
-		if errors.Is(err, fs.ErrNotExist) || errors.Is(err, fs.ErrInvalid) || errors.As(err, &pathErrPtr) {
-			logger.DebugContext(ctx, "will not treat src as a local path because the path does not exist", "src", src)
+	if _, err := os.Stat(absSource); err != nil {
+		if common.IsStatNotExistErr(err) {
+			logger.DebugContext(ctx, "will not treat template location as a local path because the path does not exist", "src", absSource)
 			return nil, false, nil
 		}
 		return nil, false, fmt.Errorf("Stat(): %w", err)
 	}
 
-	logger.InfoContext(ctx, "treating src as a local path", "src", src)
+	logger.InfoContext(ctx, "treating src as a local path", "src", absSource)
 
-	return &localDownloader{
-		srcPath: src, // Uses OS-native file separator
+	canonicalSource, ok, err := isCanonical(ctx, absSource, absDest)
+	if err != nil {
+		return nil, false, err
+	}
+
+	return &ParsedSource{
+		CanonicalSource:    canonicalSource,
+		HasCanonicalSource: ok,
+		Downloader: &localDownloader{
+			srcPath: absSource,
+		},
 	}, true, nil
 }
 
+// isCanonical determines whether the template source is a "canonical" one.
+// See ParsedSource for more info on canonical sources.
+func isCanonical(ctx context.Context, absSource, absDest string) (string, bool, error) {
+	logger := logging.FromContext(ctx).With("logger", "localsource_isCanonical")
+
+	// See the docs on ParsedSource for an explanation of why we compare the git
+	// workspaces to decide if source is canonical.
+	sourceGitWorkspace, templateIsGit, err := gitWorkspace(ctx, absSource)
+	if err != nil {
+		return "", false, err
+	}
+	destGitWorkspace, destIsGit, err := gitWorkspace(ctx, absDest)
+	if err != nil {
+		return "", false, err
+	}
+	if !templateIsGit || !destIsGit || sourceGitWorkspace != destGitWorkspace {
+		logger.DebugContext(ctx, "local template source is not canonical, template dir and dest dir do not share a git workspace",
+			"source", absSource, "dest", absDest, "source_git_workspace", sourceGitWorkspace, "dest_git_workspace", destGitWorkspace)
+		return "", false, nil
+	}
+
+	logger.DebugContext(ctx, "local template source is canonical because template dir and dest dir are both in the same git workspace",
+		"source", absSource, "dest", absDest, "git_workspace", destGitWorkspace)
+	out, err := filepath.Rel(absDest, absSource)
+	if err != nil {
+		return "", false, fmt.Errorf("filepath.Rel(%q,%q): %w", absDest, absSource, err)
+	}
+	return out, true, nil
+}
+
 type localDownloader struct {
-	srcPath string // uses OS-native file separator
+	// This path uses the OS-native file separator and is an absolute path.
+	srcPath string
 }
 
 func (l *localDownloader) Download(ctx context.Context, outDir string) error {
@@ -84,4 +120,41 @@ func (l *localDownloader) Download(ctx context.Context, outDir string) error {
 		DstRoot: outDir,
 		RFS:     &common.RealFS{},
 	})
+}
+
+// gitWorkspace looks for the presence of a .git directory in parent directories
+// to determine the root directory of the git workspace containing "path".
+// Returns false if the given path is not inside a git workspace.
+//
+// The input path need not actually exist yet. For example, suppose "/a/b" is a
+// git workspace, which means that "/a/b/.git" is a directory that exists.
+// Calling gitWorkspace("/a/b/c") will return "/a/b" whether or not "c" actually
+// exists yet. This supports the case where the user is rendering into a
+// directory that doesn't exist yet but will be created by the render operation.
+func gitWorkspace(ctx context.Context, path string) (string, bool, error) {
+	// Alternative considered and rejected: use "git rev-parse --git-dir" to
+	// print the .git dir. We can't use that here because that would require the
+	// directory to already exist in the filesystem, but this function is called
+	// for hypothetical directories that might not exist yet.
+	for {
+		fileInfo, err := os.Stat(filepath.Join(path, ".git"))
+		if err != nil && !common.IsStatNotExistErr(err) {
+			return "", false, err
+		}
+		if fileInfo != nil && fileInfo.IsDir() {
+			return path, true, nil
+		}
+		// At this point, we know that one of two things is true:
+		//   - $path/.git doesn't exist
+		//   - $path/.git is a file (not a directory)
+		//
+		// In both cases, we'll continue crawling upward in the directory tree
+		// looking for a .git directory.
+		path = filepath.Dir(path)
+		if len(path) <= 1 {
+			// We crawled to the root of the filesystem without finding a .git
+			// directory.
+			return "", false, nil
+		}
+	}
 }

--- a/templates/commands/render/templatesource/localsource.go
+++ b/templates/commands/render/templatesource/localsource.go
@@ -150,8 +150,9 @@ func gitWorkspace(ctx context.Context, path string) (string, bool, error) {
 		//
 		// In both cases, we'll continue crawling upward in the directory tree
 		// looking for a .git directory.
+		pathBefore := path
 		path = filepath.Dir(path)
-		if len(path) <= 1 {
+		if path == pathBefore || len(path) <= 1 {
 			// We crawled to the root of the filesystem without finding a .git
 			// directory.
 			return "", false, nil

--- a/templates/commands/render/templatesource/localsource.go
+++ b/templates/commands/render/templatesource/localsource.go
@@ -139,7 +139,7 @@ func gitWorkspace(ctx context.Context, path string) (string, bool, error) {
 	for {
 		fileInfo, err := os.Stat(filepath.Join(path, ".git"))
 		if err != nil && !common.IsStatNotExistErr(err) {
-			return "", false, err
+			return "", false, err //nolint:wrapcheck
 		}
 		if fileInfo != nil && fileInfo.IsDir() {
 			return path, true, nil

--- a/templates/commands/render/templatesource/source.go
+++ b/templates/commands/render/templatesource/source.go
@@ -28,14 +28,18 @@ type sourceParser interface {
 	// being downloadable by this sourceParser, then it returns true, along with
 	// a downloader that can download that template, and other metadata. See
 	// ParsedSource.
-	sourceParse(ctx context.Context, cwd string, params *ParseSourceParams) (*ParsedSource, bool, error)
+	sourceParse(ctx context.Context, cwd string, params *ParseSourceParams) (Downloader, bool, error)
 }
 
-// ParsedSource is returned from ParseSource provide the ability to download
-// a template, as well as some metadata about the template.
-type ParsedSource struct {
-	Downloader Downloader
+// A Downloader is returned by a sourceParser. It offers the ability to
+// download a template, and provides some metadata.
+type Downloader interface {
+	// Download downloads this template into the given directory.
+	Download(ctx context.Context, outDir string) error
 
+	// CanonicalSource() returns the canonical source location for this
+	// template, if it exists.
+	//
 	// A "canonical" location is one that's the same for everybody. When
 	// installing a template source like
 	// "~/my_downloaded_templates/foo_template", that location is not canonical,
@@ -45,31 +49,25 @@ type ParsedSource struct {
 	// everyone everywhere can access it by that name.
 	//
 	// Canonical template locations are preferred because they make automatic
-	// template upgrades easier. Given a destination directory that is the output
-	// of a template, we can easily upgrade it if we know the canonical location
-	// of the template that created it. We just go look for new git tags at the
-	// canonical location.
+	// template upgrades easier. Given a destination directory that is the
+	// output of a template, we can easily upgrade it if we know the canonical
+	// location of the template that created it. We just go look for new git
+	// tags at the canonical location.
 	//
-	// A local template directory is not a canonical location except for one special
-	// case: when the template source directory and the destination directory are
-	// within the same repo. This supports the case where a single git repo contains
-	// templates that are rendered into that repo. Since the relative path between
-	// the template directory and the destination directory are the same for
-	// everyone who clones the repo, that means the relative path counts as a
-	// canonical source.
-	HasCanonicalSource bool // true iff CanonicalLocation is valid.
-
-	// CanonicalSource is the globally usable path to this template that anyone
-	// can use on any machine to reference this template. Does not include
-	// @version suffix.
-	CanonicalSource string
-}
-
-// A Downloader is returned by a sourceParser, and offers the ability to
-// download a template.
-type Downloader interface {
-	// Download downloads this template into the given directory.
-	Download(ctx context.Context, outDir string) error
+	// A local template directory is not a canonical location except for one
+	// special case: when the template source directory and the destination
+	// directory are within the same repo. This supports the case where a single
+	// git repo contains templates that are rendered into that repo. Since the
+	// relative path between the template directory and the destination
+	// directory are the same for everyone who clones the repo, that means the
+	// relative path counts as a canonical source.
+	//
+	// CanonicalSource should only be called after Download() has returned
+	// successfully. This lets us account for redirects encountered while
+	// downloading.
+	//
+	// "dest" is the value of --dest. cwd is the current working directory.
+	CanonicalSource(ctx context.Context, cwd, dest string) (string, bool, error)
 }
 
 // realSourceParsers contains the non-test sourceParsers.
@@ -122,8 +120,7 @@ var realSourceParsers = []sourceParser{
 	},
 }
 
-// ParseSourceParams contains the arguments to ParseSource, since there were a
-// lot of them.
+// ParseSourceParams contains the arguments to ParseSource.
 type ParseSourceParams struct {
 	// Source could be any of the template source types we accept. Examples:
 	//  - github.com/foo/bar@latest
@@ -133,14 +130,6 @@ type ParseSourceParams struct {
 	// In the case where the source is a local filesystem path, it uses native
 	// filesystem separators.
 	Source string
-
-	// Dest is the value of --dest. You might justifiably wonder why this is
-	// here since it's not obviously relevant to parsing the template source.
-	// This is here so that we can determine whether the template source
-	// directory is in the same git workspace as the destination directory. This
-	// matters when determining whether the template source location is
-	// canonical or not. See the docs on ParsedSource for more.
-	Dest string
 
 	// The value of --git-protocol.
 	GitProtocol string
@@ -154,7 +143,7 @@ type ParseSourceParams struct {
 //
 // A list of sourceParsers is accepted as input for the purpose of testing,
 // rather than hardcoding the real list of sourceParsers.
-func parseSourceWithCwd(ctx context.Context, cwd string, params *ParseSourceParams) (*ParsedSource, error) {
+func parseSourceWithCwd(ctx context.Context, cwd string, params *ParseSourceParams) (Downloader, error) {
 	for _, sp := range realSourceParsers {
 		downloader, ok, err := sp.sourceParse(ctx, cwd, params)
 		if err != nil {
@@ -169,7 +158,7 @@ func parseSourceWithCwd(ctx context.Context, cwd string, params *ParseSourcePara
 
 // ParseSource is the same as [ParseSourceWithWorkingDir], but it uses the
 // current working directory [os.Getwd] as the base path.
-func ParseSource(ctx context.Context, params *ParseSourceParams) (*ParsedSource, error) {
+func ParseSource(ctx context.Context, params *ParseSourceParams) (Downloader, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get current working directory: %w", err)

--- a/templates/commands/render/templatesource/source.go
+++ b/templates/commands/render/templatesource/source.go
@@ -42,7 +42,7 @@ type ParsedSource struct {
 	// because not every has that directory downloaded on their machine. On the
 	// other hand, a template location like
 	// github.com/abcxyz/gcp-org-terraform-template *is* canonical because
-	// everyone everwhere can access it by that name.
+	// everyone everywhere can access it by that name.
 	//
 	// Canonical template locations are preferred because they make automatic
 	// template upgrades easier. Given a destination directory that is the output

--- a/templates/commands/render/templatesource/source_test.go
+++ b/templates/commands/render/templatesource/source_test.go
@@ -149,7 +149,7 @@ func TestParseSourceWithWorkingDir(t *testing.T) {
 			dest: "dir1/dest",
 			want: &ParsedSource{
 				HasCanonicalSource: true,
-				CanonicalSource:    "../mytemplate",
+				CanonicalSource:    filepath.FromSlash("../mytemplate"),
 				Downloader: &localDownloader{
 					srcPath: filepath.FromSlash("dir1/mytemplate"),
 				},

--- a/templates/commands/render/templatesource/source_test.go
+++ b/templates/commands/render/templatesource/source_test.go
@@ -133,7 +133,7 @@ func TestParseSourceWithWorkingDIr(t *testing.T) {
 				"github.com/myorg/myrepo/mysubdir@latest/spec.yaml": "my spec file contents",
 			},
 			want: &localDownloader{
-				srcPath: filepath.FromSlash("./github.com/myorg/myrepo/mysubdir@latest"),
+				srcPath: filepath.FromSlash("github.com/myorg/myrepo/mysubdir@latest"),
 			},
 		},
 		{
@@ -242,7 +242,9 @@ func TestParseSourceWithWorkingDIr(t *testing.T) {
 				// relative. This comparer removes the tempDir prefix so that test cases
 				// can still do relative filepath comparisons.
 				cmp.Comparer(func(a, b localDownloader) bool {
-					return strings.TrimPrefix(tempDir, a.srcPath) == strings.TrimPrefix(tempDir, b.srcPath)
+					l := strings.TrimPrefix(a.srcPath, tempDir+string(filepath.Separator))
+					r := strings.TrimPrefix(b.srcPath, tempDir+string(filepath.Separator))
+					return l == r
 				}),
 			}
 			if diff := cmp.Diff(dl, tc.want, opts...); diff != "" {

--- a/templates/commands/render/templatesource/source_test.go
+++ b/templates/commands/render/templatesource/source_test.go
@@ -29,87 +29,78 @@ func TestParseSourceWithWorkingDir(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		name            string
-		source          string
-		gitProtocol     string
-		tempDirContents map[string]string
-		dest            string
-		want            *ParsedSource
-		wantErr         string
+		name                string
+		source              string
+		gitProtocol         string
+		tempDirContents     map[string]string
+		dest                string
+		want                Downloader
+		wantCanonicalSource string
+		wantErr             string
 	}{
 		{
-			name:   "latest",
-			source: "github.com/myorg/myrepo@latest",
-			want: &ParsedSource{
-				HasCanonicalSource: true,
-				CanonicalSource:    "github.com/myorg/myrepo",
-				Downloader: &gitDownloader{
-					remote:  "https://github.com/myorg/myrepo.git",
-					subdir:  "",
-					version: "latest",
-					cloner:  &realCloner{},
-					tagser:  &realTagser{},
-				},
+			name:                "latest",
+			source:              "github.com/myorg/myrepo@latest",
+			wantCanonicalSource: "github.com/myorg/myrepo",
+			want: &gitDownloader{
+				canonicalSource: "github.com/myorg/myrepo",
+				remote:          "https://github.com/myorg/myrepo.git",
+				subdir:          "",
+				version:         "latest",
+				cloner:          &realCloner{},
+				tagser:          &realTagser{},
 			},
 		},
 		{
-			name:   "given_version",
-			source: "github.com/myorg/myrepo@v1.2.3",
-			want: &ParsedSource{
-				HasCanonicalSource: true,
-				CanonicalSource:    "github.com/myorg/myrepo",
-				Downloader: &gitDownloader{
-					remote:  "https://github.com/myorg/myrepo.git",
-					subdir:  "",
-					version: "v1.2.3",
-					cloner:  &realCloner{},
-					tagser:  &realTagser{},
-				},
+			name:                "given_version",
+			source:              "github.com/myorg/myrepo@v1.2.3",
+			wantCanonicalSource: "github.com/myorg/myrepo",
+			want: &gitDownloader{
+				canonicalSource: "github.com/myorg/myrepo",
+				remote:          "https://github.com/myorg/myrepo.git",
+				subdir:          "",
+				version:         "v1.2.3",
+				cloner:          &realCloner{},
+				tagser:          &realTagser{},
 			},
 		},
 		{
-			name:   "version_with_weird_chars",
-			source: "github.com/myorg/myrepo@v1.2.3-foo/bar",
-			want: &ParsedSource{
-				HasCanonicalSource: true,
-				CanonicalSource:    "github.com/myorg/myrepo",
-				Downloader: &gitDownloader{
-					remote:  "https://github.com/myorg/myrepo.git",
-					subdir:  "",
-					version: "v1.2.3-foo/bar",
-					cloner:  &realCloner{},
-					tagser:  &realTagser{},
-				},
+			name:                "version_with_weird_chars",
+			source:              "github.com/myorg/myrepo@v1.2.3-foo/bar",
+			wantCanonicalSource: "github.com/myorg/myrepo",
+			want: &gitDownloader{
+				canonicalSource: "github.com/myorg/myrepo",
+				remote:          "https://github.com/myorg/myrepo.git",
+				subdir:          "",
+				version:         "v1.2.3-foo/bar",
+				cloner:          &realCloner{},
+				tagser:          &realTagser{},
 			},
 		},
 		{
-			name:   "subdir",
-			source: "github.com/myorg/myrepo/mysubdir@v1.2.3",
-			want: &ParsedSource{
-				HasCanonicalSource: true,
-				CanonicalSource:    "github.com/myorg/myrepo/mysubdir",
-				Downloader: &gitDownloader{
-					remote:  "https://github.com/myorg/myrepo.git",
-					subdir:  "mysubdir",
-					version: "v1.2.3",
-					cloner:  &realCloner{},
-					tagser:  &realTagser{},
-				},
+			name:                "subdir",
+			source:              "github.com/myorg/myrepo/mysubdir@v1.2.3",
+			wantCanonicalSource: "github.com/myorg/myrepo/mysubdir",
+			want: &gitDownloader{
+				canonicalSource: "github.com/myorg/myrepo/mysubdir",
+				remote:          "https://github.com/myorg/myrepo.git",
+				subdir:          "mysubdir",
+				version:         "v1.2.3",
+				cloner:          &realCloner{},
+				tagser:          &realTagser{},
 			},
 		},
 		{
-			name:   "deep_subdir",
-			source: "github.com/myorg/myrepo/my/deep/subdir@v1.2.3",
-			want: &ParsedSource{
-				HasCanonicalSource: true,
-				CanonicalSource:    "github.com/myorg/myrepo/my/deep/subdir",
-				Downloader: &gitDownloader{
-					remote:  "https://github.com/myorg/myrepo.git",
-					subdir:  "my/deep/subdir",
-					version: "v1.2.3",
-					cloner:  &realCloner{},
-					tagser:  &realTagser{},
-				},
+			name:                "deep_subdir",
+			source:              "github.com/myorg/myrepo/my/deep/subdir@v1.2.3",
+			wantCanonicalSource: "github.com/myorg/myrepo/my/deep/subdir",
+			want: &gitDownloader{
+				canonicalSource: "github.com/myorg/myrepo/my/deep/subdir",
+				remote:          "https://github.com/myorg/myrepo.git",
+				subdir:          "my/deep/subdir",
+				version:         "v1.2.3",
+				cloner:          &realCloner{},
+				tagser:          &realTagser{},
 			},
 		},
 		{
@@ -128,11 +119,8 @@ func TestParseSourceWithWorkingDir(t *testing.T) {
 			tempDirContents: map[string]string{
 				"my/dir/spec.yaml": "my spec file contents",
 			},
-			want: &ParsedSource{
-				HasCanonicalSource: false,
-				Downloader: &localDownloader{
-					srcPath: filepath.FromSlash("my/dir"),
-				},
+			want: &localDownloader{
+				srcPath: filepath.FromSlash("my/dir"),
 			},
 		},
 		{
@@ -146,13 +134,10 @@ func TestParseSourceWithWorkingDir(t *testing.T) {
 				"dir1/.git/objects/_": "",
 				"dir1/.git/HEAD":      "ref: refs/heads/main",
 			},
-			dest: "dir1/dest",
-			want: &ParsedSource{
-				HasCanonicalSource: true,
-				CanonicalSource:    filepath.FromSlash("../mytemplate"),
-				Downloader: &localDownloader{
-					srcPath: filepath.FromSlash("dir1/mytemplate"),
-				},
+			dest:                "dir1/dest",
+			wantCanonicalSource: filepath.FromSlash("../mytemplate"),
+			want: &localDownloader{
+				srcPath: filepath.FromSlash("dir1/mytemplate"),
 			},
 		},
 		{
@@ -172,11 +157,8 @@ func TestParseSourceWithWorkingDir(t *testing.T) {
 				"dir2/.git/HEAD":      "ref: refs/heads/main",
 			},
 			dest: "dir2",
-			want: &ParsedSource{
-				HasCanonicalSource: false,
-				Downloader: &localDownloader{
-					srcPath: filepath.FromSlash("dir1/mytemplate"),
-				},
+			want: &localDownloader{
+				srcPath: filepath.FromSlash("dir1/mytemplate"),
 			},
 		},
 		{
@@ -191,11 +173,8 @@ func TestParseSourceWithWorkingDir(t *testing.T) {
 				"dir1/.git/HEAD":      "ref: refs/heads/main",
 			},
 			dest: "dir2",
-			want: &ParsedSource{
-				HasCanonicalSource: false,
-				Downloader: &localDownloader{
-					srcPath: filepath.FromSlash("dir1/mytemplate"),
-				},
+			want: &localDownloader{
+				srcPath: filepath.FromSlash("dir1/mytemplate"),
 			},
 		},
 		{
@@ -210,11 +189,8 @@ func TestParseSourceWithWorkingDir(t *testing.T) {
 				"dir2/.git/HEAD":      "ref: refs/heads/main",
 			},
 			dest: "dir2",
-			want: &ParsedSource{
-				HasCanonicalSource: false,
-				Downloader: &localDownloader{
-					srcPath: filepath.FromSlash("dir1/mytemplate"),
-				},
+			want: &localDownloader{
+				srcPath: filepath.FromSlash("dir1/mytemplate"),
 			},
 		},
 		{
@@ -238,11 +214,8 @@ func TestParseSourceWithWorkingDir(t *testing.T) {
 			tempDirContents: map[string]string{
 				"github.com/myorg/myrepo/mysubdir@latest/spec.yaml": "my spec file contents",
 			},
-			want: &ParsedSource{
-				HasCanonicalSource: false,
-				Downloader: &localDownloader{
-					srcPath: filepath.FromSlash("github.com/myorg/myrepo/mysubdir@latest"),
-				},
+			want: &localDownloader{
+				srcPath: filepath.FromSlash("github.com/myorg/myrepo/mysubdir@latest"),
 			},
 		},
 		{
@@ -251,106 +224,92 @@ func TestParseSourceWithWorkingDir(t *testing.T) {
 			tempDirContents: map[string]string{
 				"github.com/myorg/myrepo/mysubdir@latest/spec.yaml": "my spec file contents",
 			},
-			want: &ParsedSource{
-				HasCanonicalSource: true,
-				CanonicalSource:    "github.com/myorg/myrepo/mysubdir",
-				Downloader: &gitDownloader{
-					remote:  "https://github.com/myorg/myrepo.git",
-					subdir:  "mysubdir",
-					version: "latest",
-					cloner:  &realCloner{},
-					tagser:  &realTagser{},
-				},
+			wantCanonicalSource: "github.com/myorg/myrepo/mysubdir",
+			want: &gitDownloader{
+				canonicalSource: "github.com/myorg/myrepo/mysubdir",
+				remote:          "https://github.com/myorg/myrepo.git",
+				subdir:          "mysubdir",
+				version:         "latest",
+				cloner:          &realCloner{},
+				tagser:          &realTagser{},
 			},
 		},
 		{
-			name:   "go_getter_with_ref_and_subdirs",
-			source: "github.com/myorg/myrepo.git//sub/dir?ref=latest",
-			want: &ParsedSource{
-				HasCanonicalSource: true,
-				CanonicalSource:    "github.com/myorg/myrepo/sub/dir",
-				Downloader: &gitDownloader{
-					remote:  "https://github.com/myorg/myrepo.git",
-					subdir:  "sub/dir",
-					version: "latest",
-					cloner:  &realCloner{},
-					tagser:  &realTagser{},
-				},
+			name:                "go_getter_with_ref_and_subdirs",
+			source:              "github.com/myorg/myrepo.git//sub/dir?ref=latest",
+			wantCanonicalSource: "github.com/myorg/myrepo/sub/dir",
+			want: &gitDownloader{
+				canonicalSource: "github.com/myorg/myrepo/sub/dir",
+				remote:          "https://github.com/myorg/myrepo.git",
+				subdir:          "sub/dir",
+				version:         "latest",
+				cloner:          &realCloner{},
+				tagser:          &realTagser{},
 			},
 		},
 		{
-			name:   "go_getter_with_ref_no_subdirs",
-			source: "github.com/myorg/myrepo.git?ref=latest",
-			want: &ParsedSource{
-				HasCanonicalSource: true,
-				CanonicalSource:    "github.com/myorg/myrepo",
-				Downloader: &gitDownloader{
-					remote:  "https://github.com/myorg/myrepo.git",
-					subdir:  "",
-					version: "latest",
-					cloner:  &realCloner{},
-					tagser:  &realTagser{},
-				},
+			name:                "go_getter_with_ref_no_subdirs",
+			source:              "github.com/myorg/myrepo.git?ref=latest",
+			wantCanonicalSource: "github.com/myorg/myrepo",
+			want: &gitDownloader{
+				canonicalSource: "github.com/myorg/myrepo",
+				remote:          "https://github.com/myorg/myrepo.git",
+				subdir:          "",
+				version:         "latest",
+				cloner:          &realCloner{},
+				tagser:          &realTagser{},
 			},
 		},
 		{
-			name:   "go_getter_no_ref_no_subdirs",
-			source: "github.com/myorg/myrepo.git",
-			want: &ParsedSource{
-				HasCanonicalSource: true,
-				CanonicalSource:    "github.com/myorg/myrepo",
-				Downloader: &gitDownloader{
-					remote:  "https://github.com/myorg/myrepo.git",
-					subdir:  "",
-					version: "latest",
-					cloner:  &realCloner{},
-					tagser:  &realTagser{},
-				},
+			name:                "go_getter_no_ref_no_subdirs",
+			source:              "github.com/myorg/myrepo.git",
+			wantCanonicalSource: "github.com/myorg/myrepo",
+			want: &gitDownloader{
+				canonicalSource: "github.com/myorg/myrepo",
+				remote:          "https://github.com/myorg/myrepo.git",
+				subdir:          "",
+				version:         "latest",
+				cloner:          &realCloner{},
+				tagser:          &realTagser{},
 			},
 		},
 		{
-			name:   "go_getter_no_ref_with_subdirs",
-			source: "github.com/myorg/myrepo.git//sub/dir",
-			want: &ParsedSource{
-				HasCanonicalSource: true,
-				CanonicalSource:    "github.com/myorg/myrepo/sub/dir",
-				Downloader: &gitDownloader{
-					remote:  "https://github.com/myorg/myrepo.git",
-					subdir:  "sub/dir",
-					version: "latest",
-					cloner:  &realCloner{},
-					tagser:  &realTagser{},
-				},
+			name:                "go_getter_no_ref_with_subdirs",
+			source:              "github.com/myorg/myrepo.git//sub/dir",
+			wantCanonicalSource: "github.com/myorg/myrepo/sub/dir",
+			want: &gitDownloader{
+				canonicalSource: "github.com/myorg/myrepo/sub/dir",
+				remote:          "https://github.com/myorg/myrepo.git",
+				subdir:          "sub/dir",
+				version:         "latest",
+				cloner:          &realCloner{},
+				tagser:          &realTagser{},
 			},
 		},
 		{
-			name:   "go_getter_no_ref_single_subdir",
-			source: "github.com/myorg/myrepo.git//subdir",
-			want: &ParsedSource{
-				HasCanonicalSource: true,
-				CanonicalSource:    "github.com/myorg/myrepo/subdir",
-				Downloader: &gitDownloader{
-					remote:  "https://github.com/myorg/myrepo.git",
-					subdir:  "subdir",
-					version: "latest",
-					cloner:  &realCloner{},
-					tagser:  &realTagser{},
-				},
+			name:                "go_getter_no_ref_single_subdir",
+			source:              "github.com/myorg/myrepo.git//subdir",
+			wantCanonicalSource: "github.com/myorg/myrepo/subdir",
+			want: &gitDownloader{
+				canonicalSource: "github.com/myorg/myrepo/subdir",
+				remote:          "https://github.com/myorg/myrepo.git",
+				subdir:          "subdir",
+				version:         "latest",
+				cloner:          &realCloner{},
+				tagser:          &realTagser{},
 			},
 		},
 		{
-			name:   "go_getter_semver_ref",
-			source: "github.com/myorg/myrepo.git?ref=v1.2.3",
-			want: &ParsedSource{
-				HasCanonicalSource: true,
-				CanonicalSource:    "github.com/myorg/myrepo",
-				Downloader: &gitDownloader{
-					remote:  "https://github.com/myorg/myrepo.git",
-					subdir:  "",
-					version: "v1.2.3",
-					cloner:  &realCloner{},
-					tagser:  &realTagser{},
-				},
+			name:                "go_getter_semver_ref",
+			source:              "github.com/myorg/myrepo.git?ref=v1.2.3",
+			wantCanonicalSource: "github.com/myorg/myrepo",
+			want: &gitDownloader{
+				canonicalSource: "github.com/myorg/myrepo",
+				remote:          "https://github.com/myorg/myrepo.git",
+				subdir:          "",
+				version:         "v1.2.3",
+				cloner:          &realCloner{},
+				tagser:          &realTagser{},
 			},
 		},
 	}
@@ -369,7 +328,6 @@ func TestParseSourceWithWorkingDir(t *testing.T) {
 
 			params := &ParseSourceParams{
 				Source:      tc.source,
-				Dest:        tc.dest,
 				GitProtocol: tc.gitProtocol,
 			}
 			got, err := parseSourceWithCwd(ctx, tempDir, params)
@@ -391,6 +349,23 @@ func TestParseSourceWithWorkingDir(t *testing.T) {
 			}
 			if diff := cmp.Diff(got, tc.want, opts...); diff != "" {
 				t.Errorf("downloader was not as expected (-got,+want): %s", diff)
+			}
+
+			// We can't continue with verifying the canonical source if there's
+			// no Downloader.
+			if got == nil {
+				return
+			}
+
+			gotCanonicalSource, ok, err := got.CanonicalSource(ctx, tempDir, tc.dest)
+			if err != nil {
+				t.Fatalf("CanonicalSource() returned error: %v", err)
+			}
+			if gotCanonicalSource != tc.wantCanonicalSource {
+				t.Errorf("got canonical source %q, want %q", gotCanonicalSource, tc.wantCanonicalSource)
+			}
+			if gotCanonicalSource == "" && ok {
+				t.Errorf("CanonicalSource returned true but with an empty canonical source")
 			}
 		})
 	}

--- a/templates/common/git/git_test.go
+++ b/templates/common/git/git_test.go
@@ -16,11 +16,11 @@ package git
 
 import (
 	"context"
-	"errors"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/abcxyz/abc/templates/common"
 	"github.com/abcxyz/pkg/testutil"
 	"golang.org/x/exp/slices"
 )
@@ -134,7 +134,7 @@ func TestClone(t *testing.T) {
 			wantFile := "README.md"
 			_, err = os.Stat(filepath.Join(outDir, wantFile))
 			if err != nil {
-				if errors.Is(err, os.ErrNotExist) {
+				if common.IsStatNotExistErr(err) {
 					t.Fatalf("git clone seemed to work but the output didn't contain %q, something weird happened", wantFile)
 				}
 				t.Error(err)

--- a/templates/common/test_utils.go
+++ b/templates/common/test_utils.go
@@ -17,7 +17,6 @@
 package common
 
 import (
-	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -100,7 +99,7 @@ func LoadDirContents(t *testing.T, dir string) map[string]ModeAndContents {
 	t.Helper()
 
 	if _, err := os.Stat(dir); err != nil {
-		if errors.Is(err, fs.ErrNotExist) {
+		if IsStatNotExistErr(err) {
 			return nil
 		}
 		t.Fatal(err)


### PR DESCRIPTION
A canonical template source is one that isn't tied to the machine where it's running. For example, a template source like
`github/abcxyz/abc/t/rest_server` is canonical because anyone can reference it. A template source like "/home/dave/my_unpacked_tarball" is not canonical because that directory only exists on my machine. As a complicated special case, a path like `/home/dave/git/myrepo` may or may not be canonical, depending on whether the destination is in the same git repo as the source. See the internal design doc (ping me for a link).

Also, we add a new common function `IsStatNotExist()` to factor out the common pattern of checking whether we Stat()ed a path that doesn't exist.