### PR TITLE
Don't sign debug commits

### DIFF
--- a/templates/commands/render/render.go
+++ b/templates/commands/render/render.go
@@ -354,7 +354,7 @@ func executeSteps(ctx context.Context, steps []*spec.Step, sp *stepParams) error
 			m := fmt.Sprintf("action %s at line %d", step.Action.Val, step.Pos.Line)
 			argsList := [][]string{
 				{"git", "--git-dir", sp.debugDir, "add", "-A"},
-				{"git", "--git-dir", sp.debugDir, "commit", "-a", "-m", m, "--allow-empty"},
+				{"git", "--git-dir", sp.debugDir, "commit", "-a", "-m", m, "--allow-empty", "--no-gpg-sign"},
 			}
 			if err := runCmds(ctx, argsList); err != nil {
 				return err


### PR DESCRIPTION
When the user enables `--debug-step-diffs` (debugging of per-step diffs using a temporary git repo on the side), don't sign the git commits in that repo. For people like me that have a security device requiring a touch for each signature, this means that many extra touches are required.