### PR TITLE
fix: template with no output should create an empty output dir

### DIFF
--- a/templates/commands/goldentest/test_funcs.go
+++ b/templates/commands/goldentest/test_funcs.go
@@ -154,10 +154,6 @@ func renderTestCases(ctx context.Context, testCases []*TestCase, location string
 func renderTestCase(ctx context.Context, templateDir, outputDir string, tc *TestCase) error {
 	testDir := filepath.Join(outputDir, goldenTestDir, tc.TestName, testDataDir)
 
-	if err := os.RemoveAll(testDir); err != nil {
-		return fmt.Errorf("failed to clear test directory: %w", err)
-	}
-
 	cwd, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("os.Getwd(): %w", err)

--- a/templates/commands/goldentest/test_funcs_test.go
+++ b/templates/commands/goldentest/test_funcs_test.go
@@ -282,6 +282,25 @@ steps:
 				"data/b.txt": "file B content",
 			},
 		},
+		{
+			name: "empty_template_output_is_valid",
+			testCase: &TestCase{
+				TestName:   "test",
+				TestConfig: &goldentest.Test{},
+			},
+			filesContent: map[string]string{
+				"spec.yaml": `api_version: 'cli.abcxyz.dev/v1alpha1'
+kind: 'Template'
+
+desc: 'A template that outputs no files'
+steps:
+  - desc: 'Print a message'
+    action: 'print'
+    params:
+        message: 'Hello'`,
+			},
+			expectedGoldenContent: map[string]string{},
+		},
 	}
 
 	for _, tc := range cases {
@@ -315,11 +334,11 @@ func TestOverrideBuiltIns(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		name                  string
-		testCase              *TestCase
-		filesContent          map[string]string
-		expectedGoldenContent map[string]string
-		wantErr               string
+		name         string
+		testCase     *TestCase
+		filesContent map[string]string
+		want         map[string]string
+		wantErr      string
 	}{
 		{
 			name: "builtins_are_present_on_spec_api_version_v1beta3",
@@ -351,7 +370,7 @@ steps:
     paths: ['my_file.txt']`,
 				"my_file.txt": "{{._git_tag}}",
 			},
-			expectedGoldenContent: map[string]string{
+			want: map[string]string{
 				"data/my_file.txt": "my-cool-tag",
 			},
 		},
@@ -468,6 +487,7 @@ steps:
   params:
     message: '{{._flag_dest}} {{._flag_source}}'`,
 			},
+			want: map[string]string{},
 		},
 
 		{
@@ -541,7 +561,7 @@ steps:
 			}
 
 			gotDestContents := common.LoadDirWithoutMode(t, filepath.Join(tempDir, "testdata/golden/test"))
-			if diff := cmp.Diff(gotDestContents, tc.expectedGoldenContent, common.CmpFileMode); diff != "" {
+			if diff := cmp.Diff(gotDestContents, tc.want, common.CmpFileMode); diff != "" {
 				t.Errorf("dest directory contents were not as expected (-got,+want): %s", diff)
 			}
 		})

--- a/templates/common/render/render_test.go
+++ b/templates/common/render/render_test.go
@@ -602,7 +602,7 @@ steps:
         skip: ['file1.txt']
 `,
 			},
-			wantDestContents: nil,
+			wantDestContents: map[string]string{},
 		},
 		{
 			name: "glob_include",
@@ -664,7 +664,8 @@ steps:
             message: 'Working on environment {{.env}}'
 `,
 			},
-			wantStdout: "Working on environment production\nWorking on environment dev\n",
+			wantStdout:       "Working on environment production\nWorking on environment dev\n",
+			wantDestContents: map[string]string{},
 		},
 		{
 			name: "skip_input_validation",
@@ -688,6 +689,7 @@ steps:
 			flagInputs:              map[string]string{"my_input": "crocodile"},
 			flagSkipInputValidation: true,
 			wantStdout:              "my_input is crocodile\n",
+			wantDestContents:        map[string]string{},
 		},
 		{
 			name: "step_with_if",
@@ -713,7 +715,8 @@ steps:
     params:
       message: 'Goodbye'`,
 			},
-			wantStdout: "Hello\n",
+			wantStdout:       "Hello\n",
+			wantDestContents: map[string]string{},
 		},
 		{
 			name: "step_with_if_needs_v1beta1",
@@ -889,7 +892,8 @@ steps:
 				builtinvar.FlagDest:   "/my/dest",
 				builtinvar.FlagSource: "/my/source",
 			},
-			wantStdout: "/my/dest /my/source\n",
+			wantStdout:       "/my/dest /my/source\n",
+			wantDestContents: map[string]string{},
 		},
 		{
 			name:       "print_only_flags_are_not_in_scope_outside_of_print_actions",


### PR DESCRIPTION
The former behavior was that the output directory would not be created in the edge case where the template produced no output files. This was problematic for two reasons:

 - It broke `golden-test record`; it expected to find an output directory
 - Empty output is semantically valid. Suppose there's a template that has a bunch of optional steps that are all skipped.

Also:
 - Rename `expectGoldenContents` to `want` for consistency with convention
 - Remove an unnecessary call to os.RemoveAll(). This is a vestige of the old days before we recorded into a temp dir.