### PR TITLE
Add the skeleton of the upgrade command

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,6 +14,7 @@
             "args": [
                 "templates",
                 "render",
+                "--manifest",
                 "${workspaceFolder}/examples/templates/render/hello_jupiter"
             ]
         },

--- a/cmd/abc/abc.go
+++ b/cmd/abc/abc.go
@@ -25,6 +25,7 @@ import (
 	"github.com/abcxyz/abc/templates/commands/describe"
 	"github.com/abcxyz/abc/templates/commands/goldentest"
 	"github.com/abcxyz/abc/templates/commands/render"
+	"github.com/abcxyz/abc/templates/commands/upgrade"
 	"github.com/abcxyz/pkg/cli"
 	"github.com/abcxyz/pkg/logging"
 )
@@ -44,8 +45,8 @@ var rootCmd = func() *cli.RootCommand {
 					Name:        "templates",
 					Description: "subcommands for rendering templates and related things",
 					Commands: map[string]cli.CommandFactory{
-						"render": func() cli.Command {
-							return &render.Command{}
+						"describe": func() cli.Command {
+							return &describe.Command{}
 						},
 						"golden-test": func() cli.Command {
 							return &cli.RootCommand{
@@ -61,8 +62,11 @@ var rootCmd = func() *cli.RootCommand {
 								},
 							}
 						},
-						"describe": func() cli.Command {
-							return &describe.Command{}
+						"render": func() cli.Command {
+							return &render.Command{}
+						},
+						"upgrade": func() cli.Command {
+							return &upgrade.Command{}
 						},
 					},
 				}

--- a/templates/commands/render/flags.go
+++ b/templates/commands/render/flags.go
@@ -39,37 +39,29 @@ type RenderFlags struct {
 	// It's OK for it to already exist or not.
 	Dest string
 
-	// GitProtocol is either https or ssh.
+	// See common/flags.GitProtocol().
 	GitProtocol string
 
 	// ForceOverwrite lets existing output files in the Dest directory be overwritten
 	// with the output of the template.
 	ForceOverwrite bool
 
-	// Inputs provide values that are substituted into the template. The keys in
-	// this map must match the input names in the Source template's spec.yaml
-	// file.
-	//
-	// This is mutable, even after flag parsing. It may be updated when default
-	// values are added and as the user is prompted for inputs.
-	Inputs map[string]string // these are just the --input values from flags; doesn't include values from env vars
+	// See common/flags.Inputs().
+	Inputs map[string]string
 
-	// InputFiles are the files containing a list of inputs. See Inputs flag for details.
+	// See common/flags.InputFiles().
 	InputFiles []string
 
-	// KeepTempDirs prevents the cleanup of temporary directories after rendering is complete.
-	// This can be useful for debugging a failing template.
+	// See common/flags.KeepTempDirs().
 	KeepTempDirs bool
 
 	// Whether to prompt the user for template inputs.
 	Prompt bool
 
-	// DebugScratchContents causes the contents of the scratch directory to be
-	// logged at level INFO after each step of the spec.yaml.
+	// See common/flags.DebugScratchContents().
 	DebugScratchContents bool
 
-	// SkipInputValidation skips the execution of the input validation rules as
-	// configured in the template's spec.yaml file.
+	// See common/flags.SkipInputValidation().
 	SkipInputValidation bool
 
 	// Manifest enables the writing of manifest files, which are an experimental
@@ -79,6 +71,11 @@ type RenderFlags struct {
 
 func (r *RenderFlags) Register(set *cli.FlagSet) {
 	f := set.NewSection("RENDER OPTIONS")
+
+	f.StringMapVar(flags.Inputs(&r.Inputs))
+	f.StringSliceVar(flags.InputFiles(&r.InputFiles))
+	f.BoolVar(flags.KeepTempDirs(&r.KeepTempDirs))
+	f.BoolVar(flags.SkipInputValidation(&r.SkipInputValidation))
 
 	f.StringVar(&cli.StringVar{
 		Name:    "dest",
@@ -90,32 +87,11 @@ func (r *RenderFlags) Register(set *cli.FlagSet) {
 		Usage:   "Required. The target directory in which to write the output files.",
 	})
 
-	f.StringMapVar(&cli.StringMapVar{
-		Name:    "input",
-		Example: "foo=bar",
-		Target:  &r.Inputs,
-		Usage:   "The key=val pairs of template values; may be repeated.",
-	})
-
-	f.StringSliceVar(&cli.StringSliceVar{
-		Name:    "input-file",
-		Example: "/my/git/abc-inputs.yaml",
-		Target:  &r.InputFiles,
-		Usage:   "The yaml files with key: val pairs of template values; may be repeated.",
-	})
-
 	f.BoolVar(&cli.BoolVar{
 		Name:    "force-overwrite",
 		Target:  &r.ForceOverwrite,
 		Default: false,
 		Usage:   "If an output file already exists in the destination, overwrite it instead of failing.",
-	})
-
-	f.BoolVar(&cli.BoolVar{
-		Name:    "keep-temp-dirs",
-		Target:  &r.KeepTempDirs,
-		Default: false,
-		Usage:   "Preserve the temp directories instead of deleting them normally.",
 	})
 
 	f.BoolVar(&cli.BoolVar{
@@ -139,13 +115,6 @@ func (r *RenderFlags) Register(set *cli.FlagSet) {
 	})
 
 	f.BoolVar(&cli.BoolVar{
-		Name:    "skip-input-validation",
-		Target:  &r.SkipInputValidation,
-		Default: false,
-		Usage:   "Skip running the validation expressions for inputs that were configured in spec.yaml.",
-	})
-
-	f.BoolVar(&cli.BoolVar{
 		Name:    "manifest",
 		Target:  &r.Manifest,
 		Default: false,
@@ -153,12 +122,7 @@ func (r *RenderFlags) Register(set *cli.FlagSet) {
 	})
 
 	t := set.NewSection("TEMPLATE AUTHORS")
-	t.BoolVar(&cli.BoolVar{
-		Name:    "debug-scratch-contents",
-		Target:  &r.DebugScratchContents,
-		Default: false,
-		Usage:   "Print the contents of the scratch directory after each step; for debugging spec.yaml files.",
-	})
+	t.BoolVar(flags.DebugScratchContents(&r.DebugScratchContents))
 
 	g := set.NewSection("GIT OPTIONS")
 

--- a/templates/commands/render/render.go
+++ b/templates/commands/render/render.go
@@ -65,6 +65,7 @@ func (c *Command) Desc() string {
 	return "instantiate a template to setup a new app or add config files"
 }
 
+// Help implements cli.Command.
 func (c *Command) Help() string {
 	return `
 Usage: {{ COMMAND }} [options] <source>
@@ -85,6 +86,7 @@ few forms:
 `
 }
 
+// Flags implements cli.Command.
 func (c *Command) Flags() *cli.FlagSet {
 	set := c.NewFlagSet()
 	c.flags.Register(set)

--- a/templates/commands/upgrade/flags.go
+++ b/templates/commands/upgrade/flags.go
@@ -1,0 +1,74 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package upgrade
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/abcxyz/abc/templates/common/flags"
+	"github.com/abcxyz/pkg/cli"
+)
+
+type Flags struct {
+	Manifest string
+
+	// See common/flags.DebugScratchContents().
+	DebugScratchContents bool
+
+	// See common/flags.GitProtocol().
+	GitProtocol string
+
+	// See common/flags.Inputs().
+	Inputs map[string]string
+
+	// See common/flags.InputFiles().
+	InputFiles []string
+
+	// See common/flags.SkipInputValidation().
+	SkipInputValidation bool
+}
+
+func (f *Flags) Register(set *cli.FlagSet) {
+	r := set.NewSection("RENDER OPTIONS")
+
+	r.StringMapVar(flags.Inputs(&f.Inputs))
+	r.StringSliceVar(flags.InputFiles(&f.InputFiles))
+	r.BoolVar(flags.SkipInputValidation(&f.SkipInputValidation))
+	r.BoolVar(flags.DebugScratchContents(&f.DebugScratchContents))
+
+	r.StringMapVar(&cli.StringMapVar{
+		Name:    "input",
+		Example: "foo=bar",
+		Target:  &f.Inputs,
+		Usage:   "The key=val pairs of template values; may be repeated.",
+	})
+
+	t := set.NewSection("TEMPLATE AUTHORS")
+	t.BoolVar(flags.DebugScratchContents(&f.DebugScratchContents))
+
+	g := set.NewSection("GIT OPTIONS")
+	g.StringVar(flags.GitProtocol(&f.GitProtocol))
+
+	// Manifest is the first CLI argument.
+	set.AfterParse(func(existingErr error) error {
+		f.Manifest = strings.TrimSpace(set.Arg(0))
+		if f.Manifest == "" {
+			return fmt.Errorf("missing <manifest> file argument")
+		}
+
+		return nil
+	})
+}

--- a/templates/commands/upgrade/upgrade.go
+++ b/templates/commands/upgrade/upgrade.go
@@ -1,0 +1,115 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package render implements the template rendering related subcommands.
+package upgrade
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/abcxyz/abc/templates/common"
+	"github.com/abcxyz/abc/templates/model/decode"
+	manifest "github.com/abcxyz/abc/templates/model/manifest/v1alpha1"
+	"github.com/abcxyz/pkg/cli"
+)
+
+// Command implements cli.Command for template upgrades.
+type Command struct {
+	cli.BaseCommand
+	flags Flags
+
+	testFS common.FS
+}
+
+// Desc implements cli.Command.
+func (c *Command) Desc() string {
+	return "apply a new template version to an already-rendered template output directory"
+}
+
+// Help implements cli.Command.
+func (c *Command) Help() string {
+	return `
+Usage: {{ COMMAND }} [options] <manifest>
+
+The {{ COMMAND }} command upgrades an already-rendered template output to use
+the latest version of a template.
+
+The "<manifest>" is the path to the *.lock.yaml file that was created when the
+template was originally rendered.
+`
+}
+
+// Hidden implements cli.Command.
+func (c *Command) Hidden() bool {
+	// TODO(#191): unhide the upgrade command when it's ready.
+	return true
+}
+
+func (c *Command) Flags() *cli.FlagSet {
+	set := c.NewFlagSet()
+	c.flags.Register(set)
+	return set
+}
+
+func (c *Command) Run(ctx context.Context, args []string) error {
+	if err := c.Flags().Parse(args); err != nil {
+		return fmt.Errorf("failed to parse flags: %w", err)
+	}
+
+	fSys := c.testFS // allow filesystem interaction to be faked for testing
+	if fSys == nil {
+		fSys = &common.RealFS{}
+	}
+
+	return c.realRun(ctx, &runParams{
+		fs: fSys,
+	})
+}
+
+type runParams struct {
+	fs common.FS
+}
+
+func (c *Command) realRun(ctx context.Context, rp *runParams) error {
+	manifest, err := loadManifest(ctx, rp.fs, c.flags.Manifest)
+	if err != nil {
+		return err
+	}
+	_ = manifest
+
+	// TODO(#191): implement the upgrade feature
+
+	return nil
+}
+
+func loadManifest(ctx context.Context, fs common.FS, path string) (*manifest.Manifest, error) {
+	f, err := fs.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open manifest file at %q: %w", path, err)
+	}
+	defer f.Close()
+
+	manifestI, err := decode.DecodeValidateUpgrade(ctx, f, path, decode.KindManifest)
+	if err != nil {
+		return nil, fmt.Errorf("error reading manifest file: %w", err)
+	}
+
+	out, ok := manifestI.(*manifest.Manifest)
+	if !ok {
+		return nil, fmt.Errorf("internal error: manifest file did not decode to *manifest.Manifest")
+	}
+
+	return out, nil
+}

--- a/templates/common/flags/flags.go
+++ b/templates/common/flags/flags.go
@@ -21,6 +21,8 @@ import (
 	"github.com/abcxyz/pkg/cli"
 )
 
+// GitProtocol is a flag that's either https or ssh. It controls how we talk to
+// remote git servers like GitHub.
 func GitProtocol(target *string) *cli.StringVar {
 	return &cli.StringVar{
 		Name:    "git-protocol",
@@ -29,5 +31,64 @@ func GitProtocol(target *string) *cli.StringVar {
 		Predict: predict.Set([]string{"https", "ssh"}),
 		Target:  target,
 		Usage:   "Either ssh or https, the protocol for connecting to git. Only used if the template source is a git repo.",
+	}
+}
+
+// Inputs provide values that are substituted into the template. The keys in
+// this map must match the input names in the Source template's spec.yaml
+// file.
+//
+// These are just the --input values from flags. It doesn't include inputs
+// from config files, defaults, or prompts.
+func Inputs(inputs *map[string]string) *cli.StringMapVar {
+	return &cli.StringMapVar{
+		Name:    "input",
+		Example: "foo=bar",
+		Target:  inputs,
+		Usage:   "The key=val pairs of template values; may be repeated.",
+	}
+}
+
+// InputFiles are the files containing a YAML template inputs, similar to --input.
+func InputFiles(inputFiles *[]string) *cli.StringSliceVar {
+	return &cli.StringSliceVar{
+		Name:    "input-file",
+		Example: "/my/git/abc-inputs.yaml",
+		Predict: predict.Files(""),
+		Target:  inputFiles,
+		Usage:   "The yaml files with key: val pairs of template values; may be repeated.",
+	}
+}
+
+// KeepTempDirs prevents the cleanup of temporary directories after rendering is
+// complete. This can be useful for debugging a failing template.
+func KeepTempDirs(k *bool) *cli.BoolVar {
+	return &cli.BoolVar{
+		Name:    "keep-temp-dirs",
+		Target:  k,
+		Default: false,
+		Usage:   "Preserve the temp directories instead of deleting them normally.",
+	}
+}
+
+// SkipInputValidation skips the execution of the input validation rules as
+// configured in the template's spec.yaml file.
+func SkipInputValidation(s *bool) *cli.BoolVar {
+	return &cli.BoolVar{
+		Name:    "skip-input-validation",
+		Target:  s,
+		Default: false,
+		Usage:   "Skip running the validation expressions for inputs that were configured in spec.yaml.",
+	}
+}
+
+// DebugScratchContents causes the contents of the scratch directory to be
+// logged at level INFO after each step of the spec.yaml.
+func DebugScratchContents(d *bool) *cli.BoolVar {
+	return &cli.BoolVar{
+		Name:    "debug-scratch-contents",
+		Target:  d,
+		Default: false,
+		Usage:   "Print the contents of the scratch directory after each step; for debugging spec.yaml files.",
 	}
 }

--- a/templates/common/specutil/spec.go
+++ b/templates/common/specutil/spec.go
@@ -131,7 +131,7 @@ func Load(ctx context.Context, fs common.FS, templateDir, source string) (*spec.
 
 	spec, ok := specI.(*spec.Spec)
 	if !ok {
-		return nil, fmt.Errorf("internal error: spec file did not decode to spec.Spec")
+		return nil, fmt.Errorf("internal error: spec file did not decode to *spec.Spec")
 	}
 
 	return spec, nil


### PR DESCRIPTION
There's no interesting upgrade logic yet. This PR just:

 - factors out some flags that were formerly specific to the `render` command that are now shared with the `upgrade` command, into the `common/flags` package.
 - Adds the `abc templates upgrade` common as a no-op. It's in "hidden" mode so it won't show up in the help text. It just loads the manifest file from the filesystem and does nothing with it.
 - Adds usage instructions.