### PR TITLE
Factor out template input handling into common package

### DIFF
--- a/templates/commands/upgrade/upgrade.go
+++ b/templates/commands/upgrade/upgrade.go
@@ -89,8 +89,6 @@ func (c *Command) realRun(ctx context.Context, rp *runParams) error {
 	}
 	_ = manifest
 
-	// TODO(#191): implement the upgrade feature
-
 	return nil
 }
 

--- a/templates/common/input/input.go
+++ b/templates/common/input/input.go
@@ -1,0 +1,300 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package input
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/mattn/go-isatty"
+	"golang.org/x/exp/maps"
+	"gopkg.in/yaml.v3"
+
+	"github.com/abcxyz/abc/templates/common"
+	spec "github.com/abcxyz/abc/templates/model/spec/v1beta2"
+	"github.com/abcxyz/pkg/sets"
+)
+
+// ResolveParams are the parameters to Resolve(), wrapped in a struct because
+// there are so many.
+type ResolveParams struct {
+	FS common.FS
+
+	// The template spec.yaml model.
+	Spec *spec.Spec
+
+	// The value of --input. Template input values.
+	Inputs map[string]string
+
+	// The value of --input-file. A list of YAML filenames defining template inputs.
+	InputFiles []string
+
+	// Prompt is the value of --prompt, it enables or disables the prompting feature.
+	Prompt bool
+
+	// Prompter is used to print prompts to the user requesting them to enter
+	// input.
+	Prompter            Prompter
+	SkipInputValidation bool
+
+	// Normally, we'll only prompt if the input is a TTY. For testing, this
+	// can be set to true to bypass the check and allow stdin to be something
+	// other than a TTY, like an os.Pipe.
+	SkipPromptTTYCheck bool
+
+	// The input stream used for reading prompted values from the user.
+	Stdin io.Reader
+}
+
+// Prompter prints messages to the user asking them to enter a value. This is
+// implemented by *cli.Command.
+type Prompter interface {
+	Prompt(ctx context.Context, msg string, args ...any) (string, error)
+}
+
+// Resolve combines flags, user prompts, and defaults to get the full set
+// of template inputs.
+func Resolve(ctx context.Context, rp *ResolveParams) (map[string]string, error) {
+	if unknownInputs := checkUnknownInputs(rp.Spec, rp.Inputs); len(unknownInputs) > 0 {
+		return nil, fmt.Errorf("unknown input(s): %s", strings.Join(unknownInputs, ", "))
+	}
+
+	fileInputs, err := loadInputFiles(ctx, rp.FS, rp.InputFiles)
+	if err != nil {
+		return nil, err
+	}
+	// Effectively ignore inputs in file that are not in spec inputs, thereby ignoring them
+	knownFileInputs := filterUnknownInputs(rp.Spec, fileInputs)
+
+	// Order matters: values from --input take precedence over --input-file.
+	inputs := sets.UnionMapKeys(rp.Inputs, knownFileInputs)
+
+	if rp.Prompt {
+		if !rp.SkipPromptTTYCheck {
+			isATTY := (rp.Stdin == os.Stdin && isatty.IsTerminal(os.Stdin.Fd()))
+			if !isATTY {
+				return nil, fmt.Errorf("the flag --prompt was provided, but standard input is not a terminal")
+			}
+		}
+
+		if err := promptForInputs(ctx, rp.Prompter, rp.Spec, inputs); err != nil {
+			return nil, err
+		}
+	} else {
+		insertDefaultInputs(rp.Spec, inputs)
+		if missing := checkInputsMissing(rp.Spec, inputs); len(missing) > 0 {
+			return nil, fmt.Errorf("missing input(s): %s", strings.Join(missing, ", "))
+		}
+	}
+
+	if rp.SkipInputValidation {
+		return inputs, nil
+	}
+
+	if err := validateInputs(ctx, rp.Spec.Inputs, inputs); err != nil {
+		return nil, err
+	}
+
+	return inputs, nil
+}
+
+func validateInputs(ctx context.Context, specInputs []*spec.Input, inputVals map[string]string) error {
+	scope := common.NewScope(inputVals)
+
+	sb := &strings.Builder{}
+	tw := tabwriter.NewWriter(sb, 8, 0, 2, ' ', 0)
+
+	for _, input := range specInputs {
+		for _, rule := range input.Rules {
+			var ok bool
+			err := common.CelCompileAndEval(ctx, scope, rule.Rule, &ok)
+			if ok && err == nil {
+				continue
+			}
+
+			fmt.Fprintf(tw, "\nInput name:\t%s", input.Name.Val)
+			fmt.Fprintf(tw, "\nInput value:\t%s", inputVals[input.Name.Val])
+			writeRule(tw, rule, false, 0)
+			if err != nil {
+				fmt.Fprintf(tw, "\nCEL error:\t%s", err.Error())
+			}
+			fmt.Fprintf(tw, "\n") // Add vertical relief between validation messages
+		}
+	}
+
+	tw.Flush()
+	if sb.Len() > 0 {
+		return fmt.Errorf("input validation failed:\n%s", sb.String())
+	}
+	return nil
+}
+
+// promptForInputs looks for template inputs that were not provided on the
+// command line and prompts the user for them. This mutates "inputs".
+//
+// This must only be called when the user specified --prompt and the input is a
+// terminal (or in a test).
+func promptForInputs(ctx context.Context, prompter Prompter, spec *spec.Spec, inputs map[string]string) error {
+	for _, i := range spec.Inputs {
+		if _, ok := inputs[i.Name.Val]; ok {
+			// Don't prompt if we already have a value for this input.
+			continue
+		}
+		sb := &strings.Builder{}
+		tw := tabwriter.NewWriter(sb, 8, 0, 2, ' ', 0)
+		fmt.Fprintf(tw, "\nInput name:\t%s", i.Name.Val)
+		fmt.Fprintf(tw, "\nDescription:\t%s", i.Desc.Val)
+		for idx, rule := range i.Rules {
+			printRuleIndex := len(i.Rules) > 1
+			writeRule(tw, rule, printRuleIndex, idx)
+		}
+
+		if i.Default != nil {
+			defaultStr := i.Default.Val
+			if defaultStr == "" {
+				// When empty string is the default, print it differently so
+				// the user can actually see what's happening.
+				defaultStr = `""`
+			}
+			fmt.Fprintf(tw, "\nDefault:\t%s", defaultStr)
+		}
+
+		tw.Flush()
+
+		if i.Default != nil {
+			fmt.Fprintf(sb, "\n\nEnter value, or leave empty to accept default: ")
+		} else {
+			fmt.Fprintf(sb, "\n\nEnter value: ")
+		}
+
+		inputVal, err := prompter.Prompt(ctx, sb.String())
+		if err != nil {
+			return fmt.Errorf("failed to prompt for user input: %w", err)
+		}
+
+		if inputVal == "" && i.Default != nil {
+			inputVal = i.Default.Val
+		}
+
+		inputs[i.Name.Val] = inputVal
+	}
+	return nil
+}
+
+// checkUnknownInputs checks for any unknown input flags and returns them in a slice.
+func checkUnknownInputs(spec *spec.Spec, inputs map[string]string) []string {
+	specInputs := make([]string, 0, len(spec.Inputs))
+	for _, v := range spec.Inputs {
+		specInputs = append(specInputs, v.Name.Val)
+	}
+
+	seenInputs := maps.Keys(inputs)
+	unknownInputs := sets.Subtract(seenInputs, specInputs)
+	sort.Strings(unknownInputs)
+	return unknownInputs
+}
+
+func filterUnknownInputs(spec *spec.Spec, inputs map[string]string) map[string]string {
+	specInputs := make(map[string]string)
+	for _, v := range spec.Inputs {
+		specInputs[v.Name.Val] = ""
+	}
+	return sets.IntersectMapKeys(inputs, specInputs)
+}
+
+// loadInputFiles iterates over each --input-file and combines them all into a map.
+func loadInputFiles(ctx context.Context, fs common.FS, paths []string) (map[string]string, error) {
+	out := make(map[string]string)
+	sourceFileForInput := make(map[string]string)
+
+	for _, f := range paths {
+		inputsThisFile, err := loadInputFile(ctx, fs, f)
+		if err != nil {
+			return nil, err
+		}
+
+		for key, val := range inputsThisFile {
+			if _, ok := out[key]; ok {
+				return nil, fmt.Errorf("input key %q appears in multiple input files %q and %q; there must not be any overlap between input files",
+					key, f, sourceFileForInput[key])
+			}
+
+			out[key] = val
+			sourceFileForInput[key] = f
+		}
+	}
+	return out, nil
+}
+
+// insertDefaultInputs defaults any missing inputs for which a default
+// exists. The input map will be mutated by adding new keys.
+func insertDefaultInputs(spec *spec.Spec, inputs map[string]string) {
+	for _, specInput := range spec.Inputs {
+		if _, ok := inputs[specInput.Name.Val]; !ok && specInput.Default != nil {
+			inputs[specInput.Name.Val] = specInput.Default.Val
+		}
+	}
+}
+
+// checkInputsMissing checks for missing inputs and returns them as a slice.
+func checkInputsMissing(spec *spec.Spec, inputs map[string]string) []string {
+	missing := make([]string, 0, len(inputs))
+
+	for _, input := range spec.Inputs {
+		if _, ok := inputs[input.Name.Val]; !ok {
+			missing = append(missing, input.Name.Val)
+		}
+	}
+
+	sort.Strings(missing)
+
+	return missing
+}
+
+// writeRule writes a human-readable description of the given rule to the given
+// tabwriter in a 2-column format.
+//
+// Sometimes we run this in a context where we want to include the index of the
+// rule in the list of rules; in that case, pass includeIndex=true and the index
+// value. If includeIndex is false, then index is ignored.
+func writeRule(tw *tabwriter.Writer, rule *spec.InputRule, includeIndex bool, index int) {
+	indexStr := ""
+	if includeIndex {
+		indexStr = fmt.Sprintf(" %d", index)
+	}
+
+	fmt.Fprintf(tw, "\nRule%s:\t%s", indexStr, rule.Rule.Val)
+	if rule.Message.Val != "" {
+		fmt.Fprintf(tw, "\nRule%s msg:\t%s", indexStr, rule.Message.Val)
+	}
+}
+
+// loadInputFile loads a single --input-file into a map.
+func loadInputFile(ctx context.Context, fs common.FS, path string) (map[string]string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("error reading input file: %w", err)
+	}
+	m := make(map[string]string)
+	if err := yaml.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("error parsing yaml file: %w", err)
+	}
+	return m, nil
+}

--- a/templates/common/input/input_test.go
+++ b/templates/common/input/input_test.go
@@ -1,0 +1,347 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package input
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/abcxyz/abc/templates/model"
+	spec "github.com/abcxyz/abc/templates/model/spec/v1beta2"
+	"github.com/abcxyz/pkg/cli"
+	"github.com/abcxyz/pkg/testutil"
+)
+
+// TODO move to common.
+func TestPromptForInputs_CanceledContext(t *testing.T) {
+	t.Parallel()
+
+	cmd := &cli.BaseCommand{}
+
+	stdinReader, _ := io.Pipe()
+	stdoutReader, stdoutWriter := io.Pipe()
+	_, stderrWriter := io.Pipe()
+
+	cmd.SetStdin(stdinReader)
+	cmd.SetStdout(stdoutWriter)
+	cmd.SetStderr(stderrWriter)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	errCh := make(chan error)
+	go func() {
+		defer close(errCh)
+		spec := &spec.Spec{
+			Inputs: []*spec.Input{
+				{
+					Name: model.String{Val: "my_input"},
+				},
+			},
+		}
+		errCh <- promptForInputs(ctx, cmd, spec, map[string]string{})
+	}()
+
+	go func() {
+		for {
+			// Read and discard prompt printed to the user.
+			if _, err := stdoutReader.Read(make([]byte, 1024)); err != nil {
+				return
+			}
+		}
+	}()
+
+	cancel()
+	var err error
+	select {
+	case err = <-errCh:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for the background goroutine to finish")
+	}
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("got an error %v, want context.Canceled", err)
+	}
+
+	stdoutWriter.Close() // terminate the background goroutine blocking on stdoutReader.Read()
+}
+
+func TestValidateInputs(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		inputModels []*spec.Input
+		inputVals   map[string]string
+		want        string
+	}{
+		{
+			name: "no-validation-rule",
+			inputModels: []*spec.Input{
+				{
+					Name: model.String{Val: "my_input"},
+				},
+			},
+			inputVals: map[string]string{
+				"my_input": "foo",
+			},
+		},
+		{
+			name: "single-passing-validation-rule",
+			inputModels: []*spec.Input{
+				{
+					Name: model.String{Val: "my_input"},
+					Rules: []*spec.InputRule{
+						{
+							Rule:    model.String{Val: `size(my_input) < 5`},
+							Message: model.String{Val: "Length must be less than 5"},
+						},
+					},
+				},
+			},
+			inputVals: map[string]string{
+				"my_input": "foo",
+			},
+		},
+		{
+			name: "single-failing-validation-rule",
+			inputModels: []*spec.Input{
+				{
+					Name: model.String{Val: "my_input"},
+					Rules: []*spec.InputRule{
+						{
+							Rule:    model.String{Val: `size(my_input) < 3`},
+							Message: model.String{Val: "Length must be less than 3"},
+						},
+					},
+				},
+			},
+			inputVals: map[string]string{
+				"my_input": "foo",
+			},
+			want: `input validation failed:
+
+Input name:   my_input
+Input value:  foo
+Rule:         size(my_input) < 3
+Rule msg:     Length must be less than 3`,
+		},
+		{
+			name: "multiple-passing-validation-rules",
+			inputModels: []*spec.Input{
+				{
+					Name: model.String{Val: "my_input"},
+					Rules: []*spec.InputRule{
+						{
+							Rule:    model.String{Val: `size(my_input) < 5`},
+							Message: model.String{Val: "Length must be less than 5"},
+						},
+						{
+							Rule:    model.String{Val: `my_input.startsWith("fo")`},
+							Message: model.String{Val: `Must start with "fo"`},
+						},
+						{
+							Rule:    model.String{Val: `my_input.contains("oo")`},
+							Message: model.String{Val: `Must contain "oo"`},
+						},
+					},
+				},
+			},
+			inputVals: map[string]string{
+				"my_input": "foo",
+			},
+		},
+		{
+			name: "multiple-passing-validation-rules-one-failing",
+			inputModels: []*spec.Input{
+				{
+					Name: model.String{Val: "my_input"},
+					Rules: []*spec.InputRule{
+						{
+							Rule:    model.String{Val: `size(my_input) < 3`},
+							Message: model.String{Val: "Length must be less than 3"},
+						},
+						{
+							Rule:    model.String{Val: `my_input.startsWith("fo")`},
+							Message: model.String{Val: `Must start with "fo"`},
+						},
+						{
+							Rule:    model.String{Val: `my_input.contains("oo")`},
+							Message: model.String{Val: `Must contain "oo"`},
+						},
+					},
+				},
+			},
+			inputVals: map[string]string{
+				"my_input": "foo",
+			},
+			want: `input validation failed:
+
+Input name:   my_input
+Input value:  foo
+Rule:         size(my_input) < 3
+Rule msg:     Length must be less than 3`,
+		},
+		{
+			name: "multiple-failing-validation-rules",
+			inputModels: []*spec.Input{
+				{
+					Name: model.String{Val: "my_input"},
+					Rules: []*spec.InputRule{
+						{
+							Rule:    model.String{Val: `size(my_input) < 3`},
+							Message: model.String{Val: "Length must be less than 3"},
+						},
+						{
+							Rule:    model.String{Val: `my_input.startsWith("ham")`},
+							Message: model.String{Val: `Must start with "ham"`},
+						},
+						{
+							Rule:    model.String{Val: `my_input.contains("shoe")`},
+							Message: model.String{Val: `Must contain "shoe"`},
+						},
+					},
+				},
+			},
+			inputVals: map[string]string{
+				"my_input": "foo",
+			},
+			want: `input validation failed:
+
+Input name:   my_input
+Input value:  foo
+Rule:         size(my_input) < 3
+Rule msg:     Length must be less than 3
+
+Input name:   my_input
+Input value:  foo
+Rule:         my_input.startsWith("ham")
+Rule msg:     Must start with "ham"
+
+Input name:   my_input
+Input value:  foo
+Rule:         my_input.contains("shoe")
+Rule msg:     Must contain "shoe"`,
+		},
+		{
+			name: "cel-syntax-error",
+			inputModels: []*spec.Input{
+				{
+					Name: model.String{Val: "my_input"},
+					Rules: []*spec.InputRule{
+						{
+							Rule: model.String{Val: `(`},
+						},
+					},
+				},
+			},
+			inputVals: map[string]string{
+				"my_input": "foo",
+			},
+			want: `input validation failed:
+
+Input name:   my_input
+Input value:  foo
+Rule:         (
+CEL error:    failed compiling CEL expression: ERROR: <input>:1:2: Syntax error:`, // remainder of error omitted
+		},
+		{
+			name: "cel-type-conversion-error",
+			inputModels: []*spec.Input{
+				{
+					Name: model.String{Val: "my_input"},
+					Rules: []*spec.InputRule{
+						{
+							Rule: model.String{Val: `bool(42)`},
+						},
+					},
+				},
+			},
+			inputVals: map[string]string{
+				"my_input": "foo",
+			},
+			want: `input validation failed:
+
+Input name:   my_input
+Input value:  foo
+Rule:         bool(42)
+CEL error:    failed compiling CEL expression: ERROR: <input>:1:5: found no matching overload for 'bool'`, // remainder of error omitted
+		},
+		{
+			name: "cel-output-type-conversion-error",
+			inputModels: []*spec.Input{
+				{
+					Name: model.String{Val: "my_input"},
+					Rules: []*spec.InputRule{
+						{
+							Rule: model.String{Val: `42`},
+						},
+					},
+				},
+			},
+			inputVals: map[string]string{
+				"my_input": "foo",
+			},
+			want: `input validation failed:
+
+Input name:   my_input
+Input value:  foo
+Rule:         42
+CEL error:    CEL expression result couldn't be converted to bool. The CEL engine error was: unsupported type conversion from 'int' to bool`, // remainder of error omitted
+		},
+		{
+			name: "multi-input-validation",
+			inputModels: []*spec.Input{
+				{
+					Name: model.String{Val: "my_input"},
+					Rules: []*spec.InputRule{
+						{
+							Rule: model.String{Val: `my_input + my_other_input == "sharknado"`},
+						},
+					},
+				},
+				{
+					Name: model.String{Val: "my_other_input"},
+					Rules: []*spec.InputRule{
+						{
+							Rule: model.String{Val: `"tor" + my_other_input + my_input == "tornadoshark"`},
+						},
+					},
+				},
+			},
+			inputVals: map[string]string{
+				"my_input":       "shark",
+				"my_other_input": "nado",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// r := &Command{}
+			ctx := context.Background()
+			err := validateInputs(ctx, tc.inputModels, tc.inputVals)
+			if diff := testutil.DiffErrString(err, tc.want); diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This code will be needed for the `upgrade` command, so it can't live with the `render` command anymore.

This involved:
 - Turning methods into plain methods. This required passing a lot more parameters around, so we create the `ResolveParams` struct to encapsulate them.
 - Moving code from render.go into a new package, common/input/input.go. Along with associated tests.