### PR TITLE
Give a more helpful error when the input is not a template

### DIFF
--- a/templates/commands/describe/describe.go
+++ b/templates/commands/describe/describe.go
@@ -109,14 +109,14 @@ func (c *Command) realRun(ctx context.Context, rp *runParams) (rErr error) {
 		return err //nolint:wrapcheck
 	}
 
-	specutil.FormatAttrList(c.Stdout(), c.specFieldsForDescribe(spec))
+	specutil.FormatAttrs(c.Stdout(), c.specFieldsForDescribe(spec))
 	return nil
 }
 
 // specFieldsForDescribe get Description and Inputs fields for spec.
 func (c *Command) specFieldsForDescribe(spec *spec.Spec) [][]string {
 	l := make([][]string, 0)
-	l = append(l, specutil.Describe(spec)...)
-	l = append(l, specutil.DescribeAllInputs(spec)...)
+	l = append(l, specutil.Attrs(spec)...)
+	l = append(l, specutil.AllInputAttrs(spec)...)
 	return l
 }

--- a/templates/commands/describe/describe.go
+++ b/templates/commands/describe/describe.go
@@ -20,12 +20,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"path/filepath"
 
 	"github.com/abcxyz/abc/templates/common"
 	"github.com/abcxyz/abc/templates/common/specutil"
 	"github.com/abcxyz/abc/templates/common/templatesource"
-	"github.com/abcxyz/abc/templates/model/decode"
 	spec "github.com/abcxyz/abc/templates/model/spec/v1beta1"
 	"github.com/abcxyz/pkg/cli"
 )
@@ -106,21 +104,9 @@ func (c *Command) realRun(ctx context.Context, rp *runParams) (rErr error) {
 		return err //nolint:wrapcheck
 	}
 
-	specPath := filepath.Join(templateDir, specutil.SpecFileName)
-	f, err := rp.fs.Open(specPath)
+	spec, err := specutil.Load(ctx, rp.fs, templateDir, c.flags.Source)
 	if err != nil {
-		return fmt.Errorf("error opening template spec: ReadFile(): %w", err)
-	}
-	defer f.Close()
-
-	specI, err := decode.DecodeValidateUpgrade(ctx, f, specutil.SpecFileName, decode.KindTemplate)
-	if err != nil {
-		return fmt.Errorf("error reading template spec file: %w", err)
-	}
-
-	spec, ok := specI.(*spec.Spec)
-	if !ok {
-		return fmt.Errorf("internal error: spec file did not decode to spec.Spec")
+		return err //nolint:wrapcheck
 	}
 
 	specutil.FormatAttrList(c.Stdout(), c.specFieldsForDescribe(spec))
@@ -130,7 +116,7 @@ func (c *Command) realRun(ctx context.Context, rp *runParams) (rErr error) {
 // specFieldsForDescribe get Description and Inputs fields for spec.
 func (c *Command) specFieldsForDescribe(spec *spec.Spec) [][]string {
 	l := make([][]string, 0)
-	l = append(l, specutil.SpecDescriptionForDescribe(spec)...)
-	l = append(l, specutil.AllSpecInputVarForDescribe(spec)...)
+	l = append(l, specutil.Describe(spec)...)
+	l = append(l, specutil.DescribeAllInputs(spec)...)
 	return l
 }

--- a/templates/commands/render/render.go
+++ b/templates/commands/render/render.go
@@ -38,7 +38,6 @@ import (
 	"github.com/abcxyz/abc/templates/common"
 	"github.com/abcxyz/abc/templates/common/specutil"
 	"github.com/abcxyz/abc/templates/common/templatesource"
-	"github.com/abcxyz/abc/templates/model/decode"
 	spec "github.com/abcxyz/abc/templates/model/spec/v1beta1"
 	"github.com/abcxyz/pkg/cli"
 	"github.com/abcxyz/pkg/logging"
@@ -157,9 +156,9 @@ func (c *Command) realRun(ctx context.Context, rp *runParams) (outErr error) {
 		return err //nolint:wrapcheck
 	}
 
-	spec, err := loadSpecFile(ctx, rp.fs, templateDir)
+	spec, err := specutil.Load(ctx, rp.fs, templateDir, c.flags.Source)
 	if err != nil {
-		return err
+		return err //nolint:wrapcheck
 	}
 
 	resolvedInputs, err := c.resolveInputs(ctx, rp.fs, spec)
@@ -623,27 +622,6 @@ func loadInputFile(ctx context.Context, fs common.FS, path string) (map[string]s
 		return nil, fmt.Errorf("error parsing yaml file: %w", err)
 	}
 	return m, nil
-}
-
-func loadSpecFile(ctx context.Context, fs common.FS, templateDir string) (*spec.Spec, error) {
-	specPath := filepath.Join(templateDir, specutil.SpecFileName)
-	f, err := fs.Open(specPath)
-	if err != nil {
-		return nil, fmt.Errorf("error opening template spec: ReadFile(): %w", err)
-	}
-	defer f.Close()
-
-	specI, err := decode.DecodeValidateUpgrade(ctx, f, specutil.SpecFileName, decode.KindTemplate)
-	if err != nil {
-		return nil, fmt.Errorf("error reading template spec file: %w", err)
-	}
-
-	spec, ok := specI.(*spec.Spec)
-	if !ok {
-		return nil, fmt.Errorf("internal error: spec file did not decode to spec.Spec")
-	}
-
-	return spec, nil
 }
 
 // Calls RemoveAll on each temp directory. A nonexistent directory is not an error.

--- a/templates/common/specutil/spec.go
+++ b/templates/common/specutil/spec.go
@@ -39,7 +39,7 @@ const (
 	OutputInputRuleKey         = "Rule"
 )
 
-// Describe returns a list of human-readable attributes describing a spec,
+// Attrs returns a list of human-readable attributes describing a spec,
 // as a list where each entry is a list of columns.
 //
 // Example:
@@ -48,23 +48,23 @@ const (
 //	  {"Description", "example description"},
 //	  {"Input Name", "example name"},
 //	}
-func Describe(spec *spec.Spec) [][]string {
+func Attrs(spec *spec.Spec) [][]string {
 	l := make([][]string, 0)
 	l = append(l, []string{OutputDescriptionKey, spec.Desc.Val})
 	return l
 }
 
-// DescribeAllInputs describes all spec.Input values in the spec.
-func DescribeAllInputs(spec *spec.Spec) [][]string {
+// AllInputAttrs describes all spec.Input values in the spec.
+func AllInputAttrs(spec *spec.Spec) [][]string {
 	l := make([][]string, 0)
 	for _, v := range spec.Inputs {
-		l = append(l, DescribeOneInput(v)...)
+		l = append(l, OneInputAttrs(v)...)
 	}
 	return l
 }
 
-// DescribeOneInput describes a specific spec.Input value.
-func DescribeOneInput(input *spec.Input) [][]string {
+// OneInputAttrs describes a specific spec.Input value.
+func OneInputAttrs(input *spec.Input) [][]string {
 	l := make([][]string, 0)
 	l = append(l, []string{OutputInputNameKey, input.Name.Val}, []string{OutputDescriptionKey, input.Desc.Val})
 	if input.Default != nil {
@@ -86,7 +86,7 @@ func DescribeOneInput(input *spec.Input) [][]string {
 	return l
 }
 
-// FormatAttrList formats the attribute list for output
+// FormatAttrs formats the attribute list for output
 //
 // Example output:
 //
@@ -101,7 +101,7 @@ func DescribeOneInput(input *spec.Input) [][]string {
 //
 // Input name:   name2
 // Description:  desc2.
-func FormatAttrList(w io.Writer, attrList [][]string) {
+func FormatAttrs(w io.Writer, attrList [][]string) {
 	tw := tabwriter.NewWriter(w, 8, 0, 2, ' ', 0)
 	for _, v := range attrList {
 		if v[0] == OutputInputNameKey {

--- a/templates/common/specutil/spec_test.go
+++ b/templates/common/specutil/spec_test.go
@@ -38,7 +38,7 @@ func TestSpecDescriptionForDescribe(t *testing.T) {
 		{OutputDescriptionKey, "Test Description"},
 	}
 
-	if diff := cmp.Diff(SpecDescriptionForDescribe(spec), want); diff != "" {
+	if diff := cmp.Diff(Describe(spec), want); diff != "" {
 		t.Errorf("got unexpected spec description (-got +want): %v", diff)
 	}
 }
@@ -80,7 +80,7 @@ func TestAllSpecInputVarForDescribe(t *testing.T) {
 		{"Description", "desc2"},
 	}
 
-	if diff := cmp.Diff(AllSpecInputVarForDescribe(spec), want); diff != "" {
+	if diff := cmp.Diff(DescribeAllInputs(spec), want); diff != "" {
 		t.Errorf("got unexpected spec description (-got +want): %v", diff)
 	}
 }
@@ -164,7 +164,7 @@ func TestSingleSpecInputVarForDescribe(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			if diff := cmp.Diff(AllSpecInputVarForDescribe(tc.spec), tc.want); diff != "" {
+			if diff := cmp.Diff(DescribeAllInputs(tc.spec), tc.want); diff != "" {
 				t.Errorf("got unexpected spec description (-got +want): %v", diff)
 			}
 		})

--- a/templates/common/specutil/spec_test.go
+++ b/templates/common/specutil/spec_test.go
@@ -38,7 +38,7 @@ func TestSpecDescriptionForDescribe(t *testing.T) {
 		{OutputDescriptionKey, "Test Description"},
 	}
 
-	if diff := cmp.Diff(Describe(spec), want); diff != "" {
+	if diff := cmp.Diff(Attrs(spec), want); diff != "" {
 		t.Errorf("got unexpected spec description (-got +want): %v", diff)
 	}
 }
@@ -80,7 +80,7 @@ func TestAllSpecInputVarForDescribe(t *testing.T) {
 		{"Description", "desc2"},
 	}
 
-	if diff := cmp.Diff(DescribeAllInputs(spec), want); diff != "" {
+	if diff := cmp.Diff(AllInputAttrs(spec), want); diff != "" {
 		t.Errorf("got unexpected spec description (-got +want): %v", diff)
 	}
 }
@@ -164,7 +164,7 @@ func TestSingleSpecInputVarForDescribe(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			if diff := cmp.Diff(DescribeAllInputs(tc.spec), tc.want); diff != "" {
+			if diff := cmp.Diff(AllInputAttrs(tc.spec), tc.want); diff != "" {
 				t.Errorf("got unexpected spec description (-got +want): %v", diff)
 			}
 		})


### PR DESCRIPTION
The old error message was:

```
$ abc templates render .
error opening template spec: ReadFile(): open /tmp/template-copy-2622731642/spec.yaml: no such file or directory
```

The new error message is:

```
$ abc templates render .
couldn't find spec.yaml in that directory, the provided template location "." might be incorrect
```

As part of this, we refactor some duplicated code into a common package.

Also clean up some repetitive names and out-of-date comments in specutil/spec.go.