### PR TITLE
Refactor clean-up of passing around canonical source

### DIFF
--- a/templates/commands/render/manifest_test.go
+++ b/templates/commands/render/manifest_test.go
@@ -16,7 +16,6 @@ package render
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -24,6 +23,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/abcxyz/abc/templates/common"
+	"github.com/abcxyz/abc/templates/common/templatesource"
 	"github.com/abcxyz/pkg/testutil"
 )
 
@@ -35,7 +35,7 @@ func TestWriteManifest(t *testing.T) {
 	cases := []struct {
 		name             string
 		dryRun           bool
-		canonicalSourcer canonicalSourcer
+		dlMeta           *templatesource.DownloadMetadata
 		templateContents map[string]string
 		destDirContents  map[string]string
 		inputs           map[string]string
@@ -52,7 +52,9 @@ func TestWriteManifest(t *testing.T) {
 			destDirContents: map[string]string{
 				"a.txt": "some other stuff",
 			},
-			canonicalSourcer: fakeCanonicalSourcer{},
+			dlMeta: &templatesource.DownloadMetadata{
+				IsCanonical: false,
+			},
 			inputs: map[string]string{
 				"pizza":     "hawaiian",
 				"pineapple": "deal with it",
@@ -87,9 +89,9 @@ output_hashes:
 			destDirContents: map[string]string{
 				"a.txt": "some other stuff",
 			},
-			canonicalSourcer: fakeCanonicalSourcer{
-				isCanonical:     true,
-				canonicalSource: "github.com/foo/bar",
+			dlMeta: &templatesource.DownloadMetadata{
+				IsCanonical:     true,
+				CanonicalSource: "github.com/foo/bar",
 			},
 			inputs: map[string]string{
 				"pizza":     "hawaiian",
@@ -117,9 +119,12 @@ output_hashes:
 			},
 		},
 		{
-			name:             "dryrun_no_output",
-			canonicalSourcer: &fakeCanonicalSourcer{},
-			dryRun:           true,
+			name: "dryrun_no_output",
+			dlMeta: &templatesource.DownloadMetadata{
+				IsCanonical:     false,
+				CanonicalSource: "github.com/foo/bar",
+			},
+			dryRun: true,
 			templateContents: map[string]string{
 				"spec.yaml": "some stuff",
 				"a.txt":     "some other stuff",
@@ -147,8 +152,10 @@ output_hashes:
 			destDirContents: map[string]string{
 				"a.txt": "some other stuff",
 			},
-			canonicalSourcer: fakeCanonicalSourcer{},
-			inputs:           map[string]string{},
+			dlMeta: &templatesource.DownloadMetadata{
+				IsCanonical: false,
+			},
+			inputs: map[string]string{},
 			outputHashes: map[string][]byte{
 				"a.txt": []byte("fake_output_hash_32_bytes_sha256"),
 			},
@@ -172,8 +179,10 @@ output_hashes:
 				"spec.yaml": "some stuff",
 				"a.txt":     "some other stuff",
 			},
-			destDirContents:  map[string]string{},
-			canonicalSourcer: fakeCanonicalSourcer{},
+			destDirContents: map[string]string{},
+			dlMeta: &templatesource.DownloadMetadata{
+				IsCanonical: false,
+			},
 			inputs: map[string]string{
 				"pizza":     "hawaiian",
 				"pineapple": "deal with it",
@@ -194,30 +203,6 @@ output_hashes: []
 `,
 			},
 		},
-		{
-			name: "canonical_sourcer_err",
-			templateContents: map[string]string{
-				"spec.yaml": "some stuff",
-				"a.txt":     "some other stuff",
-			},
-			destDirContents: map[string]string{
-				"a.txt": "some other stuff",
-			},
-			canonicalSourcer: fakeCanonicalSourcer{
-				err: fmt.Errorf("fake error for testing"),
-			},
-			inputs: map[string]string{
-				"pizza":     "hawaiian",
-				"pineapple": "deal with it",
-			},
-			outputHashes: map[string][]byte{
-				"a.txt": []byte("fake_output_hash_32_bytes_sha256"),
-			},
-			want: map[string]string{
-				"a.txt": "some other stuff",
-			},
-			wantErr: "fake error for testing",
-		},
 	}
 
 	for _, tc := range cases {
@@ -235,13 +220,13 @@ output_hashes: []
 			ctx := context.Background()
 			err := writeManifest(ctx, &writeManifestParams{
 				clock:        clk,
-				templateDir:  templateDir,
 				destDir:      destDir,
+				dlMeta:       tc.dlMeta,
 				dryRun:       tc.dryRun,
-				cs:           tc.canonicalSourcer,
 				fs:           &common.RealFS{},
 				inputs:       tc.inputs,
 				outputHashes: tc.outputHashes,
+				templateDir:  templateDir,
 			})
 
 			if diff := testutil.DiffErrString(err, tc.wantErr); diff != "" {
@@ -254,16 +239,6 @@ output_hashes: []
 			}
 		})
 	}
-}
-
-type fakeCanonicalSourcer struct {
-	canonicalSource string
-	isCanonical     bool
-	err             error
-}
-
-func (f fakeCanonicalSourcer) CanonicalSource(_ context.Context, cwd, destDir string) (string, bool, error) {
-	return f.canonicalSource, f.isCanonical, f.err
 }
 
 func mockClock(t *testing.T) *clock.Mock {

--- a/templates/commands/render/render.go
+++ b/templates/commands/render/render.go
@@ -148,7 +148,7 @@ func (c *Command) realRun(ctx context.Context, rp *runParams) (outErr error) {
 		outErr = errors.Join(outErr, err)
 	}()
 
-	downloader, templateDir, err := templatesource.Download(ctx, &templatesource.DownloadParams{
+	dlMeta, templateDir, err := templatesource.Download(ctx, &templatesource.DownloadParams{
 		FS:          rp.fs,
 		TempDirBase: rp.tempDirBase,
 		Source:      c.flags.Source,
@@ -210,8 +210,8 @@ func (c *Command) realRun(ctx context.Context, rp *runParams) (outErr error) {
 			if err := writeManifest(ctx, &writeManifestParams{
 				clock:        rp.clock,
 				cwd:          rp.cwd,
+				dlMeta:       dlMeta,
 				destDir:      c.flags.Dest,
-				cs:           downloader,
 				dryRun:       dryRun,
 				fs:           rp.fs,
 				inputs:       resolvedInputs,

--- a/templates/common/templatesource/download.go
+++ b/templates/common/templatesource/download.go
@@ -36,11 +36,10 @@ const (
 // download a template, and provides some metadata.
 type Downloader interface {
 	// Download downloads this template into the given directory.
-	Download(ctx context.Context, outDir string) error
+	Download(ctx context.Context, cwd, destDir string) (*DownloadMetadata, error)
+}
 
-	// CanonicalSource() returns the canonical source location for this
-	// template, if it exists.
-	//
+type DownloadMetadata struct {
 	// A "canonical" location is one that's the same for everybody. When
 	// installing a template source like
 	// "~/my_downloaded_templates/foo_template", that location is not canonical,
@@ -63,12 +62,9 @@ type Downloader interface {
 	// directory are the same for everyone who clones the repo, that means the
 	// relative path counts as a canonical source.
 	//
-	// CanonicalSource should only be called after Download() has returned
-	// successfully. This lets us account for redirects encountered while
-	// downloading.
-	//
-	// "dest" is the value of --dest. cwd is the current working directory.
-	CanonicalSource(ctx context.Context, cwd, dest string) (string, bool, error)
+	// IsCanonical is true if and only if CanonicalSource is non-empty.
+	IsCanonical     bool
+	CanonicalSource string
 }
 
 // The parameters to Download, wrapped in a struct because there are so many.
@@ -97,7 +93,7 @@ type DownloadParams struct {
 //
 // If error is returned, then the returned directory name may or may not exist,
 // and may or may not be empty.
-func Download(ctx context.Context, p *DownloadParams) (Downloader, string, error) {
+func Download(ctx context.Context, p *DownloadParams) (*DownloadMetadata, string, error) {
 	logger := logging.FromContext(ctx).With("logger", "Download")
 
 	templateDir, err := p.FS.MkdirTemp(p.TempDirBase, templateDirNamePart)
@@ -116,19 +112,18 @@ func Download(ctx context.Context, p *DownloadParams) (Downloader, string, error
 	}
 	logger.DebugContext(ctx, "template location parse successful as", "type", reflect.TypeOf(downloader).String())
 
-	if err := downloader.Download(ctx, templateDir); err != nil {
+	dlMeta, err := downloader.Download(ctx, p.CWD, templateDir)
+	if err != nil {
 		return nil, templateDir, err //nolint:wrapcheck
 	}
 	logger.DebugContext(ctx, "downloaded source template temporary directory",
 		"source", p.Source,
 		"destination", templateDir)
 
-	if canonicalSource, _, err := downloader.CanonicalSource(ctx, p.CWD, p.Dest); err != nil {
-		return nil, "", err //nolint:wrapcheck
-	} else if canonicalSource != "" && strings.ContainsAny(canonicalSource, `\`+"\n") { // TODO test
+	if dlMeta.IsCanonical && strings.ContainsAny(dlMeta.CanonicalSource, `\`+"\n") {
 		return nil, "", fmt.Errorf("the template location contains a disallowed character; no backslashes or newlines are allowed in the canonicalized source %q",
-			canonicalSource)
+			dlMeta.CanonicalSource)
 	}
 
-	return downloader, templateDir, nil
+	return dlMeta, templateDir, nil
 }

--- a/templates/common/templatesource/git.go
+++ b/templates/common/templatesource/git.go
@@ -113,12 +113,12 @@ func (g *gitSourceParser) sourceParse(ctx context.Context, _ string, params *Par
 // gitDownloader implements templateSource for templates hosted in a remote git
 // repo, regardless of which git hosting service it uses.
 type gitDownloader struct {
-	// An HTTPS or SSH connection string understood by "git clone"
+	// An HTTPS or SSH connection string understood by "git clone".
 	remote string
-	// An optional subdirectory within the git repo that we want
+	// An optional subdirectory within the git repo that we want.
 	subdir string
 
-	// either a semver-formatted tag, or the magic value "latest"
+	// A tag, branch, SHA, or the magic value "latest".
 	version string
 
 	canonicalSource string
@@ -128,62 +128,67 @@ type gitDownloader struct {
 }
 
 // Download implements Downloader.
-func (g *gitDownloader) Download(ctx context.Context, outDir string) error {
+func (g *gitDownloader) Download(ctx context.Context, cwd, destDir string) (*DownloadMetadata, error) {
 	logger := logging.FromContext(ctx).With("logger", "gitDownloader.Download")
 
 	// Validate first before doing expensive work
 	subdir, err := common.SafeRelPath(nil, g.subdir) // protect against ".." traversal attacks
 	if err != nil {
-		return fmt.Errorf("invalid subdirectory: %w", err)
+		return nil, fmt.Errorf("invalid subdirectory: %w", err)
 	}
 
 	version, err := resolveVersion(ctx, g.tagser, g.remote, g.version)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	logger.DebugContext(ctx, "resolved version from",
 		"input", g.version,
 		"to", version)
 
-	// Rather than cloning directly into outDir, we clone into a temp dir. It would
-	// be incorrect to clone the whole repo into outDir if the caller only asked
+	// Rather than cloning directly into destDir, we clone into a temp dir. It would
+	// be incorrect to clone the whole repo into destDir if the caller only asked
 	// for a subdirectory, e.g. "github.com/my-org/my-repo/my-subdir@v1.2.3".
 	tmpDir, err := os.MkdirTemp(os.TempDir(), "git-clone-")
 	if err != nil {
-		return fmt.Errorf("MkdirTemp: %w", err)
+		return nil, fmt.Errorf("MkdirTemp: %w", err)
 	}
 	defer os.RemoveAll(tmpDir)
 	subdirToCopy := filepath.Join(tmpDir, filepath.FromSlash(subdir))
 
 	if err := g.cloner.Clone(ctx, g.remote, version, tmpDir); err != nil {
-		return fmt.Errorf("Clone(): %w", err)
+		return nil, fmt.Errorf("Clone(): %w", err)
 	}
 
 	fi, err := os.Stat(subdirToCopy)
 	if err != nil {
 		if common.IsStatNotExistErr(err) {
-			return fmt.Errorf(`the repo %q at tag %q doesn't contain a subdirectory named %q; it's possible that the template exists in the "main" branch but is not part of the release %q`, g.remote, version, subdir, version)
+			return nil, fmt.Errorf(`the repo %q at tag %q doesn't contain a subdirectory named %q; it's possible that the template exists in the "main" branch but is not part of the release %q`, g.remote, version, subdir, version)
 		}
-		return err //nolint:wrapcheck // Stat() returns a decently informative error
+		return nil, err //nolint:wrapcheck // Stat() returns a decently informative error
 	}
 	if !fi.IsDir() {
-		return fmt.Errorf("the path %q is not a directory", subdir)
+		return nil, fmt.Errorf("the path %q is not a directory", subdir)
 	}
 
 	logger.DebugContext(ctx, "cloned repo",
 		"remote", g.remote,
 		"version", version)
 
-	// Copy only the requested subdir to outDir.
+	// Copy only the requested subdir to destDir.
 	if err := common.CopyRecursive(ctx, nil, &common.CopyParams{
-		DstRoot: outDir,
+		DstRoot: destDir,
 		SrcRoot: subdirToCopy,
 		RFS:     &common.RealFS{},
 	}); err != nil {
-		return err //nolint:wrapcheck
+		return nil, err //nolint:wrapcheck
 	}
 
-	return nil
+	dlMeta := &DownloadMetadata{
+		IsCanonical:     true, // Remote git sources are always canonical.
+		CanonicalSource: g.canonicalSource,
+	}
+
+	return dlMeta, nil
 }
 
 func (g *gitDownloader) CanonicalSource(context.Context, string, string) (string, bool, error) {
@@ -252,13 +257,13 @@ func resolveLatest(ctx context.Context, t tagser, remote, version string) (strin
 
 // A fakeable interface around the lower-level git Clone function, for testing.
 type cloner interface {
-	Clone(ctx context.Context, remote, version, outDir string) error
+	Clone(ctx context.Context, remote, version, destDir string) error
 }
 
 type realCloner struct{}
 
-func (r *realCloner) Clone(ctx context.Context, remote, version, outDir string) error {
-	return git.Clone(ctx, remote, version, outDir) //nolint:wrapcheck
+func (r *realCloner) Clone(ctx context.Context, remote, version, destDir string) error {
+	return git.Clone(ctx, remote, version, destDir) //nolint:wrapcheck
 }
 
 // A fakeable interface around the lower-level git Tags function, for testing.

--- a/templates/common/templatesource/localsource.go
+++ b/templates/common/templatesource/localsource.go
@@ -136,7 +136,7 @@ func canonicalize(ctx context.Context, cwd, src, dest string) (string, bool, err
 	if err != nil {
 		return "", false, fmt.Errorf("filepath.Rel(%q,%q): %w", dest, src, err)
 	}
-	return out, true, nil
+	return filepath.ToSlash(out), true, nil
 }
 
 // gitWorkspace looks for the presence of a .git directory in parent directories

--- a/templates/common/templatesource/localsource_test.go
+++ b/templates/common/templatesource/localsource_test.go
@@ -1,0 +1,177 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package templatesource
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	"github.com/abcxyz/abc/templates/common"
+	"github.com/abcxyz/pkg/sets"
+	"github.com/abcxyz/pkg/testutil"
+)
+
+func TestLocalDownloader_Download(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name            string
+		srcDir          string
+		destDir         string
+		initialContents map[string]string
+		wantNewFiles    map[string]string
+		wantDLMeta      *DownloadMetadata
+		wantErr         string
+	}{
+		{
+			name:    "simple_success",
+			srcDir:  "src",
+			destDir: "dst",
+			initialContents: map[string]string{
+				"src/file1.txt":   "file1 contents",
+				"src/a/file2.txt": "file2 contents",
+			},
+			wantNewFiles: map[string]string{
+				"dst/file1.txt":   "file1 contents",
+				"dst/a/file2.txt": "file2 contents",
+			},
+			wantDLMeta: &DownloadMetadata{
+				IsCanonical: false,
+			},
+		},
+		{
+			name:    "nonexistent_source",
+			srcDir:  "nonexistent",
+			wantErr: "no such file",
+		},
+		{
+			name:    "dest_dir_in_same_git_workspace",
+			srcDir:  "src",
+			destDir: "dst",
+			initialContents: map[string]string{
+				// A minimal .git directory
+				".git/refs/_":    "",
+				".git/objects/_": "",
+				".git/HEAD":      "ref: refs/heads/main",
+				"src/spec.yaml":  "file1 contents",
+				"src/file1.txt":  "file1 contents",
+			},
+			wantNewFiles: map[string]string{
+				"dst/spec.yaml": "file1 contents",
+				"dst/file1.txt": "file1 contents",
+			},
+			wantDLMeta: &DownloadMetadata{
+				IsCanonical:     true,
+				CanonicalSource: "../src",
+			},
+		},
+		{
+			name:    "dest_dir_in_different_git_workspace",
+			srcDir:  "src/dir1",
+			destDir: "dst/dir1",
+			initialContents: map[string]string{
+				"src/.git/refs/_":    "",
+				"src/.git/objects/_": "",
+				"src/.git/HEAD":      "ref: refs/heads/main",
+				"src/dir1/spec.yaml": "file1 contents",
+				"src/dir1/file1.txt": "file1 contents",
+
+				"dst/.git/refs/_":    "",
+				"dst/.git/objects/_": "",
+				"dst/.git/HEAD":      "ref: refs/heads/main",
+			},
+			wantNewFiles: map[string]string{
+				"dst/dir1/spec.yaml": "file1 contents",
+				"dst/dir1/file1.txt": "file1 contents",
+			},
+			wantDLMeta: &DownloadMetadata{
+				IsCanonical: false,
+			},
+		},
+		{
+			name:    "source_in_git_but_dest_is_not",
+			srcDir:  "src/dir1",
+			destDir: "dst",
+			initialContents: map[string]string{
+				"src/.git/refs/_":    "",
+				"src/.git/objects/_": "",
+				"src/.git/HEAD":      "ref: refs/heads/main",
+				"src/dir1/spec.yaml": "file1 contents",
+				"src/dir1/file1.txt": "file1 contents",
+			},
+			wantNewFiles: map[string]string{
+				"dst/spec.yaml": "file1 contents",
+				"dst/file1.txt": "file1 contents",
+			},
+			wantDLMeta: &DownloadMetadata{
+				IsCanonical: false,
+			},
+		},
+		{
+			name:    "dest_in_git_but_src_is_not",
+			srcDir:  "src",
+			destDir: "dst",
+			initialContents: map[string]string{
+				"src/spec.yaml": "file1 contents",
+				"src/file1.txt": "file1 contents",
+
+				"dst/.git/refs/_":    "",
+				"dst/.git/objects/_": "",
+				"dst/.git/HEAD":      "ref: refs/heads/main",
+			},
+			wantNewFiles: map[string]string{
+				"dst/spec.yaml": "file1 contents",
+				"dst/file1.txt": "file1 contents",
+			},
+			wantDLMeta: &DownloadMetadata{
+				IsCanonical: false,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			tmp := t.TempDir()
+			common.WriteAllDefaultMode(t, tmp, tc.initialContents)
+			dl := &localDownloader{
+				srcPath: filepath.Join(tmp, filepath.FromSlash(tc.srcDir)),
+			}
+			dest := filepath.Join(tmp, filepath.FromSlash(tc.destDir))
+			gotMeta, err := dl.Download(ctx, tmp, dest)
+			if diff := testutil.DiffErrString(err, tc.wantErr); diff != "" {
+				t.Error(diff)
+			}
+
+			got := common.LoadDirWithoutMode(t, tmp)
+			want := sets.UnionMapKeys(tc.initialContents, tc.wantNewFiles)
+			if diff := cmp.Diff(got, want); diff != "" {
+				t.Errorf("output directory contents were not as expected: %s", diff)
+			}
+
+			if diff := cmp.Diff(gotMeta, tc.wantDLMeta, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("DownloadMetadata was not as expected (-got,+want): %s", diff)
+			}
+		})
+	}
+}

--- a/templates/common/templatesource/localsource_test.go
+++ b/templates/common/templatesource/localsource_test.go
@@ -58,7 +58,7 @@ func TestLocalDownloader_Download(t *testing.T) {
 		{
 			name:    "nonexistent_source",
 			srcDir:  "nonexistent",
-			wantErr: "no such file",
+			wantErr: "nonexistent",
 		},
 		{
 			name:    "dest_dir_in_same_git_workspace",

--- a/templates/common/templatesource/source_test.go
+++ b/templates/common/templatesource/source_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/abcxyz/pkg/testutil"
 )
 
-func TestParseSourceWithWorkingDir(t *testing.T) {
+func TestParseSourceWithCwd(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
@@ -122,76 +122,6 @@ func TestParseSourceWithWorkingDir(t *testing.T) {
 			},
 			want: &localDownloader{
 				srcPath: filepath.FromSlash("my/dir"),
-			},
-		},
-		{
-			name:   "dest_dir_in_same_git_workspace",
-			source: filepath.FromSlash("dir1/mytemplate"),
-			tempDirContents: map[string]string{
-				"dir1/mytemplate/spec.yaml": "my spec file contents",
-
-				// A minimal .git directory
-				"dir1/.git/refs/_":    "",
-				"dir1/.git/objects/_": "",
-				"dir1/.git/HEAD":      "ref: refs/heads/main",
-			},
-			dest:                "dir1/dest",
-			wantCanonicalSource: filepath.FromSlash("../mytemplate"),
-			want: &localDownloader{
-				srcPath: filepath.FromSlash("dir1/mytemplate"),
-			},
-		},
-		{
-			name:   "dest_dir_in_different_git_workspace",
-			source: filepath.FromSlash("dir1/mytemplate"),
-			tempDirContents: map[string]string{
-				"dir1/mytemplate/spec.yaml": "my spec file contents",
-
-				// A minimal .git directory
-				"dir1/.git/refs/_":    "",
-				"dir1/.git/objects/_": "",
-				"dir1/.git/HEAD":      "ref: refs/heads/main",
-
-				// Another minimal .git directory
-				"dir2/.git/refs/_":    "",
-				"dir2/.git/objects/_": "",
-				"dir2/.git/HEAD":      "ref: refs/heads/main",
-			},
-			dest: "dir2",
-			want: &localDownloader{
-				srcPath: filepath.FromSlash("dir1/mytemplate"),
-			},
-		},
-		{
-			name:   "source_in_git_but_dest_is_not",
-			source: filepath.FromSlash("dir1/mytemplate"),
-			tempDirContents: map[string]string{
-				"dir1/mytemplate/spec.yaml": "my spec file contents",
-
-				// A minimal .git directory
-				"dir1/.git/refs/_":    "",
-				"dir1/.git/objects/_": "",
-				"dir1/.git/HEAD":      "ref: refs/heads/main",
-			},
-			dest: "dir2",
-			want: &localDownloader{
-				srcPath: filepath.FromSlash("dir1/mytemplate"),
-			},
-		},
-		{
-			name:   "dist_in_git_but_src_is_not",
-			source: filepath.FromSlash("dir1/mytemplate"),
-			tempDirContents: map[string]string{
-				"dir1/mytemplate/spec.yaml": "my spec file contents",
-
-				// A minimal .git directory
-				"dir2/.git/refs/_":    "",
-				"dir2/.git/objects/_": "",
-				"dir2/.git/HEAD":      "ref: refs/heads/main",
-			},
-			dest: "dir2",
-			want: &localDownloader{
-				srcPath: filepath.FromSlash("dir1/mytemplate"),
 			},
 		},
 		{
@@ -350,23 +280,6 @@ func TestParseSourceWithWorkingDir(t *testing.T) {
 			}
 			if diff := cmp.Diff(got, tc.want, opts...); diff != "" {
 				t.Errorf("downloader was not as expected (-got,+want): %s", diff)
-			}
-
-			// We can't continue with verifying the canonical source if there's
-			// no Downloader.
-			if got == nil {
-				return
-			}
-
-			gotCanonicalSource, ok, err := got.CanonicalSource(ctx, tempDir, tc.dest)
-			if err != nil {
-				t.Fatalf("CanonicalSource() returned error: %v", err)
-			}
-			if gotCanonicalSource != tc.wantCanonicalSource {
-				t.Errorf("got canonical source %q, want %q", gotCanonicalSource, tc.wantCanonicalSource)
-			}
-			if gotCanonicalSource == "" && ok {
-				t.Errorf("CanonicalSource returned true but with an empty canonical source")
 			}
 		})
 	}


### PR DESCRIPTION
There was some awkwardness around passing around a Downloader object that had already been used for downloading, just for the purpose of getting some metadata about the download. This cleanup just returns the download metadata from the Download() function, and that's passed around instead.

This avoids:
 - Undesirable statefulness in the Downloader
 - Leaking the Downloader to places that shouldn't download
 - Overly complicated tests that have to mock a Downloader despite not doing any downloading