### PR TITLE
Clearer golden test recording logic.

### DIFF
--- a/templates/commands/goldentest/record.go
+++ b/templates/commands/goldentest/record.go
@@ -87,8 +87,8 @@ func (c *RecordCommand) Run(ctx context.Context, args []string) error {
 
 	// Recursively copy files from tempDir to template golden test directory.
 	for _, tc := range testCases {
-		testDir := filepath.Join(c.flags.Location, goldenTestDir, tc.TestName)
-		if err := clearTestDir(testDir); err != nil {
+		testDir := filepath.Join(c.flags.Location, goldenTestDir, tc.TestName, testDataDir)
+		if err := os.RemoveAll(testDir); err != nil {
 			return fmt.Errorf("failed to clear test directory: %w", err)
 		}
 
@@ -103,7 +103,7 @@ func (c *RecordCommand) Run(ctx context.Context, args []string) error {
 			}, nil
 		}
 		params := &common.CopyParams{
-			DstRoot: filepath.Join(testDir, testDataDir),
+			DstRoot: testDir,
 			SrcRoot: filepath.Join(tempDir, goldenTestDir, tc.TestName, testDataDir),
 			RFS:     &common.RealFS{},
 			Visitor: visitor,

--- a/templates/commands/goldentest/record_test.go
+++ b/templates/commands/goldentest/record_test.go
@@ -112,7 +112,7 @@ kind: 'GoldenTest'`
 				"spec.yaml":                      specYaml,
 				"a.txt":                          "file A content",
 				"testdata/golden/test/test.yaml": testYaml,
-				"testdata/golden/test/unexpected_file.txt": "oh",
+				"testdata/golden/test/data/unexpected_file.txt": "oh",
 			},
 			expectedGoldenContent: map[string]string{
 				"test/test.yaml":  testYaml,

--- a/templates/commands/goldentest/test_funcs.go
+++ b/templates/commands/goldentest/test_funcs.go
@@ -119,27 +119,6 @@ func parseTestConfig(ctx context.Context, path string) (*goldentest.Test, error)
 	return out, nil
 }
 
-// clearTestDir clears a test directory and only keeps the test config file.
-func clearTestDir(dir string) error {
-	files, err := os.ReadDir(dir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return fmt.Errorf("failed to read test dir: %w", err)
-	}
-
-	for _, file := range files {
-		if file.Name() != configName {
-			filePath := filepath.Join(dir, file.Name())
-			if err := os.RemoveAll(filePath); err != nil {
-				return fmt.Errorf("failed to remove outdated test artifact: %w", err)
-			}
-		}
-	}
-	return nil
-}
-
 // renderTestCases render all test cases in a temporary directory.
 func renderTestCases(ctx context.Context, testCases []*TestCase, location string) (string, error) {
 	tempDir, err := os.MkdirTemp("", "abc-test-*")
@@ -161,7 +140,7 @@ func renderTestCases(ctx context.Context, testCases []*TestCase, location string
 func renderTestCase(ctx context.Context, templateDir, outputDir string, tc *TestCase) error {
 	testDir := filepath.Join(outputDir, goldenTestDir, tc.TestName, testDataDir)
 
-	if err := clearTestDir(testDir); err != nil {
+	if err := os.RemoveAll(testDir); err != nil {
 		return fmt.Errorf("failed to clear test directory: %w", err)
 	}
 

--- a/templates/commands/goldentest/test_funcs_test.go
+++ b/templates/commands/goldentest/test_funcs_test.go
@@ -149,59 +149,6 @@ kind: 'GoldenTest'`
 	}
 }
 
-func TestClearTestDir(t *testing.T) {
-	t.Parallel()
-
-	cases := []struct {
-		name         string
-		filesContent map[string]string
-		expected     map[string]string
-	}{
-		{
-			name: "outdated_test_artifacts_removed",
-			filesContent: map[string]string{
-				"test.yaml":    "yaml",
-				"data/a.txt":   "file A content",
-				"data/b/b.txt": "file B content",
-			},
-			expected: map[string]string{
-				"test.yaml": "yaml",
-			},
-		},
-		{
-			name: "test_config_in_sub_dir_removed",
-			filesContent: map[string]string{
-				"test.yaml":      "yaml",
-				"test/test.yaml": "yaml",
-			},
-			expected: map[string]string{
-				"test.yaml": "yaml",
-			},
-		},
-	}
-
-	for _, tc := range cases {
-		tc := tc
-
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			tempDir := t.TempDir()
-
-			common.WriteAllDefaultMode(t, tempDir, tc.filesContent)
-
-			if err := clearTestDir(tempDir); err != nil {
-				t.Fatal(err)
-			}
-
-			gotDestContents := common.LoadDirWithoutMode(t, tempDir)
-			if diff := cmp.Diff(gotDestContents, tc.expected); diff != "" {
-				t.Errorf("dest directory contents were not as expected (-got,+want): %s", diff)
-			}
-		})
-	}
-}
-
 func TestRenderTestCase(t *testing.T) {
 	t.Parallel()
 

--- a/templates/model/goldentest/v1alpha1/goldentest_test.go
+++ b/templates/model/goldentest/v1alpha1/goldentest_test.go
@@ -36,8 +36,7 @@ func TestTestUnmarshal(t *testing.T) {
 	}{
 		{
 			name: "simple_test_should_succeed",
-			in: `api_version: 'cli.abcxyz.dev/v1alpha1'
-inputs:
+			in: `inputs:
 - name: 'person_name'
   value: 'iron_man'
 - name: 'dog_name'
@@ -57,24 +56,22 @@ inputs:
 		},
 		{
 			name: "no_inputs_should_succeed",
-			in:   `api_version: 'cli.abcxyz.dev/v1alpha1'`,
+			in:   "",
 			want: &Test{},
 		},
 		{
 			name: "missing_field_should_fail",
-			in: `api_version: 'cli.abcxyz.dev/v1alpha1'
-inputs:
+			in: `inputs:
 - name: 'person_name'`,
-			wantErr: `at line 3 column 3: field "value" is required`,
+			wantErr: `at line 2 column 3: field "value" is required`,
 		},
 		{
 			name: "unknown_field_should_fail",
-			in: `api_version: 'cli.abcxyz.dev/v1alpha1'
-inputs:
+			in: `inputs:
 - name: 'person_name'
   value: 'iron_man'
   pet: 'iron_dog'`,
-			wantErr: `at line 5 column 3: unknown field name "pet"; valid choices are [name value]`,
+			wantErr: `at line 4 column 3: unknown field name "pet"; valid choices are [name value]`,
 		},
 	}
 


### PR DESCRIPTION
- Since we're now rendering test file in <testname>/data folder, clearTestDir is no longer needed.
- Also refactored goldentest model testing logic to only focus on goldentest yaml, leaving version and kind validation to other common logic. 