### PR TITLE
Update golden-test cmd param orders.

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,18 +106,19 @@ The valid values for `ABC_LOG_LEVEL` are `debug`, `info`, `notice`, `warning`,
 ### For `abc templates golden-test`
 
 Usages:
-- `abc templates golden-test record --location=<template_location> <testname>`
-- `abc templates golden-test verify --location=<template_location> <testname>`
+- `abc templates golden-test record --test-name=<test_name> <location>`
+- `abc templates golden-test verify --test-name=<test_name> <location>`
 
 Examples:
-- `abc templates golden-test record --location=examples/templates/render/hello_jupiter example_test`
-- `abc templates golden-test record --location=examples/templates/render/hello_jupiter`
-- `abc templates golden-test verify --location=examples/templates/render/hello_jupiter`
+- `abc templates golden-test record --test-name=example_test examples/templates/render/hello_jupiter`
+- `abc templates golden-test record examples/templates/render/hello_jupiter`
+- `abc templates golden-test verify examples/templates/render/hello_jupiter`
+
+The `<test_name>` parameter gives the test names to record or verify, if not
+specified, all tests will be run against. This flag may be repeated, like 
+-`-test-name=test1`, `--test-name=test2`, or `--test-name=test1,test2`.
 
 The `<location>` parameter gives the location of the template.
-
-The `<testname>` parameter gives the test name to record or verify, if not
-specified, all tests will be run against.
 
 For every test case, it is expected that
   - a testdata/golden/<test_name> folder exists to host test results.

--- a/README.md
+++ b/README.md
@@ -106,8 +106,8 @@ The valid values for `ABC_LOG_LEVEL` are `debug`, `info`, `notice`, `warning`,
 ### For `abc templates golden-test`
 
 Usages:
-- `abc templates golden-test record --test-name=<test_name> <location>`
-- `abc templates golden-test verify --test-name=<test_name> <location>`
+- `abc templates golden-test record [--test-name=<test_name>] <location>`
+- `abc templates golden-test verify [--test-name=<test_name>] <location>`
 
 Examples:
 - `abc templates golden-test record --test-name=example_test examples/templates/render/hello_jupiter`

--- a/templates/commands/goldentest/flags.go
+++ b/templates/commands/goldentest/flags.go
@@ -26,37 +26,37 @@ import (
 type Flags struct {
 	// Positional arguments:
 
-	// Test name is the name of the test case to record or verify. If no test
-	// name is specified, all gold tests will be run against.
-	//
-	// Optional.
-	TestName string
-
-	// Flag arguments (--foo):
-
 	// Location is the file system location of the template to be tested.
 	//
 	// Example: t/rest_server.
 	Location string
+
+	// Flag arguments (--foo):
+
+	// Testnames are the name of the test cases to record or verify. If no
+	// test name is specified, all gold tests will be run against.
+	//
+	// Optional.
+	TestNames []string
 }
 
 func (r *Flags) Register(set *cli.FlagSet) {
 	f := set.NewSection("TEST OPTIONS")
 
-	f.StringVar(&cli.StringVar{
-		Name:    "location",
-		Aliases: []string{"l"},
-		Example: "/my/template/dir",
-		Target:  &r.Location,
-		Usage:   "Required. The file system location of the template to be tested.",
+	f.StringSliceVar(&cli.StringSliceVar{
+		Name:    "test-name",
+		Aliases: []string{"t"},
+		Example: "test_case_1",
+		Target:  &r.TestNames,
+		Usage:   "The name of the test cases to record or verify.",
 	})
 
-	// Default test name to the first CLI argument, if given.
+	// Default template location to the first CLI argument, if given
 	set.AfterParse(func(existingErr error) error {
-		r.TestName = strings.TrimSpace(set.Arg(0))
+		r.Location = strings.TrimSpace(set.Arg(0))
 
 		if r.Location == "" {
-			return fmt.Errorf("-l/--location is required")
+			return fmt.Errorf("missing template <location>")
 		}
 		return nil
 	})

--- a/templates/commands/goldentest/record.go
+++ b/templates/commands/goldentest/record.go
@@ -42,7 +42,7 @@ func (c *RecordCommand) Desc() string {
 
 func (c *RecordCommand) Help() string {
 	return `
-Usage: {{ COMMAND }} --test-name=<test-name-1>,<test-name-2> <location>
+Usage: {{ COMMAND }} [--test-name=<test-name-1>,<test-name-2>] <location>
 
 The {{ COMMAND }} records the template golden tests.
 

--- a/templates/commands/goldentest/record.go
+++ b/templates/commands/goldentest/record.go
@@ -42,14 +42,14 @@ func (c *RecordCommand) Desc() string {
 
 func (c *RecordCommand) Help() string {
 	return `
-Usage: {{ COMMAND }} --location=<location> <test_name>
+Usage: {{ COMMAND }} --test-name=<test-name-1>,<test-name-2> <location>
 
 The {{ COMMAND }} records the template golden tests.
 
-The "<location>" is the location of the template.
-
 The "<test_name>" is the name of the test. If no <test_name> is specified,
 all tests will be recoreded.
+
+The "<location>" is the location of the template.
 
 For every test case, it is expected that
   - a testdata/golden/<test_name> folder exists to host test results.
@@ -68,7 +68,7 @@ func (c *RecordCommand) Run(ctx context.Context, args []string) error {
 		return fmt.Errorf("failed to parse flags: %w", err)
 	}
 
-	testCases, err := parseTestCases(ctx, c.flags.Location, c.flags.TestName)
+	testCases, err := parseTestCases(ctx, c.flags.Location, c.flags.TestNames)
 	if err != nil {
 		return fmt.Errorf("failed to parse golden test: %w", err)
 	}

--- a/templates/commands/goldentest/test_funcs.go
+++ b/templates/commands/goldentest/test_funcs.go
@@ -63,15 +63,12 @@ func parseTestCases(ctx context.Context, location string, testNames []string) ([
 
 	if len(testNames) > 0 {
 		for _, testName := range testNames {
-			testConfig := filepath.Join(testDir, testName, configName)
-			test, err := parseTestConfig(ctx, testConfig)
+			testCase, err := buildTestCase(ctx, testDir, testName)
 			if err != nil {
 				return nil, err
 			}
-			testCases = append(testCases, &TestCase{
-				TestName:   testName,
-				TestConfig: test,
-			})
+
+			testCases = append(testCases, testCase)
 		}
 		return testCases, nil
 	}
@@ -86,19 +83,29 @@ func parseTestCases(ctx context.Context, location string, testNames []string) ([
 			return nil, fmt.Errorf("unexpected file entry under golden test directory: %s", entry.Name())
 		}
 
-		testConfig := filepath.Join(testDir, entry.Name(), configName)
-		test, err := parseTestConfig(ctx, testConfig)
+		testCase, err := buildTestCase(ctx, testDir, entry.Name())
 		if err != nil {
 			return nil, err
 		}
 
-		testCases = append(testCases, &TestCase{
-			TestName:   entry.Name(),
-			TestConfig: test,
-		})
+		testCases = append(testCases, testCase)
 	}
 
 	return testCases, nil
+}
+
+// buildtestCases builds the name and config of a test case.
+func buildTestCase(ctx context.Context, testDir, testName string) (*TestCase, error) {
+	testConfig := filepath.Join(testDir, testName, configName)
+	test, err := parseTestConfig(ctx, testConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return &TestCase{
+		TestName:   testName,
+		TestConfig: test,
+	}, nil
 }
 
 // parseTestConfig reads a configuration yaml and returns the result.

--- a/templates/commands/goldentest/test_funcs.go
+++ b/templates/commands/goldentest/test_funcs.go
@@ -52,25 +52,28 @@ const (
 )
 
 // parseTestCases returns a list of test cases to record or verify.
-func parseTestCases(ctx context.Context, location, testName string) ([]*TestCase, error) {
+func parseTestCases(ctx context.Context, location string, testNames []string) ([]*TestCase, error) {
 	if _, err := os.Stat(location); err != nil {
 		return nil, fmt.Errorf("error reading template directory (%s): %w", location, err)
 	}
 
 	testDir := filepath.Join(location, goldenTestDir)
 
-	if testName != "" {
-		testConfig := filepath.Join(testDir, testName, configName)
-		test, err := parseTestConfig(ctx, testConfig)
-		if err != nil {
-			return nil, err
-		}
-		return []*TestCase{
-			{
+	testCases := []*TestCase{}
+
+	if len(testNames) > 0 {
+		for _, testName := range testNames {
+			testConfig := filepath.Join(testDir, testName, configName)
+			test, err := parseTestConfig(ctx, testConfig)
+			if err != nil {
+				return nil, err
+			}
+			testCases = append(testCases, &TestCase{
 				TestName:   testName,
 				TestConfig: test,
-			},
-		}, nil
+			})
+		}
+		return testCases, nil
 	}
 
 	entries, err := os.ReadDir(testDir)
@@ -78,7 +81,6 @@ func parseTestCases(ctx context.Context, location, testName string) ([]*TestCase
 		return nil, fmt.Errorf("error reading golden test directory (%s): %w", testDir, err)
 	}
 
-	testCases := []*TestCase{}
 	for _, entry := range entries {
 		if !entry.IsDir() {
 			return nil, fmt.Errorf("unexpected file entry under golden test directory: %s", entry.Name())

--- a/templates/commands/goldentest/test_funcs_test.go
+++ b/templates/commands/goldentest/test_funcs_test.go
@@ -39,14 +39,14 @@ kind: 'GoldenTest'`
 
 	cases := []struct {
 		name         string
-		testName     string
+		testNames    []string
 		filesContent map[string]string
 		want         []*TestCase
 		wantErr      string
 	}{
 		{
-			name:     "specified_test_name_succeed",
-			testName: "test_case_1",
+			name:      "specified_test_name_succeed",
+			testNames: []string{"test_case_1"},
 			filesContent: map[string]string{
 				"testdata/golden/test_case_1/test.yaml": validYaml,
 			},
@@ -58,8 +58,26 @@ kind: 'GoldenTest'`
 			},
 		},
 		{
-			name:     "all_tests_succeed",
-			testName: "",
+			name:      "specified_multiple_test_names_succeed",
+			testNames: []string{"test_case_1", "test_case_2"},
+			filesContent: map[string]string{
+				"testdata/golden/test_case_1/test.yaml": validYaml,
+				"testdata/golden/test_case_2/test.yaml": validYaml,
+				"testdata/golden/test_case_3/test.yaml": validYaml,
+			},
+			want: []*TestCase{
+				{
+					TestName:   "test_case_1",
+					TestConfig: validTestCase,
+				},
+				{
+					TestName:   "test_case_2",
+					TestConfig: validTestCase,
+				},
+			},
+		},
+		{
+			name: "all_tests_succeed",
 			filesContent: map[string]string{
 				"testdata/golden/test_case_1/test.yaml": validYaml,
 				"testdata/golden/test_case_2/test.yaml": validYaml,
@@ -76,8 +94,7 @@ kind: 'GoldenTest'`
 			},
 		},
 		{
-			name:     "golden_test_dir_not_exist",
-			testName: "",
+			name: "golden_test_dir_not_exist",
 			filesContent: map[string]string{
 				"myfile": invalidYaml,
 			},
@@ -85,8 +102,7 @@ kind: 'GoldenTest'`
 			wantErr: "error reading golden test directory",
 		},
 		{
-			name:     "unexpected_file_in_golden_test_dir",
-			testName: "",
+			name: "unexpected_file_in_golden_test_dir",
 			filesContent: map[string]string{
 				"testdata/golden/hello.txt": invalidYaml,
 			},
@@ -94,8 +110,7 @@ kind: 'GoldenTest'`
 			wantErr: "unexpected file entry under golden test directory",
 		},
 		{
-			name:     "test_does_not_have_config",
-			testName: "",
+			name: "test_does_not_have_config",
 			filesContent: map[string]string{
 				"testdata/golden/test_case_1/hello.txt": invalidYaml,
 			},
@@ -103,8 +118,7 @@ kind: 'GoldenTest'`
 			wantErr: "error opening test config",
 		},
 		{
-			name:     "test_bad_config",
-			testName: "",
+			name: "test_bad_config",
 			filesContent: map[string]string{
 				"testdata/golden/test_case_1/test.yaml": invalidYaml,
 			},
@@ -112,8 +126,8 @@ kind: 'GoldenTest'`
 			wantErr: "error reading golden test config file",
 		},
 		{
-			name:     "specified_test_name_not_found",
-			testName: "test_case_2",
+			name:      "specified_test_name_not_found",
+			testNames: []string{"test_case_2"},
 			filesContent: map[string]string{
 				"testdata/golden/test_case_1/test.yaml": validYaml,
 			},
@@ -133,7 +147,7 @@ kind: 'GoldenTest'`
 			common.WriteAllDefaultMode(t, tempDir, tc.filesContent)
 
 			ctx := context.Background()
-			got, err := parseTestCases(ctx, tempDir, tc.testName)
+			got, err := parseTestCases(ctx, tempDir, tc.testNames)
 			if err != nil {
 				if diff := testutil.DiffErrString(err, tc.wantErr); diff != "" {
 					t.Fatal(diff)

--- a/templates/commands/goldentest/verify.go
+++ b/templates/commands/goldentest/verify.go
@@ -46,7 +46,7 @@ func (c *VerifyCommand) Desc() string {
 
 func (c *VerifyCommand) Help() string {
 	return `
-Usage: {{ COMMAND }} --test-name=<test-name-1>,<test-name-2> <location>
+Usage: {{ COMMAND }} [--test-name=<test-name-1>,<test-name-2>] <location>
 
 The {{ COMMAND }} verifies the template golden tests.
 

--- a/templates/commands/goldentest/verify.go
+++ b/templates/commands/goldentest/verify.go
@@ -46,14 +46,14 @@ func (c *VerifyCommand) Desc() string {
 
 func (c *VerifyCommand) Help() string {
 	return `
-Usage: {{ COMMAND }} --location=<location> <test_name>
+Usage: {{ COMMAND }} --test-name=<test-name-1>,<test-name-2> <location>
 
-The {{ COMMAND }} verify the template golden test.
-
-The "<location>" is the location of the template.
+The {{ COMMAND }} records the template golden tests.
 
 The "<test_name>" is the name of the test. If no <test_name> is specified,
-all tests will be run against.
+all tests will be recoreded.
+
+The "<location>" is the location of the template.
 
 For every test case, it is expected that
   - a testdata/golden/<test_name> folder exists to host test results.
@@ -72,7 +72,7 @@ func (c *VerifyCommand) Run(ctx context.Context, args []string) error {
 		return fmt.Errorf("failed to parse flags: %w", err)
 	}
 
-	testCases, err := parseTestCases(ctx, c.flags.Location, c.flags.TestName)
+	testCases, err := parseTestCases(ctx, c.flags.Location, c.flags.TestNames)
 	if err != nil {
 		return fmt.Errorf("failed to parse golden tests: %w", err)
 	}

--- a/templates/commands/goldentest/verify.go
+++ b/templates/commands/goldentest/verify.go
@@ -48,10 +48,10 @@ func (c *VerifyCommand) Help() string {
 	return `
 Usage: {{ COMMAND }} --test-name=<test-name-1>,<test-name-2> <location>
 
-The {{ COMMAND }} records the template golden tests.
+The {{ COMMAND }} verifies the template golden tests.
 
 The "<test_name>" is the name of the test. If no <test_name> is specified,
-all tests will be recoreded.
+all tests will be run against.
 
 The "<location>" is the location of the template.
 


### PR DESCRIPTION
- Update to `abc templates golden-test record --test-name=<test_name> <location>`
- Testname is now repeatable