### PR TITLE
Add location_type to the upgrade manifest YAML model

### DIFF
--- a/templates/common/render/manifest.go
+++ b/templates/common/render/manifest.go
@@ -206,6 +206,7 @@ func buildManifest(ctx context.Context, p *writeManifestParams, dlMeta *template
 
 	return &manifest.Manifest{
 		TemplateLocation: model.String{Val: p.dlMeta.CanonicalSource}, // may be empty string if location isn't canonical
+		LocationType:     model.String{Val: dlMeta.LocationType},
 		TemplateDirhash:  model.String{Val: templateDirhash},
 		TemplateVersion:  model.String{Val: p.dlMeta.Version},
 		CreationTime:     now,

--- a/templates/common/render/manifest_test.go
+++ b/templates/common/render/manifest_test.go
@@ -70,6 +70,7 @@ kind: Manifest
 creation_time: 2023-12-08T23:59:02.000000013Z
 modification_time: 2023-12-08T23:59:02.000000013Z
 template_location: ""
+location_type: ""
 template_version: ""
 template_dirhash: h1:uh/nUYc3HpipWEon9kYOsvSrEadfu8Q9TdfBuHcnF3o=
 inputs:
@@ -95,6 +96,7 @@ output_hashes:
 			dlMeta: &templatesource.DownloadMetadata{
 				IsCanonical:     true,
 				CanonicalSource: "github.com/foo/bar",
+				LocationType:    "remote_git",
 				HasVersion:      true,
 				Version:         "v1.2.3",
 			},
@@ -113,6 +115,7 @@ kind: Manifest
 creation_time: 2023-12-08T23:59:02.000000013Z
 modification_time: 2023-12-08T23:59:02.000000013Z
 template_location: github.com/foo/bar
+location_type: remote_git
 template_version: v1.2.3
 template_dirhash: h1:uh/nUYc3HpipWEon9kYOsvSrEadfu8Q9TdfBuHcnF3o=
 inputs:
@@ -175,6 +178,7 @@ kind: Manifest
 creation_time: 2023-12-08T23:59:02.000000013Z
 modification_time: 2023-12-08T23:59:02.000000013Z
 template_location: ""
+location_type: ""
 template_version: ""
 template_dirhash: h1:uh/nUYc3HpipWEon9kYOsvSrEadfu8Q9TdfBuHcnF3o=
 inputs: []
@@ -206,6 +210,7 @@ kind: Manifest
 creation_time: 2023-12-08T23:59:02.000000013Z
 modification_time: 2023-12-08T23:59:02.000000013Z
 template_location: ""
+location_type: ""
 template_version: ""
 template_dirhash: h1:uh/nUYc3HpipWEon9kYOsvSrEadfu8Q9TdfBuHcnF3o=
 inputs:

--- a/templates/common/render/render_test.go
+++ b/templates/common/render/render_test.go
@@ -170,6 +170,7 @@ kind: Manifest
 creation_time: 2023-12-08T23:59:02.000000013Z
 modification_time: 2023-12-08T23:59:02.000000013Z
 template_location: ""
+location_type: ""
 template_version: ""
 template_dirhash: h1:Gym1rh37Q4e6h72ELjloc4lfVPR6B6tuRaLnFmakAYo=
 inputs:

--- a/templates/common/templatesource/download.go
+++ b/templates/common/templatesource/download.go
@@ -62,9 +62,11 @@ type DownloadMetadata struct {
 	// directory are the same for everyone who clones the repo, that means the
 	// relative path counts as a canonical source.
 	//
-	// IsCanonical is true if and only if CanonicalSource is non-empty.
+	// IsCanonical is true if and only if CanonicalSource and LocationType are
+	// non-empty.
 	IsCanonical     bool
 	CanonicalSource string
+	LocationType    string
 
 	// Depending on where the template was taken from, there might be a version
 	// string associated with it (e.g. a git tag or a git SHA).

--- a/templates/common/templatesource/git.go
+++ b/templates/common/templatesource/git.go
@@ -216,6 +216,7 @@ func (g *gitDownloader) Download(ctx context.Context, cwd, destDir string) (*Dow
 	dlMeta := &DownloadMetadata{
 		IsCanonical:     true, // Remote git sources are always canonical.
 		CanonicalSource: g.canonicalSource,
+		LocationType:    LocTypeRemoteGit,
 		HasVersion:      true, // Remote git sources always have a tag or SHA.
 		Version:         canonicalVersion,
 		Vars:            *vars,

--- a/templates/common/templatesource/git_test.go
+++ b/templates/common/templatesource/git_test.go
@@ -60,6 +60,7 @@ func TestGitDownloader_Download(t *testing.T) {
 			wantDLMeta: &DownloadMetadata{
 				IsCanonical:     true,
 				CanonicalSource: "mysource",
+				LocationType:    "remote_git",
 				HasVersion:      true,
 				Version:         "v1.2.3",
 				Vars: DownloaderVars{
@@ -97,6 +98,7 @@ func TestGitDownloader_Download(t *testing.T) {
 			wantDLMeta: &DownloadMetadata{
 				IsCanonical:     true,
 				CanonicalSource: "mysource",
+				LocationType:    "remote_git",
 				HasVersion:      true,
 				Version:         "v1.2.3",
 				Vars: DownloaderVars{
@@ -131,6 +133,7 @@ func TestGitDownloader_Download(t *testing.T) {
 			wantDLMeta: &DownloadMetadata{
 				IsCanonical:     true,
 				CanonicalSource: "mysource",
+				LocationType:    "remote_git",
 				HasVersion:      true,
 				Version:         "v1.2.3",
 				Vars: DownloaderVars{
@@ -165,6 +168,7 @@ func TestGitDownloader_Download(t *testing.T) {
 			wantDLMeta: &DownloadMetadata{
 				IsCanonical:     true,
 				CanonicalSource: "mysource",
+				LocationType:    "remote_git",
 				HasVersion:      true,
 				Version:         "v1.2.3",
 				Vars: DownloaderVars{
@@ -235,6 +239,7 @@ func TestGitDownloader_Download(t *testing.T) {
 			wantDLMeta: &DownloadMetadata{
 				IsCanonical:     true,
 				CanonicalSource: "mysource",
+				LocationType:    "remote_git",
 				HasVersion:      true,
 				Version:         common.MinimalGitHeadSHA,
 				Vars: DownloaderVars{
@@ -264,6 +269,7 @@ func TestGitDownloader_Download(t *testing.T) {
 			wantDLMeta: &DownloadMetadata{
 				IsCanonical:     true,
 				CanonicalSource: "mysource",
+				LocationType:    "remote_git",
 				HasVersion:      true,
 				Version:         "v1.2.3",
 				Vars: DownloaderVars{

--- a/templates/common/templatesource/localsource_test.go
+++ b/templates/common/templatesource/localsource_test.go
@@ -76,6 +76,7 @@ func TestLocalDownloader_Download(t *testing.T) {
 			wantDLMeta: &DownloadMetadata{
 				IsCanonical:     true,
 				CanonicalSource: "../src",
+				LocationType:    "local_git",
 				HasVersion:      true,
 				Version:         common.MinimalGitHeadSHA,
 				Vars: DownloaderVars{
@@ -106,6 +107,7 @@ func TestLocalDownloader_Download(t *testing.T) {
 			wantDLMeta: &DownloadMetadata{
 				IsCanonical:     true,
 				CanonicalSource: "../src",
+				LocationType:    "local_git",
 				HasVersion:      true,
 				Version:         "mytag",
 				Vars: DownloaderVars{
@@ -139,6 +141,7 @@ func TestLocalDownloader_Download(t *testing.T) {
 			wantDLMeta: &DownloadMetadata{
 				IsCanonical:     true,
 				CanonicalSource: "../src",
+				LocationType:    "local_git",
 				HasVersion:      true,
 				Version:         common.MinimalGitHeadSHA,
 				Vars: DownloaderVars{

--- a/templates/common/templatesource/source.go
+++ b/templates/common/templatesource/source.go
@@ -29,6 +29,11 @@ import (
 	"github.com/abcxyz/pkg/logging"
 )
 
+const (
+	LocTypeLocalGit  = "local_git"
+	LocTypeRemoteGit = "remote_git"
+)
+
 // sourceParser is implemented for each particular kind of template source (git,
 // local file, etc.).
 type sourceParser interface {

--- a/templates/model/manifest/v1alpha1/manifest.go
+++ b/templates/model/manifest/v1alpha1/manifest.go
@@ -41,8 +41,12 @@ type Manifest struct {
 	// accurate as the system clock on the machine where the operation ran.
 	ModificationTime time.Time `yaml:"modification_time"`
 
-	// The template source address as passed to `abc templates render`.
+	// The canonical template location from which upgraded template versions can
+	// be fetched in the future.
 	TemplateLocation model.String `yaml:"template_location"`
+
+	// How to interpret template_location, e.g. "remote_git" or "local_git".
+	LocationType model.String `yaml:"location_type"`
 
 	// The tag, branch, SHA, or other version information.
 	TemplateVersion model.String `yaml:"template_version"`


### PR DESCRIPTION
There's a design decision here. We're treating template location strings differently in manifest files than when we parse template locations provided by users on the command line.

 - Template locations on the command line don't explicitly specify the template location type. We just try to parse it in a few different ways and see what works (i.e. is this a github URL or a local directory?)
 - In manifest files, we explicitly record the template location type (either "local_git" or "remote_git"), and *don't* try to autodetect anything.

Why? There are two important differences:

 - Manifest files are written and read only by programs, not people. We can pay a little cost in verbosity to avoid the ambiguity of trying to guess whether a location is a URL or a local file.
 - Manifest files store template locations without a version string (i.e. `@1.2.3`), so we can't just reuse the same code anyway.

How this will be used in a future PR: we'll `switch` based on the value of `location_type` and construct the appropriate downloader struct, either `remoteGitDownloader` or `localDownloader`. We'll pass the `template_location` string into the downloader, and each downloader will interpret it differently.