### PR TITLE
Give a more helpful error if the user gives an invalid template location

### DIFF
--- a/templates/common/fs.go
+++ b/templates/common/fs.go
@@ -157,7 +157,7 @@ func CopyRecursive(ctx context.Context, pos *model.ConfigPos, p *CopyParams) (ou
 		if err != nil {
 			return err // There was some filesystem error. Give up.
 		}
-		logger.DebugContext(ctx, "CopyRecursive handling directory entry",
+		logger.DebugContext(ctx, "handling directory entry",
 			"path", path)
 		relToSrc, err := filepath.Rel(p.SrcRoot, path)
 		if err != nil {

--- a/templates/common/fs.go
+++ b/templates/common/fs.go
@@ -157,6 +157,8 @@ func CopyRecursive(ctx context.Context, pos *model.ConfigPos, p *CopyParams) (ou
 		if err != nil {
 			return err // There was some filesystem error. Give up.
 		}
+		logger.DebugContext(ctx, "CopyRecursive handling directory entry",
+			"path", path)
 		relToSrc, err := filepath.Rel(p.SrcRoot, path)
 		if err != nil {
 			return pos.Errorf("filepath.Rel(%s,%s): %w", p.SrcRoot, path, err)
@@ -192,13 +194,14 @@ func CopyRecursive(ctx context.Context, pos *model.ConfigPos, p *CopyParams) (ou
 		// parent directory of $path, so we must create the target directory if
 		// it doesn't exist.
 		inDir := filepath.Dir(dst)
+
 		if err := mkdirAllChecked(pos, p.FS, inDir, p.DryRun); err != nil {
 			return err
 		}
 		dstInfo, err := p.FS.Stat(dst)
 		if err == nil {
 			if dstInfo.IsDir() {
-				return pos.Errorf("cannot overwrite a directory with a file of the same name, %q", relToSrc)
+				return pos.Errorf("cannot overwrite a directory with a file of the same name; destination is %q, source is %q", dst, path)
 			}
 			if !ch.Overwrite {
 				return pos.Errorf("destination file %s already exists and overwriting was not enabled with --force-overwrite", relToSrc)

--- a/templates/common/render/render.go
+++ b/templates/common/render/render.go
@@ -117,7 +117,7 @@ func Render(ctx context.Context, p *Params) (outErr error) {
 		outErr = errors.Join(outErr, tempRemover.maybeRemoveAll(ctx))
 	}()
 
-	logger.DebugContext(ctx, "render phase: downloading/copying template")
+	logger.DebugContext(ctx, "downloading/copying template")
 	dlMeta, templateDir, err := templatesource.Download(ctx, &templatesource.DownloadParams{
 		CWD:         p.Cwd,
 		FS:          p.FS,
@@ -131,14 +131,14 @@ func Render(ctx context.Context, p *Params) (outErr error) {
 		return err //nolint:wrapcheck
 	}
 
-	logger.DebugContext(ctx, "render phase: loading spec file")
+	logger.DebugContext(ctx, "loading spec file")
 
 	spec, err := specutil.Load(ctx, p.FS, templateDir, p.Source)
 	if err != nil {
 		return err //nolint:wrapcheck
 	}
 
-	logger.DebugContext(ctx, "render phase: resolving inputs")
+	logger.DebugContext(ctx, "resolving inputs")
 	resolvedInputs, err := input.Resolve(ctx, &input.ResolveParams{
 		FS:                  p.FS,
 		InputFiles:          p.InputFiles,
@@ -156,7 +156,8 @@ func Render(ctx context.Context, p *Params) (outErr error) {
 	if err != nil {
 		return fmt.Errorf("failed to create temp directory for scratch directory: %w", err)
 	}
-	logger.DebugContext(ctx, "created temporary scratch directory")
+	logger.DebugContext(ctx, "created temporary scratch directory",
+		"path", scratchDir)
 	tempRemover.append(scratchDir)
 
 	debugStepDiffsDir, err := initDebugStepDiffsDir(ctx, p, scratchDir)
@@ -174,13 +175,13 @@ func Render(ctx context.Context, p *Params) (outErr error) {
 		templateDir:    templateDir,
 	}
 
-	logger.DebugContext(ctx, "render phase: executing template steps")
+	logger.DebugContext(ctx, "executing template steps")
 
 	if err := executeSteps(ctx, spec.Steps, sp); err != nil {
 		return err
 	}
 
-	logger.DebugContext(ctx, "render phase: committing rendered output")
+	logger.DebugContext(ctx, "committing rendered output")
 	if err := commitTentatively(ctx, p, &commitParams{
 		dlMeta:           dlMeta,
 		includedFromDest: sliceToSet(sp.includedFromDest),

--- a/templates/common/templatesource/source.go
+++ b/templates/common/templatesource/source.go
@@ -19,6 +19,9 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strings"
+
+	"github.com/abcxyz/abc/templates/common/specutil"
 )
 
 // sourceParser is implemented for each particular kind of template source (git,
@@ -105,6 +108,11 @@ type ParseSourceParams struct {
 // A list of sourceParsers is accepted as input for the purpose of testing,
 // rather than hardcoding the real list of sourceParsers.
 func parseSourceWithCwd(ctx context.Context, cwd string, params *ParseSourceParams) (Downloader, error) {
+	if strings.HasSuffix(params.Source, specutil.SpecFileName) {
+		return nil, fmt.Errorf("the template source argument should be the name of a directory *containing* %s; it should not be the full path to %s",
+			specutil.SpecFileName, specutil.SpecFileName)
+	}
+
 	for _, sp := range realSourceParsers {
 		downloader, ok, err := sp.sourceParse(ctx, cwd, params)
 		if err != nil {

--- a/templates/common/templatesource/source_test.go
+++ b/templates/common/templatesource/source_test.go
@@ -140,6 +140,25 @@ func TestParseSourceWithCwd(t *testing.T) {
 			wantErr: "isn't a valid template name",
 		},
 		{
+			name: "spec_yaml_shouldnt_be_in_path",
+			tempDirContents: map[string]string{
+				"my/dir/spec.yaml": "my spec file contents",
+			},
+			source:  "./my/dir/spec.yaml",
+			wantErr: "the template source argument should be the name of a directory",
+		},
+		{
+			name: "filename_rejected_as_location",
+			tempDirContents: map[string]string{
+				"my/dir/spec.yaml":      "my spec file contents",
+				"my/dir/other_file.txt": "my spec file contents",
+			},
+			source: "./my/dir/other_file.txt",
+			// A warning will be logged too, that's not shown here.
+			wantErr: "isn't a valid template name or doesn't exist",
+		},
+
+		{
 			name:   "dot_slash_forces_treating_as_local_dir",
 			source: filepath.FromSlash("./github.com/myorg/myrepo/mysubdir@latest"),
 			tempDirContents: map[string]string{


### PR DESCRIPTION
These are mistakes that the user is likely to make, and we want to print a more helpful error message:

Mistake 1: the user provides the path to the spec.yaml as the template path, where they're actually supposed to provide the path to the directory containing the spec.yaml. We add a very clear error message for this case.

Mistake 2: providing some other filename instead of a directory name: we provide a warning that filenames can't be parsed as local template paths.

Before this, the error message was very confusing, just `cannot overwrite a directory with a file of the same name`.