### PR TITLE
Change debug scratch contents to Warn

### DIFF
--- a/templates/commands/render/render.go
+++ b/templates/commands/render/render.go
@@ -471,7 +471,7 @@ func executeSteps(ctx context.Context, steps []*spec.Step, sp *stepParams) error
 			if err != nil {
 				return err
 			}
-			logger.DebugContext(ctx, contents)
+			logger.WarnContext(ctx, contents)
 		}
 	}
 	return nil


### PR DESCRIPTION
This should be visible at the default log level, and the default log level is Warn.