### PR TITLE
Fix golden-test command logging in JSON format instead of text

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,6 +4,7 @@
     // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
+
         {
             "name": "Render hello_jupiter example",
             "type": "go",
@@ -14,6 +15,22 @@
                 "templates",
                 "render",
                 "${workspaceFolder}/examples/templates/render/hello_jupiter"
+            ]
+        },
+
+        {
+            "name": "Debug goldentest logging",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            "program": "cmd/abc/abc.go",
+            "args": [
+                "templates",
+                "golden-test",
+                "record",
+                "-l",
+                "${workspaceFolder}/examples/templates/render/hello_jupiter",
+                "example_test"
             ]
         }
     ]

--- a/cmd/abc/abc.go
+++ b/cmd/abc/abc.go
@@ -30,8 +30,8 @@ import (
 )
 
 const (
-	defaultLogLevel = "warn"
-	defaultLogMode  = "text"
+	defaultLogLevel  = logging.LevelWarning
+	defaultLogFormat = logging.FormatText
 )
 
 var rootCmd = func() *cli.RootCommand {
@@ -88,11 +88,11 @@ func main() {
 
 func setLogEnvVars() {
 	if os.Getenv("ABC_LOG_FORMAT") == "" {
-		os.Setenv("ABC_LOG_FORMAT", defaultLogMode)
+		os.Setenv("ABC_LOG_FORMAT", string(defaultLogFormat))
 	}
 
 	if os.Getenv("ABC_LOG_LEVEL") == "" {
-		os.Setenv("ABC_LOG_LEVEL", defaultLogLevel)
+		os.Setenv("ABC_LOG_LEVEL", defaultLogLevel.String())
 	}
 }
 

--- a/templates/commands/goldentest/record.go
+++ b/templates/commands/goldentest/record.go
@@ -76,7 +76,7 @@ func (c *RecordCommand) Run(ctx context.Context, args []string) error {
 	// Create a temporary directory to validate golden tests rendered with no
 	// error. If any test fails, no data should be written to file system
 	// for atomicity purpose.
-	tempDir, err := renderTestCases(testCases, c.flags.Location)
+	tempDir, err := renderTestCases(ctx, testCases, c.flags.Location)
 	defer os.RemoveAll(tempDir)
 	if err != nil {
 		return fmt.Errorf("failed to render test cases: %w", err)

--- a/templates/commands/goldentest/test_funcs_test.go
+++ b/templates/commands/goldentest/test_funcs_test.go
@@ -292,7 +292,8 @@ steps:
 
 			common.WriteAllDefaultMode(t, tempDir, tc.filesContent)
 
-			err := renderTestCase(tempDir, tempDir, tc.testCase)
+			ctx := context.Background()
+			err := renderTestCase(ctx, tempDir, tempDir, tc.testCase)
 			if err != nil {
 				if diff := testutil.DiffErrString(err, tc.wantErr); diff != "" {
 					t.Fatal(diff)

--- a/templates/commands/goldentest/verify.go
+++ b/templates/commands/goldentest/verify.go
@@ -78,7 +78,7 @@ func (c *VerifyCommand) Run(ctx context.Context, args []string) error {
 	}
 
 	// Create a temporary directory to render golden tests
-	tempDir, err := renderTestCases(testCases, c.flags.Location)
+	tempDir, err := renderTestCases(ctx, testCases, c.flags.Location)
 	defer os.RemoveAll(tempDir)
 	if err != nil {
 		return fmt.Errorf("failed to render test cases: %w", err)

--- a/templates/model/goldentest/v1alpha1/upgrade.go
+++ b/templates/model/goldentest/v1alpha1/upgrade.go
@@ -24,7 +24,7 @@ import (
 // Upgrade implements model.ValidatorUpgrader.
 func (t *Test) Upgrade(ctx context.Context) (model.ValidatorUpgrader, error) {
 	logger := logging.FromContext(ctx).With("logger", "Upgrade")
-	logger.DebugContext(ctx, "finished upgrading, this is the most recent version")
+	logger.DebugContext(ctx, "finished upgrading goldentest model, this is the most recent version")
 
 	return nil, model.ErrLatestVersion
 }

--- a/templates/model/manifest/v1alpha1/upgrade.go
+++ b/templates/model/manifest/v1alpha1/upgrade.go
@@ -24,7 +24,7 @@ import (
 // Upgrade implements model.ValidatorUpgrader.
 func (m *Manifest) Upgrade(ctx context.Context) (model.ValidatorUpgrader, error) {
 	logger := logging.FromContext(ctx).With("logger", "Upgrade")
-	logger.DebugContext(ctx, "finished upgrading, this is the most recent version")
+	logger.DebugContext(ctx, "finished upgrading manifest model, this is the most recent version")
 
 	return nil, model.ErrLatestVersion
 }

--- a/templates/model/spec/v1beta1/upgrade.go
+++ b/templates/model/spec/v1beta1/upgrade.go
@@ -24,7 +24,7 @@ import (
 // Upgrade implements model.ValidatorUpgrader.
 func (s *Spec) Upgrade(ctx context.Context) (model.ValidatorUpgrader, error) {
 	logger := logging.FromContext(ctx).With("logger", "Upgrade")
-	logger.DebugContext(ctx, "finished upgrading, this is the most recent version")
+	logger.DebugContext(ctx, "finished upgrading spec model, this is the most recent version")
 
 	return nil, model.ErrLatestVersion
 }


### PR DESCRIPTION
The problem was that the context.Context wasn't being passed through to all the goldentest functions.

Also remove the redundant configuration of signal handlers in goldentest/test_funcs.go. We already have these in abc.go so I think this is superfluous.

Some other minor tweaks as long as I'm touching this code:

 - In the logging package, "mode" was renamed to "format". Update our constant names in abc.go accordingly.
 - Use typed constants for the default log level and mode
 - Fix a misleading log message related to upgrades to make it clear we're talking about model upgrades and not abc binary upgrades.
 - Add a VS Code debugger config for debugging goldentest recording
