### PR TITLE
Run all golden_tests during lint & test phase

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -48,3 +48,30 @@ jobs:
 
   yaml_lint:
     uses: 'abcxyz/pkg/.github/workflows/yaml-lint.yml@main' # ratchet:exclude
+
+  golden_tests:
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11' # ratchet:actions/checkout@v4
+
+      - name: 'Setup Go'
+        uses: 'actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe' # ratchet:actions/setup-go@v4
+        with:
+          go-version: '1.21'
+
+      - name: 'Run all golden tests'
+        shell: 'bash'
+        # This is a bit of a hack until we add feature #311 to discover and run
+        # all golden-tests within a given directory. Once we have that, we won't
+        # need "for", "find" and "xargs".
+        run: |-
+          exit_status=0
+          for template_dir in $(find . -name 'testdata' | grep -v '/.git/' | xargs dirname) ; do
+            go run cmd/abc/abc.go templates golden-test verify $template_dir
+            if [[ $? != "0" ]]; then
+              exit_status=1
+              echo "::error title=Golden test failed::$template_dir"
+            fi
+          done
+          exit $exit_status


### PR DESCRIPTION
This runs in parallel with the other steps, and is fast enough that it doesn't increase the overall time-to-completion.

This is a bit of a hack until we add feature #311 to discover and run all golden-tests within a given directory.