### PR TITLE
Replace ParseSource with ParseSourceWithCwd

### DIFF
--- a/templates/common/templatesource/download.go
+++ b/templates/common/templatesource/download.go
@@ -117,7 +117,8 @@ func Download(ctx context.Context, p *DownloadParams) (*DownloadMetadata, string
 	logger.DebugContext(ctx, "created temporary template directory",
 		"path", templateDir)
 
-	downloader, err := ParseSource(ctx, &ParseSourceParams{
+	downloader, err := ParseSourceWithCwd(ctx, &ParseSourceParams{
+		CWD:         p.CWD,
 		Source:      p.Source,
 		GitProtocol: p.GitProtocol,
 	})

--- a/templates/common/templatesource/git.go
+++ b/templates/common/templatesource/git.go
@@ -62,7 +62,7 @@ type gitSourceParser struct {
 	warning string
 }
 
-func (g *gitSourceParser) sourceParse(ctx context.Context, _ string, params *ParseSourceParams) (Downloader, bool, error) {
+func (g *gitSourceParser) sourceParse(ctx context.Context, params *ParseSourceParams) (Downloader, bool, error) {
 	logger := logging.FromContext(ctx).With("logger", "gitSourceParser.sourceParse")
 
 	match := g.re.FindStringSubmatchIndex(params.Source)

--- a/templates/common/templatesource/localsource.go
+++ b/templates/common/templatesource/localsource.go
@@ -32,7 +32,7 @@ var _ sourceParser = (*localSourceParser)(nil)
 // directory.
 type localSourceParser struct{}
 
-func (l *localSourceParser) sourceParse(ctx context.Context, cwd string, params *ParseSourceParams) (Downloader, bool, error) {
+func (l *localSourceParser) sourceParse(ctx context.Context, params *ParseSourceParams) (Downloader, bool, error) {
 	logger := logging.FromContext(ctx).With("logger", "localSourceParser.sourceParse")
 
 	// Design decision: we could try to look at src and guess whether it looks
@@ -47,7 +47,7 @@ func (l *localSourceParser) sourceParse(ctx context.Context, cwd string, params 
 	// If the filepath was not absolute, convert it to be relative to the cwd.
 	absSource := params.Source
 	if !filepath.IsAbs(params.Source) {
-		absSource = filepath.Join(cwd, params.Source)
+		absSource = filepath.Join(params.CWD, params.Source)
 	}
 
 	fi, err := os.Stat(absSource)

--- a/templates/common/templatesource/source.go
+++ b/templates/common/templatesource/source.go
@@ -17,7 +17,6 @@ package templatesource
 import (
 	"context"
 	"fmt"
-	"os"
 	"regexp"
 	"sort"
 	"strings"
@@ -36,7 +35,7 @@ type sourceParser interface {
 	// being downloadable by this sourceParser, then it returns true, along with
 	// a downloader that can download that template, and other metadata. See
 	// ParsedSource.
-	sourceParse(ctx context.Context, cwd string, params *ParseSourceParams) (Downloader, bool, error)
+	sourceParse(ctx context.Context, params *ParseSourceParams) (Downloader, bool, error)
 }
 
 // realSourceParsers contains the non-test sourceParsers.
@@ -91,6 +90,9 @@ var realSourceParsers = []sourceParser{
 
 // ParseSourceParams contains the arguments to ParseSource.
 type ParseSourceParams struct {
+	// The working directory that we're in. Used to resolve relative paths.
+	CWD string
+
 	// Source could be any of the template source types we accept. Examples:
 	//  - github.com/foo/bar@latest
 	//  - /a/local/path
@@ -104,7 +106,7 @@ type ParseSourceParams struct {
 	GitProtocol string
 }
 
-// parseSourceWithCwd maps the input template source to a particular kind of
+// ParseSourceWithCwd maps the input template source to a particular kind of
 // source (e.g. git) and returns a downloader that will download that source.
 //
 // source is a template location, like "github.com/foo/bar@v1.2.3". protocol is
@@ -112,14 +114,14 @@ type ParseSourceParams struct {
 //
 // A list of sourceParsers is accepted as input for the purpose of testing,
 // rather than hardcoding the real list of sourceParsers.
-func parseSourceWithCwd(ctx context.Context, cwd string, params *ParseSourceParams) (Downloader, error) {
+func ParseSourceWithCwd(ctx context.Context, params *ParseSourceParams) (Downloader, error) {
 	if strings.HasSuffix(params.Source, specutil.SpecFileName) {
 		return nil, fmt.Errorf("the template source argument should be the name of a directory *containing* %s; it should not be the full path to %s",
 			specutil.SpecFileName, specutil.SpecFileName)
 	}
 
 	for _, sp := range realSourceParsers {
-		downloader, ok, err := sp.sourceParse(ctx, cwd, params)
+		downloader, ok, err := sp.sourceParse(ctx, params)
 		if err != nil {
 			return nil, err //nolint:wrapcheck
 		}
@@ -128,16 +130,6 @@ func parseSourceWithCwd(ctx context.Context, cwd string, params *ParseSourcePara
 		}
 	}
 	return nil, fmt.Errorf(`template source %q isn't a valid template name or doesn't exist; examples of valid names are: "github.com/myorg/myrepo/subdir@v1.2.3", "github.com/myorg/myrepo/subdir@latest", "./my-local-directory"`, params.Source)
-}
-
-// ParseSource is the same as [ParseSourceWithWorkingDir], but it uses the
-// current working directory [os.Getwd] as the base path.
-func ParseSource(ctx context.Context, params *ParseSourceParams) (Downloader, error) {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get current working directory: %w", err)
-	}
-	return parseSourceWithCwd(ctx, cwd, params)
 }
 
 // gitCanonicalVersion examines a template directory and tries to determine the

--- a/templates/common/templatesource/source_test.go
+++ b/templates/common/templatesource/source_test.go
@@ -277,10 +277,11 @@ func TestParseSourceWithCwd(t *testing.T) {
 			common.WriteAllDefaultMode(t, tempDir, tc.tempDirContents)
 
 			params := &ParseSourceParams{
+				CWD:         tempDir,
 				Source:      tc.source,
 				GitProtocol: tc.gitProtocol,
 			}
-			got, err := parseSourceWithCwd(ctx, tempDir, params)
+			got, err := ParseSourceWithCwd(ctx, params)
 			if diff := testutil.DiffErrString(err, tc.wantErr); diff != "" {
 				t.Fatal(diff)
 			}


### PR DESCRIPTION
Previously, we used ParseSource as the public interface for the package. It just injected the os.GetCwd() into parseSourceWithCwd. Over time, the surrounding system has evolved that the caller of ParseSource already has access to a fakeable Cwd, so the old shim system is just unnecessary complexity now.