### PR TITLE
fix: multiple input processing bugs

### DIFF
--- a/templates/commands/render/render.go
+++ b/templates/commands/render/render.go
@@ -319,20 +319,20 @@ func (c *Command) resolveInputs(ctx context.Context, fs common.FS, spec *spec.Sp
 		return inputs, nil
 	}
 
-	if err := c.validateInputs(ctx, spec.Inputs); err != nil {
+	if err := c.validateInputs(ctx, spec.Inputs, inputs); err != nil {
 		return nil, err
 	}
 
 	return inputs, nil
 }
 
-func (c *Command) validateInputs(ctx context.Context, inputs []*spec.Input) error {
-	scope := common.NewScope(c.flags.Inputs)
+func (c *Command) validateInputs(ctx context.Context, specInputs []*spec.Input, inputVals map[string]string) error {
+	scope := common.NewScope(inputVals)
 
 	sb := &strings.Builder{}
 	tw := tabwriter.NewWriter(sb, 8, 0, 2, ' ', 0)
 
-	for _, input := range inputs {
+	for _, input := range specInputs {
 		for _, rule := range input.Rules {
 			var ok bool
 			err := common.CelCompileAndEval(ctx, scope, rule.Rule, &ok)
@@ -341,7 +341,7 @@ func (c *Command) validateInputs(ctx context.Context, inputs []*spec.Input) erro
 			}
 
 			fmt.Fprintf(tw, "\nInput name:\t%s", input.Name.Val)
-			fmt.Fprintf(tw, "\nInput value:\t%s", c.flags.Inputs[input.Name.Val])
+			fmt.Fprintf(tw, "\nInput value:\t%s", inputVals[input.Name.Val])
 			writeRule(tw, rule, false, 0)
 			if err != nil {
 				fmt.Fprintf(tw, "\nCEL error:\t%s", err.Error())

--- a/templates/commands/render/render.go
+++ b/templates/commands/render/render.go
@@ -305,7 +305,7 @@ func (c *Command) resolveInputs(ctx context.Context, fs common.FS, spec *spec.Sp
 			return nil, fmt.Errorf("the flag --prompt was provided, but standard input is not a terminal")
 		}
 
-		if err := c.promptForInputs(ctx, spec); err != nil {
+		if err := c.promptForInputs(ctx, spec, inputs); err != nil {
 			return nil, err
 		}
 	} else {
@@ -358,14 +358,14 @@ func (c *Command) validateInputs(ctx context.Context, inputs []*spec.Input) erro
 }
 
 // promptForInputs looks for template inputs that were not provided on the
-// command line and prompts the user for them. This mutates c.flags.Inputs.
+// command line and prompts the user for them. This mutates "inputs".
 //
 // This must only be called when the user specified --prompt and the input is a
 // terminal (or in a test).
-func (c *Command) promptForInputs(ctx context.Context, spec *spec.Spec) error {
+func (c *Command) promptForInputs(ctx context.Context, spec *spec.Spec, inputs map[string]string) error {
 	for _, i := range spec.Inputs {
-		if _, ok := c.flags.Inputs[i.Name.Val]; ok {
-			// Don't prompt if the cmdline had an --input for this key.
+		if _, ok := inputs[i.Name.Val]; ok {
+			// Don't prompt if we already have a value for this input.
 			continue
 		}
 		sb := &strings.Builder{}
@@ -404,7 +404,7 @@ func (c *Command) promptForInputs(ctx context.Context, spec *spec.Spec) error {
 			inputVal = i.Default.Val
 		}
 
-		c.flags.Inputs[i.Name.Val] = inputVal
+		inputs[i.Name.Val] = inputVal
 	}
 	return nil
 }

--- a/templates/commands/render/render_test.go
+++ b/templates/commands/render/render_test.go
@@ -1387,13 +1387,9 @@ CEL error:    CEL expression result couldn't be converted to bool. The CEL engin
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			r := &Command{
-				flags: RenderFlags{
-					Inputs: tc.inputVals,
-				},
-			}
+			r := &Command{}
 			ctx := context.Background()
-			err := r.validateInputs(ctx, tc.inputModels)
+			err := r.validateInputs(ctx, tc.inputModels, tc.inputVals)
 			if diff := testutil.DiffErrString(err, tc.want); diff != "" {
 				t.Error(diff)
 			}


### PR DESCRIPTION
We recently rewrote the input handling logic to make the c.flags.Input field immutable and update a different mutable map as input values were processed. However, we missed two spots that was left working the old way. This resulted in:

 - inputs being ignored in the case where they were interactively entered by the user
 - validation logic not seeing some inputs