### PR TITLE
Remove superfluous call to MkdirAll for temp dir

### DIFF
--- a/templates/commands/render/render.go
+++ b/templates/commands/render/render.go
@@ -177,9 +177,6 @@ func (c *Command) realRun(ctx context.Context, rp *runParams) (outErr error) {
 	if err != nil {
 		return fmt.Errorf("failed to create temp directory for scratch directory: %w", err)
 	}
-	if err := rp.fs.MkdirAll(scratchDir, common.OwnerRWXPerms); err != nil {
-		return fmt.Errorf("failed to create scratch directory: MkdirAll(): %w", err)
-	}
 	tempDirs = append(tempDirs, scratchDir)
 	logger := logging.FromContext(ctx)
 	logger.DebugContext(ctx, "created temporary scratch directory", "path", scratchDir)


### PR DESCRIPTION
This was a leftover from an earlier time when the temp dir had a separate name generation step and creation step.