### PR TITLE
Enforce the presence of the --location flag in goldentest

### DIFF
--- a/templates/commands/goldentest/flags.go
+++ b/templates/commands/goldentest/flags.go
@@ -16,6 +16,7 @@
 package goldentest
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/abcxyz/pkg/cli"
@@ -53,6 +54,10 @@ func (r *Flags) Register(set *cli.FlagSet) {
 	// Default test name to the first CLI argument, if given.
 	set.AfterParse(func(existingErr error) error {
 		r.TestName = strings.TrimSpace(set.Arg(0))
+
+		if r.Location == "" {
+			return fmt.Errorf("-l/--location is required")
+		}
 		return nil
 	})
 }

--- a/templates/commands/goldentest/verify_test.go
+++ b/templates/commands/goldentest/verify_test.go
@@ -204,3 +204,14 @@ kind: 'GoldenTest'`
 		})
 	}
 }
+
+func TestVerifyLocationRequired(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	err := (&VerifyCommand{}).Run(ctx, nil)
+	want := "-l/--location is required"
+	if diff := testutil.DiffErrString(err, want); diff != "" {
+		t.Error(diff)
+	}
+}


### PR DESCRIPTION
This flag is documented as required, but not enforced. This PR adds enforcement and a unit test.