### PR TITLE
Consistently use underscore for test names

### DIFF
--- a/templates/common/cel_test.go
+++ b/templates/common/cel_test.go
@@ -40,47 +40,47 @@ func TestCompileAndEvalCEL(t *testing.T) {
 		wantEvalErr    string
 	}{
 		{
-			name: "simple-success",
+			name: "simple_success",
 			in:   model.String{Val: `["alligator","crocodile"]`},
 			want: []string{"alligator", "crocodile"},
 		},
 		{
-			name:        "bad-int-to-string",
+			name:        "bad_int_to_string",
 			in:          model.String{Val: `42`},
 			want:        []string(nil),
 			wantEvalErr: `CEL expression result couldn't be converted to []string. The CEL engine error was: unsupported type conversion from 'int' to []string`,
 		},
 		{
-			name:        "bad-list-of-int-to-list-of-string",
+			name:        "bad_list_of_int_to_list_of_string",
 			in:          model.String{Val: `[42]`},
 			want:        []string(nil),
 			wantEvalErr: `CEL expression result couldn't be converted to []string. The CEL engine error was: unsupported type conversion from 'int' to string`,
 		},
 		{
-			name:        "bad-heterogenous list",
+			name:        "bad_heterogenous_list",
 			in:          model.String{Val: `["alligator", 42]`},
 			want:        []string(nil),
 			wantEvalErr: `CEL expression result couldn't be converted to []string. The CEL engine error was: unsupported type conversion from 'int' to string`,
 		},
 		{
-			name: "string-split",
+			name: "string_split",
 			in:   model.String{Val: `"alligator,crocodile".split(",")`},
 			want: []string{"alligator", "crocodile"},
 		},
 		{
-			name: "input-vars",
+			name: "input_vars",
 			in:   model.String{Val: `["alligator", reptile]`},
 			vars: map[string]string{"reptile": "crocodile"},
 			want: []string{"alligator", "crocodile"},
 		},
 		{
-			name:           "invalid-cel-syntax",
+			name:           "invalid_cel_syntax",
 			in:             model.String{Val: `[[[[[`},
 			want:           "",
 			wantCompileErr: "Syntax error: mismatched input",
 		},
 		{
-			name: "yaml-pos-passed-through-on-error",
+			name: "yaml_pos_passed_through_on_error",
 			in: model.String{
 				Val: `[[[[[`,
 				Pos: &model.ConfigPos{Line: 9876},
@@ -89,17 +89,17 @@ func TestCompileAndEvalCEL(t *testing.T) {
 			wantCompileErr: "9876",
 		},
 		{
-			name: "simple-int-return",
+			name: "simple_int_return",
 			in:   model.String{Val: "42"},
 			want: 42,
 		},
 		{
-			name: "simple-uint-return",
+			name: "simple_uint_return",
 			in:   model.String{Val: "42u"},
 			want: uint(42),
 		},
 		{
-			name: "simple-map-return",
+			name: "simple_map_return",
 			in:   model.String{Val: `{"reptile": "alligator"}`},
 			want: map[string]any{"reptile": "alligator"},
 		},
@@ -151,22 +151,22 @@ func TestCELFuncs(t *testing.T) {
 		wantErr string
 	}{
 		{
-			name: "string-split-success",
+			name: "string_split_success",
 			expr: `"foo,bar".split(",")`,
 			want: []string{"foo", "bar"},
 		},
 		{
-			name: "string-split-no-separator",
+			name: "string_split_no_separator",
 			expr: `"foo".split(",")`,
 			want: []string{"foo"},
 		},
 		{
-			name: "string-split-multiple-separators",
+			name: "string_split_multiple_separators",
 			expr: `"foo,bar,baz".split(",")`,
 			want: []string{"foo", "bar", "baz"},
 		},
 		{
-			name: "string-split-empty-string",
+			name: "string_split_empty_string",
 			expr: `"".split(",")`,
 			want: []string{""},
 		},

--- a/templates/common/input/input_test.go
+++ b/templates/common/input/input_test.go
@@ -89,7 +89,7 @@ func TestValidateInputs(t *testing.T) {
 		want        string
 	}{
 		{
-			name: "no-validation-rule",
+			name: "no_validation_rule",
 			inputModels: []*spec.Input{
 				{
 					Name: model.String{Val: "my_input"},
@@ -100,7 +100,7 @@ func TestValidateInputs(t *testing.T) {
 			},
 		},
 		{
-			name: "single-passing-validation-rule",
+			name: "single_passing_validation_rule",
 			inputModels: []*spec.Input{
 				{
 					Name: model.String{Val: "my_input"},
@@ -117,7 +117,7 @@ func TestValidateInputs(t *testing.T) {
 			},
 		},
 		{
-			name: "single-failing-validation-rule",
+			name: "single_failing_validation_rule",
 			inputModels: []*spec.Input{
 				{
 					Name: model.String{Val: "my_input"},
@@ -140,7 +140,7 @@ Rule:         size(my_input) < 3
 Rule msg:     Length must be less than 3`,
 		},
 		{
-			name: "multiple-passing-validation-rules",
+			name: "multiple_passing_validation_rules",
 			inputModels: []*spec.Input{
 				{
 					Name: model.String{Val: "my_input"},
@@ -165,7 +165,7 @@ Rule msg:     Length must be less than 3`,
 			},
 		},
 		{
-			name: "multiple-passing-validation-rules-one-failing",
+			name: "multiple_passing_validation_rules_one_failing",
 			inputModels: []*spec.Input{
 				{
 					Name: model.String{Val: "my_input"},
@@ -196,7 +196,7 @@ Rule:         size(my_input) < 3
 Rule msg:     Length must be less than 3`,
 		},
 		{
-			name: "multiple-failing-validation-rules",
+			name: "multiple_failing_validation_rules",
 			inputModels: []*spec.Input{
 				{
 					Name: model.String{Val: "my_input"},
@@ -237,7 +237,7 @@ Rule:         my_input.contains("shoe")
 Rule msg:     Must contain "shoe"`,
 		},
 		{
-			name: "cel-syntax-error",
+			name: "cel_syntax_error",
 			inputModels: []*spec.Input{
 				{
 					Name: model.String{Val: "my_input"},
@@ -259,7 +259,7 @@ Rule:         (
 CEL error:    failed compiling CEL expression: ERROR: <input>:1:2: Syntax error:`, // remainder of error omitted
 		},
 		{
-			name: "cel-type-conversion-error",
+			name: "cel_type_conversion_error",
 			inputModels: []*spec.Input{
 				{
 					Name: model.String{Val: "my_input"},
@@ -281,7 +281,7 @@ Rule:         bool(42)
 CEL error:    failed compiling CEL expression: ERROR: <input>:1:5: found no matching overload for 'bool'`, // remainder of error omitted
 		},
 		{
-			name: "cel-output-type-conversion-error",
+			name: "cel_output_type_conversion_error",
 			inputModels: []*spec.Input{
 				{
 					Name: model.String{Val: "my_input"},
@@ -303,7 +303,7 @@ Rule:         42
 CEL error:    CEL expression result couldn't be converted to bool. The CEL engine error was: unsupported type conversion from 'int' to bool`, // remainder of error omitted
 		},
 		{
-			name: "multi-input-validation",
+			name: "multi_input_validation",
 			inputModels: []*spec.Input{
 				{
 					Name: model.String{Val: "my_input"},

--- a/templates/common/render/action_foreach_test.go
+++ b/templates/common/render/action_foreach_test.go
@@ -168,7 +168,7 @@ func TestActionForEach(t *testing.T) {
 			wantErr: `nonexistent variable name "nonexistent"`,
 		},
 		{
-			name: "cel-values-from",
+			name: "cel_values_from",
 			inputs: map[string]string{
 				"environments": "production,dev",
 			},
@@ -188,7 +188,7 @@ func TestActionForEach(t *testing.T) {
 			wantStdout: "production\ndev\n",
 		},
 		{
-			name: "cel-values-empty-no-actions",
+			name: "cel_values_empty_no_actions",
 			in: &spec.ForEach{
 				Iterator: &spec.ForEachIterator{
 					Key:        model.String{Val: "env"},
@@ -205,7 +205,7 @@ func TestActionForEach(t *testing.T) {
 			wantStdout: "",
 		},
 		{
-			name: "cel-values-literal",
+			name: "cel_values_literal",
 			in: &spec.ForEach{
 				Iterator: &spec.ForEachIterator{
 					Key:        model.String{Val: "env"},

--- a/templates/model/spec/v1alpha1/spec_test.go
+++ b/templates/model/spec/v1alpha1/spec_test.go
@@ -233,7 +233,7 @@ name: '_name_with_leading_underscore'`,
 			wantValidateErr: "are reserved",
 		},
 		{
-			name: "validation-rule",
+			name: "validation_rule",
 			in: `desc: 'foo'
 name: 'a'
 rules:
@@ -251,7 +251,7 @@ rules:
 			},
 		},
 		{
-			name: "validation-rule-without-message",
+			name: "validation_rule_without_message",
 			in: `desc: 'foo'
 name: 'a'
 rules:
@@ -267,7 +267,7 @@ rules:
 			},
 		},
 		{
-			name: "multiple-validation-rules",
+			name: "multiple_validation_rules",
 			in: `desc: 'foo'
 name: 'a'
 rules:

--- a/templates/model/spec/v1beta1/spec_test.go
+++ b/templates/model/spec/v1beta1/spec_test.go
@@ -233,7 +233,7 @@ name: '_name_with_leading_underscore'`,
 			wantValidateErr: "are reserved",
 		},
 		{
-			name: "validation-rule",
+			name: "validation_rule",
 			in: `desc: 'foo'
 name: 'a'
 rules:
@@ -251,7 +251,7 @@ rules:
 			},
 		},
 		{
-			name: "validation-rule-without-message",
+			name: "validation_rule_without_message",
 			in: `desc: 'foo'
 name: 'a'
 rules:
@@ -267,7 +267,7 @@ rules:
 			},
 		},
 		{
-			name: "multiple-validation-rules",
+			name: "multiple_validation_rules",
 			in: `desc: 'foo'
 name: 'a'
 rules:

--- a/templates/model/spec/v1beta2/spec_test.go
+++ b/templates/model/spec/v1beta2/spec_test.go
@@ -233,7 +233,7 @@ name: '_name_with_leading_underscore'`,
 			wantValidateErr: "are reserved",
 		},
 		{
-			name: "validation-rule",
+			name: "validation_rule",
 			in: `desc: 'foo'
 name: 'a'
 rules:
@@ -251,7 +251,7 @@ rules:
 			},
 		},
 		{
-			name: "validation-rule-without-message",
+			name: "validation_rule_without_message",
 			in: `desc: 'foo'
 name: 'a'
 rules:
@@ -267,7 +267,7 @@ rules:
 			},
 		},
 		{
-			name: "multiple-validation-rules",
+			name: "multiple_validation_rules",
 			in: `desc: 'foo'
 name: 'a'
 rules:

--- a/templates/model/spec/v1beta3/spec_test.go
+++ b/templates/model/spec/v1beta3/spec_test.go
@@ -233,7 +233,7 @@ name: '_name_with_leading_underscore'`,
 			wantValidateErr: "are reserved",
 		},
 		{
-			name: "validation-rule",
+			name: "validation_rule",
 			in: `desc: 'foo'
 name: 'a'
 rules:
@@ -251,7 +251,7 @@ rules:
 			},
 		},
 		{
-			name: "validation-rule-without-message",
+			name: "validation_rule_without_message",
 			in: `desc: 'foo'
 name: 'a'
 rules:
@@ -267,7 +267,7 @@ rules:
 			},
 		},
 		{
-			name: "multiple-validation-rules",
+			name: "multiple_validation_rules",
 			in: `desc: 'foo'
 name: 'a'
 rules:


### PR DESCRIPTION
 - It's cleaner
 - It allows double-clicking subtest names when debugging