### PR TITLE
chore: allow versions with branch names or SHA

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,17 @@ The `<template_location>` parameter is one of these two things:
 
 - A remote git repository. The subdirectory is optional, defaulting to the root
   of the repo. This directory must contain a `spec.yaml`. The version suffix
-  must be either `@latest` or a semantic version with a leading 'v' like
-  `@v1.2.3`. Examples:
+  must be either `@latest`, long commit SHA, branch name or tag. Short commit
+  SHA's are not supported and if provided, they will be tried as a
+  branch or tag name. Examples:
 
   - `github.com/abcxyz/gcp-org-terraform-template@latest` (no subdirectory)
   - `github.com/abcxyz/abc/t/rest_server@latest` (with subdirectory)
-  - `github.com/abcxyz/abc/t/rest_server@v0.2.1` (uses semver instead of
+  - `github.com/abcxyz/abc/t/rest_server@v0.2.1` (uses tag instead of
     "latest")
+  - `github.com/abcxyz/abc/t/rest_server@main` (use branch name instead of "latest")
+  - `github.com/abcxyz/abc/t/rest_server@0402ed8413f02e1069c2aec368eca208895918b1`
+    (use ref to long commit SHA)
 
 - A local directory as an absolute or relative path. This directory must contain
   a `spec.yaml`. Examples:

--- a/templates/commands/render/templatesource/git.go
+++ b/templates/commands/render/templatesource/git.go
@@ -203,6 +203,8 @@ func resolveVersion(ctx context.Context, t tagser, remote, version string) (stri
 	}
 }
 
+// resolveLatest retrieves the tags from the remote repository and returns the
+// highest semver tag. An error is thrown if no semver tags are found.
 func resolveLatest(ctx context.Context, t tagser, remote, version string) (string, error) {
 	logger := logging.FromContext(ctx).With("logger", "resolveVersion")
 

--- a/templates/commands/render/templatesource/git.go
+++ b/templates/commands/render/templatesource/git.go
@@ -30,10 +30,7 @@ import (
 	"github.com/abcxyz/pkg/logging"
 )
 
-var (
-	_  sourceParser = (*gitSourceParser)(nil)
-	re              = regexp.MustCompile("^[a-zA-Z0-9/_-]+$")
-)
+var _ sourceParser = (*gitSourceParser)(nil)
 
 // gitSourceParser implements sourceParser for downloading templates from a
 // remote git repo.
@@ -190,8 +187,8 @@ func (g *gitDownloader) CanonicalSource(context.Context, string, string) (string
 }
 
 // resolveVersion returns the latest release tag if version is "latest", and otherwise
-// just returns the input version after validating it. The return value always begins
-// with "v" (unless there's an error).
+// just returns the input version. The return value is either a branch, tag, or
+// a long commit SHA (unless there's an error).
 func resolveVersion(ctx context.Context, t tagser, remote, version string) (string, error) {
 	logger := logging.FromContext(ctx).With("logger", "resolveVersion")
 

--- a/templates/commands/render/templatesource/git.go
+++ b/templates/commands/render/templatesource/git.go
@@ -192,20 +192,20 @@ func (g *gitDownloader) CanonicalSource(context.Context, string, string) (string
 func resolveVersion(ctx context.Context, t tagser, remote, version string) (string, error) {
 	logger := logging.FromContext(ctx).With("logger", "resolveVersion")
 
-	if version != "latest" {
-		if !strings.HasPrefix(version, "v") {
-			return "", fmt.Errorf(`the template source version %q must start with "v", like "v1.2.3"`, version)
-		}
-		ersion := version[1:] // trim off "v" prefix
-		if _, err := semver.StrictNewVersion(ersion); err != nil {
-			return "", fmt.Errorf("the template source requested git tag %q, which is not a valid format for a semver.org version", version)
-		}
+	switch version {
+	case "":
+		return "", fmt.Errorf("the template source version cannot be empty")
+	case "latest":
+		return resolveLatest(ctx, t, remote, version)
+	default:
 		logger.DebugContext(ctx, `using user provided version, no need to look up remote tags`, "version", version)
 		return version, nil
 	}
+}
 
-	// If we're here, then the user requested version "latest", so we need to
-	// look up the latest version.
+func resolveLatest(ctx context.Context, t tagser, remote, version string) (string, error) {
+	logger := logging.FromContext(ctx).With("logger", "resolveVersion")
+
 	logger.DebugContext(ctx, `looking up semver tags to resolve "latest"`, "git_remote", remote)
 	tags, err := t.Tags(ctx, remote)
 	if err != nil {

--- a/templates/commands/render/templatesource/git.go
+++ b/templates/commands/render/templatesource/git.go
@@ -30,7 +30,10 @@ import (
 	"github.com/abcxyz/pkg/logging"
 )
 
-var _ sourceParser = (*gitSourceParser)(nil)
+var (
+	_  sourceParser = (*gitSourceParser)(nil)
+	re              = regexp.MustCompile("^[a-zA-Z0-9/_-]+$")
+)
 
 // gitSourceParser implements sourceParser for downloading templates from a
 // remote git repo.
@@ -198,7 +201,7 @@ func resolveVersion(ctx context.Context, t tagser, remote, version string) (stri
 	case "latest":
 		return resolveLatest(ctx, t, remote, version)
 	default:
-		logger.DebugContext(ctx, `using user provided version, no need to look up remote tags`, "version", version)
+		logger.DebugContext(ctx, "using user provided version and skipping remote tags lookup", "version", version)
 		return version, nil
 	}
 }

--- a/templates/commands/render/templatesource/git_test.go
+++ b/templates/commands/render/templatesource/git_test.go
@@ -223,6 +223,16 @@ func TestResolveVersion(t *testing.T) {
 			want: "main",
 		},
 		{
+			name: "version_with_forward_slash",
+			in:   "username/branch-name",
+			want: "username/branch-name",
+		},
+		{
+			name: "version_with_snake_case",
+			in:   "branch_name",
+			want: "branch_name",
+		},
+		{
 			name:    "empty_input",
 			in:      "",
 			wantErr: `cannot be empty`,

--- a/templates/commands/render/templatesource/git_test.go
+++ b/templates/commands/render/templatesource/git_test.go
@@ -220,7 +220,7 @@ func TestResolveVersion(t *testing.T) {
 		{
 			name:    "empty_input",
 			in:      "",
-			wantErr: `cannot be empty`,
+			wantErr: "cannot be empty",
 		},
 		{
 			name: "version_with_suffix_can_be_specifically_requested",

--- a/templates/commands/render/templatesource/git_test.go
+++ b/templates/commands/render/templatesource/git_test.go
@@ -198,14 +198,9 @@ func TestResolveVersion(t *testing.T) {
 			want: "v1.2.3",
 		},
 		{
-			name:    "version_without_v_prefix_rejected",
-			in:      "1.2.3",
-			wantErr: `must start with "v"`,
-		},
-		{
 			name:    "empty_input",
 			in:      "",
-			wantErr: `must start with "v"`,
+			wantErr: `cannot be empty`,
 		},
 		{
 			name: "version_with_suffix_can_be_specifically_requested",

--- a/templates/commands/render/templatesource/git_test.go
+++ b/templates/commands/render/templatesource/git_test.go
@@ -198,21 +198,6 @@ func TestResolveVersion(t *testing.T) {
 			want: "v1.2.3",
 		},
 		{
-			name:    "version_semver_with_leading_zero",
-			in:      "v01.2.3",
-			wantErr: "not a valid format",
-		},
-		{
-			name:    "version_malformed_semantic_versioning",
-			in:      "v1..23",
-			wantErr: "not a valid format",
-		},
-		{
-			name: "version_branch_name_with_v_prefix",
-			in:   "vbranch",
-			want: "vbranch",
-		},
-		{
 			name: "version_with_sha",
 			in:   "b488f14a5302518e0ba347712e6dc4db4d0f7ce5",
 			want: "b488f14a5302518e0ba347712e6dc4db4d0f7ce5",
@@ -285,11 +270,6 @@ func TestResolveVersion(t *testing.T) {
 				out:        []string{"v1.2.3", "nonsense"},
 			},
 			want: "v1.2.3",
-		},
-		{
-			name:    "malformed_version_rejected",
-			in:      "v👍.😀.🎉",
-			wantErr: "not a valid format",
 		},
 		{
 			name:     "no_tags_exist",

--- a/templates/commands/render/templatesource/git_test.go
+++ b/templates/commands/render/templatesource/git_test.go
@@ -198,6 +198,31 @@ func TestResolveVersion(t *testing.T) {
 			want: "v1.2.3",
 		},
 		{
+			name:    "version_semver_with_leading_zero",
+			in:      "v01.2.3",
+			wantErr: "not a valid format",
+		},
+		{
+			name:    "version_malformed_semantic_versioning",
+			in:      "v1..23",
+			wantErr: "not a valid format",
+		},
+		{
+			name: "version_branch_name_with_v_prefix",
+			in:   "vbranch",
+			want: "vbranch",
+		},
+		{
+			name: "version_with_sha",
+			in:   "b488f14a5302518e0ba347712e6dc4db4d0f7ce5",
+			want: "b488f14a5302518e0ba347712e6dc4db4d0f7ce5",
+		},
+		{
+			name: "version_with_main_branch",
+			in:   "main",
+			want: "main",
+		},
+		{
 			name:    "empty_input",
 			in:      "",
 			wantErr: `cannot be empty`,

--- a/templates/common/git/git.go
+++ b/templates/common/git/git.go
@@ -29,8 +29,8 @@ import (
 
 var sha = regexp.MustCompile("^[0-9a-f]{40}$")
 
-// Clone checks out the given branch or tag from the given repo. It uses the git
-// CLI already installed on the system.
+// Clone checks out the given branch, tag or long commit SHA from the given repo.
+// It uses the git CLI already installed on the system.
 //
 // To optimize storage and bandwidth, the full git history is not fetched.
 //

--- a/templates/common/git/git.go
+++ b/templates/common/git/git.go
@@ -27,7 +27,7 @@ import (
 	"github.com/abcxyz/abc/templates/common"
 )
 
-var sha = regexp.MustCompile("^[[0-9a-f]{40}$")
+var sha = regexp.MustCompile("^[0-9a-f]{40}$")
 
 // Clone checks out the given branch or tag from the given repo. It uses the git
 // CLI already installed on the system.
@@ -39,12 +39,12 @@ var sha = regexp.MustCompile("^[[0-9a-f]{40}$")
 func Clone(ctx context.Context, remote, version, outDir string) error {
 	// if it looks like a sha, run clone, then reset --hard
 	if sha.MatchString(version) {
-		_, _, err := common.Run(ctx, "git", "clone", "--depth", "1", remote, outDir)
+		_, _, err := common.Run(ctx, "git", "clone", remote, outDir)
 		if err != nil {
 			return err //nolint:wrapcheck
 		}
 
-		_, _, err = common.Run(ctx, "git", "clone", "reset", "--hard", version)
+		_, _, err = common.Run(ctx, "git", "-C", outDir, "checkout", version)
 		if err != nil {
 			return err //nolint:wrapcheck
 		}

--- a/templates/common/git/git.go
+++ b/templates/common/git/git.go
@@ -37,14 +37,13 @@ var sha = regexp.MustCompile("^[0-9a-f]{40}$")
 // "remote" may be any format accepted by git, such as
 // https://github.com/abcxyz/abc.git or git@github.com:abcxyz/abc.git .
 func Clone(ctx context.Context, remote, version, outDir string) error {
-	// if it looks like a sha, run clone, then reset --hard
 	if sha.MatchString(version) {
 		_, _, err := common.Run(ctx, "git", "clone", remote, outDir)
 		if err != nil {
 			return err //nolint:wrapcheck
 		}
 
-		_, _, err = common.Run(ctx, "git", "-C", outDir, "checkout", version)
+		_, _, err = common.Run(ctx, "git", "-C", outDir, "reset", "--hard", version)
 		if err != nil {
 			return err //nolint:wrapcheck
 		}

--- a/templates/common/git/git_test.go
+++ b/templates/common/git/git_test.go
@@ -63,44 +63,43 @@ func TestClone(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		name        string
-		remote      string
-		branchOrTag string
-		wantErr     string
+		name    string
+		remote  string
+		version string
+		wantErr string
 	}{
 		{
-			name:        "clone_tag",
-			remote:      "https://github.com/abcxyz/abc.git",
-			branchOrTag: "v0.2.0",
+			name:    "clone_tag",
+			remote:  "https://github.com/abcxyz/abc.git",
+			version: "v0.2.0",
 		},
 		{
-			name:        "alternative_tag_format_fails",
-			remote:      "https://github.com/abcxyz/abc.git",
-			branchOrTag: "refs/tags/v0.2.0",
-			wantErr:     "refs/tags/v0.2.0 not found",
+			name:    "alternative_tag_format_fails",
+			remote:  "https://github.com/abcxyz/abc.git",
+			version: "refs/tags/v0.2.0",
+			wantErr: "refs/tags/v0.2.0 not found",
 		},
 		{
-			name:        "clone_branch",
-			remote:      "https://github.com/abcxyz/abc.git",
-			branchOrTag: "main",
+			name:    "clone_branch",
+			remote:  "https://github.com/abcxyz/abc.git",
+			version: "main",
 		},
 		{
-			name:        "alternative_branch_format_fails",
-			remote:      "https://github.com/abcxyz/abc.git",
-			branchOrTag: "refs/heads/v0.2.0",
-			wantErr:     "refs/heads/v0.2.0 not found",
+			name:    "alternative_branch_format_fails",
+			remote:  "https://github.com/abcxyz/abc.git",
+			version: "refs/heads/v0.2.0",
+			wantErr: "refs/heads/v0.2.0 not found",
 		},
 		{
-			name:        "long_commit_not_supported",
-			remote:      "https://github.com/abcxyz/abc.git",
-			branchOrTag: "b6687471f424efd125f9a3e156c68ed78b9d3b47",
-			wantErr:     "Could not find remote branch b6687471f424efd125f9a3e156c68ed78b9d3b47 to clone",
+			name:    "long_commit_supported",
+			remote:  "https://github.com/abcxyz/abc.git",
+			version: "b6687471f424efd125f9a3e156c68ed78b9d3b47",
 		},
 		{
-			name:        "short_commit_not_supported",
-			remote:      "https://github.com/abcxyz/abc.git",
-			branchOrTag: "b668747",
-			wantErr:     "Could not find remote branch b668747 to clone",
+			name:    "short_commit_not_supported",
+			remote:  "https://github.com/abcxyz/abc.git",
+			version: "b668747",
+			wantErr: "Could not find remote branch b668747 to clone",
 		},
 		{
 			name:    "nonexistent_remote",
@@ -108,10 +107,10 @@ func TestClone(t *testing.T) {
 			wantErr: "repository 'https://example.com/foo/bar/' not found",
 		},
 		{
-			name:        "symlinks_forbidden",
-			remote:      "https://github.com/abcxyz/abc.git",
-			branchOrTag: "drevell/forbidden-symlink-for-test",
-			wantErr:     `one or more symlinks were found in \"https://github.com/abcxyz/abc.git\" at [example-symlink]`,
+			name:    "symlinks_forbidden",
+			remote:  "https://github.com/abcxyz/abc.git",
+			version: "drevell/forbidden-symlink-for-test",
+			wantErr: `one or more symlinks were found in "https://github.com/abcxyz/abc.git" at [example-symlink]`,
 		},
 	}
 
@@ -123,7 +122,7 @@ func TestClone(t *testing.T) {
 
 			ctx := context.Background()
 			outDir := t.TempDir()
-			err := Clone(ctx, tc.remote, tc.branchOrTag, outDir)
+			err := Clone(ctx, tc.remote, tc.version, outDir)
 			if diff := testutil.DiffErrString(err, tc.wantErr); diff != "" {
 				t.Fatal(diff)
 			}

--- a/templates/common/git/git_test.go
+++ b/templates/common/git/git_test.go
@@ -96,6 +96,12 @@ func TestClone(t *testing.T) {
 			version: "b6687471f424efd125f9a3e156c68ed78b9d3b47",
 		},
 		{
+			name:    "non_hexadecimal_long_commit",
+			remote:  "https://github.com/abcxyz/abc.git",
+			version: "z668747&-424.fd125f9a3e156c68ed78b9d3b47",
+			wantErr: "z668747&-424.fd125f9a3e156c68ed78b9d3b47 not found",
+		},
+		{
 			name:    "short_commit_not_supported",
 			remote:  "https://github.com/abcxyz/abc.git",
 			version: "b668747",


### PR DESCRIPTION
abc CLI `v0.3.0` introduced a constraint to only allowing versions with `latest` or `semver` tag. We no longer want to force the tagged semver constraint on users so this change will allow versioning with branch names, including `@main`, or long commit SHA's. Short commit SHA's are not supported and will be tried as branch name or tag.

Resolves #288