### PR TITLE
fix: don't copy .git dir into template output

### DIFF
--- a/templates/common/templatesource/git.go
+++ b/templates/common/templatesource/git.go
@@ -17,6 +17,7 @@ package templatesource
 import (
 	"context"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -179,6 +180,11 @@ func (g *gitDownloader) Download(ctx context.Context, cwd, destDir string) (*Dow
 		DstRoot: destDir,
 		SrcRoot: subdirToCopy,
 		RFS:     &common.RealFS{},
+		Visitor: func(relPath string, de fs.DirEntry) (common.CopyHint, error) {
+			return common.CopyHint{
+				Skip: relPath == ".git",
+			}, nil
+		},
 	}); err != nil {
 		return nil, err //nolint:wrapcheck
 	}

--- a/templates/common/templatesource/git_test.go
+++ b/templates/common/templatesource/git_test.go
@@ -344,6 +344,10 @@ func (f *fakeCloner) Clone(ctx context.Context, remote, version, outDir string) 
 	}
 
 	common.WriteAllDefaultMode(f.t, outDir, f.out)
+
+	common.WriteAllDefaultMode(f.t, outDir, map[string]string{
+		".git/refs/heads/main": "abcdef",
+	})
 	return nil
 }
 


### PR DESCRIPTION
There was a bug here. When installing a template from a remote git repo, and the spec.yaml is in the root of the repo, then the template output would include the .git dir created by the clone operation. Nobody wants that.