### PR TITLE
Make builtin vars only in scope if overridden

### DIFF
--- a/templates/commands/goldentest/test_funcs_test.go
+++ b/templates/commands/goldentest/test_funcs_test.go
@@ -356,6 +356,31 @@ steps:
 			},
 		},
 		{
+			name: "builtins_are_only_in_scope_if_overridden",
+			testCase: &TestCase{
+				TestName:   "test",
+				TestConfig: &goldentest.Test{},
+			},
+			filesContent: map[string]string{
+				"spec.yaml": `api_version: 'cli.abcxyz.dev/v1beta3'
+kind: 'Template'
+
+desc: 'A simple template'
+
+steps:
+- desc: 'Include some files and directories'
+  action: 'include'
+  params:
+    paths: ['.']
+- desc: 'Replace git tag placeholder'
+  action: 'go_template'
+  params:
+    paths: ['my_file.txt']`,
+				"my_file.txt": "{{._git_tag}}",
+			},
+			wantErr: `nonexistent variable name "_git_tag"`,
+		},
+		{
 			name: "builtins_are_rejected_on_old_spec_api_version_v1beta2",
 			testCase: &TestCase{
 				TestName: "test",

--- a/templates/commands/goldentest/test_funcs_test.go
+++ b/templates/commands/goldentest/test_funcs_test.go
@@ -189,10 +189,10 @@ builtin_vars:
 
 			ctx := context.Background()
 			got, err := parseTestCases(ctx, tempDir, tc.testNames)
+			if diff := testutil.DiffErrString(err, tc.wantErr); diff != "" {
+				t.Fatal(diff)
+			}
 			if err != nil {
-				if diff := testutil.DiffErrString(err, tc.wantErr); diff != "" {
-					t.Fatal(diff)
-				}
 				return
 			}
 
@@ -296,10 +296,10 @@ steps:
 
 			ctx := context.Background()
 			err := renderTestCase(ctx, tempDir, tempDir, tc.testCase)
+			if diff := testutil.DiffErrString(err, tc.wantErr); diff != "" {
+				t.Fatal(diff)
+			}
 			if err != nil {
-				if diff := testutil.DiffErrString(err, tc.wantErr); diff != "" {
-					t.Fatal(diff)
-				}
 				return
 			}
 
@@ -490,10 +490,10 @@ steps:
 
 			ctx := context.Background()
 			err := renderTestCase(ctx, tempDir, tempDir, tc.testCase)
+			if diff := testutil.DiffErrString(err, tc.wantErr); diff != "" {
+				t.Fatal(diff)
+			}
 			if err != nil {
-				if diff := testutil.DiffErrString(err, tc.wantErr); diff != "" {
-					t.Fatal(diff)
-				}
 				return
 			}
 

--- a/templates/common/builtinvar/builtin_vars.go
+++ b/templates/common/builtinvar/builtin_vars.go
@@ -47,7 +47,7 @@ const (
 // needed because the set of variable names that are in scope depends on the
 // api_version; we sometimes add new variables.
 func Validate(f features.Features, attemptedNames []string) error {
-	allowed := namesInScope(f)
+	allowed := NamesInScope(f)
 	unknown := sets.Subtract(attemptedNames, allowed)
 	if len(unknown) > 0 {
 		return fmt.Errorf("these builtin override var names are unknown and therefore invalid: %v; the set of valid builtin var names is %v",
@@ -56,8 +56,8 @@ func Validate(f features.Features, attemptedNames []string) error {
 	return nil
 }
 
-// namesInScope returns the set of builtin var names.
-func namesInScope(f features.Features) []string {
+// NamesInScope returns the set of builtin var names.
+func NamesInScope(f features.Features) []string {
 	// These vars have always existed in every api_version
 	out := []string{FlagDest, FlagSource}
 

--- a/templates/common/render/render.go
+++ b/templates/common/render/render.go
@@ -232,29 +232,10 @@ func Render(ctx context.Context, p *Params) (outErr error) {
 func scopes(resolvedInputs map[string]string, rp *Params, f features.Features, dlVars templatesource.DownloaderVars) (_ *common.Scope, extraPrintVars map[string]string, _ error) {
 	scope := common.NewScope(resolvedInputs)
 
-	// Git vars are present only in api_version >=v1beta3, hence this check.
-	if !f.SkipGitVars {
-		// Design decision: on api_version>=v1beta3, the _git_* vars are always
-		// in scope, even if their value is just empty string. Why? Because we
-		// need to be able to write CEL expressions that test the absence of eg
-		// a git tag, and those CEL expressions will fail to compile if the
-		// variables don't exist. Like: `if: '_git_tag == ""'`.
-		//
-		// Each of these values can be empty string in the case where the user
-		// is rendering the template from a non-git location, such as a local
-		// directory.
-		scope = scope.With(map[string]string{
-			builtinvar.GitTag:      dlVars.GitTag,
-			builtinvar.GitSHA:      dlVars.GitSHA,
-			builtinvar.GitShortSHA: dlVars.GitShortSHA,
-		})
-	}
-
-	if len(rp.OverrideBuiltinVars) > 0 { // The caller is overriding the builtin underscore-prefixed vars.
+	if rp.OverrideBuiltinVars != nil { // The caller is overriding the builtin underscore-prefixed vars.
 		if err := builtinvar.Validate(f, maps.Keys(rp.OverrideBuiltinVars)); err != nil {
 			return nil, nil, err //nolint:wrapcheck
 		}
-
 		// Split the caller-provided OverrideBuiltinVars into two
 		// non-overlapping sets:
 		//  1. The var names that are available everywhere in the spec, not just
@@ -269,11 +250,31 @@ func scopes(resolvedInputs map[string]string, rp *Params, f features.Features, d
 		}
 		extraPrintVars = sets.IntersectMapKeys(rp.OverrideBuiltinVars, printOnlyVarNames)
 		scope = scope.With(sets.SubtractMapKeys(rp.OverrideBuiltinVars, printOnlyVarNames))
-	} else { // The caller isn't overriding any of the builtin underscore-prefixed vars.
-		extraPrintVars = map[string]string{
-			builtinvar.FlagDest:   rp.DestDir,
-			builtinvar.FlagSource: rp.Source,
-		}
+		return scope, extraPrintVars, nil
+	}
+
+	// The caller isn't overriding the builtin underscore-prefixed vars (this
+	// isn't a golden test). Set the builtin vars normally.
+
+	// The set of builtins varies depending on api_version, hence NamesInScope.
+	builtinNames := builtinvar.NamesInScope(f)
+	builtinsEmptyStringMap := make(map[string]string, len(builtinNames))
+	for _, n := range builtinNames {
+		builtinsEmptyStringMap[n] = ""
+	}
+	scope = scope.With(builtinsEmptyStringMap)
+
+	if !f.SkipGitVars { // if this api_version supports _git_* vars, add them.
+		scope = scope.With(map[string]string{
+			builtinvar.GitTag:      dlVars.GitTag,
+			builtinvar.GitSHA:      dlVars.GitSHA,
+			builtinvar.GitShortSHA: dlVars.GitShortSHA,
+		})
+	}
+
+	extraPrintVars = map[string]string{
+		builtinvar.FlagDest:   rp.DestDir,
+		builtinvar.FlagSource: rp.Source,
 	}
 
 	return scope, extraPrintVars, nil


### PR DESCRIPTION
To help golden-test authors write good tests, we want to force them to provide fake values for all the builtin vars that they use, without accidentally relying on a default value of empty string. By forcing the test authors to think through what they're testing, they'll be more likely to cover both the empty-string and non-empty-string cases.

To this, if a template is being run in a golden-test, and the template references a builtin var, and that var doesn't have an override defined in test.yaml's `builtin_vars` field, the test will fail with a message about an unknown variable.

A future PR will make the error easier to understand and obvious how to fix the test.