### PR TITLE
Rewrite temp dir management

### DIFF
--- a/templates/commands/goldentest/new_test_cli.go
+++ b/templates/commands/goldentest/new_test_cli.go
@@ -75,20 +75,7 @@ func (c *NewTestCommand) Run(ctx context.Context, args []string) (rErr error) {
 	if err := c.Flags().Parse(args); err != nil {
 		return fmt.Errorf("failed to parse flags: %w", err)
 	}
-
-	tempDir, err := os.MkdirTemp("", "abc-new-test-*")
-	if err != nil {
-		return fmt.Errorf("failed to create temporary directory: %w", err)
-	}
-	defer func() {
-		rErr = errors.Join(rErr, os.RemoveAll(tempDir))
-	}()
-
 	fs := &common.RealFS{}
-
-	if err != nil {
-		return err //nolint:wrapcheck
-	}
 
 	spec, err := specutil.Load(ctx, fs, c.flags.Location, c.flags.Location)
 	if err != nil {

--- a/templates/commands/goldentest/record.go
+++ b/templates/commands/goldentest/record.go
@@ -26,6 +26,7 @@ import (
 	"path/filepath"
 
 	"github.com/abcxyz/abc/templates/common"
+	"github.com/abcxyz/abc/templates/common/tempdir"
 	"github.com/abcxyz/pkg/cli"
 	"github.com/abcxyz/pkg/logging"
 )
@@ -66,7 +67,7 @@ func (c *RecordCommand) Flags() *cli.FlagSet {
 	return set
 }
 
-func (c *RecordCommand) Run(ctx context.Context, args []string) error {
+func (c *RecordCommand) Run(ctx context.Context, args []string) (rErr error) {
 	if err := c.Flags().Parse(args); err != nil {
 		return fmt.Errorf("failed to parse flags: %w", err)
 	}
@@ -76,14 +77,19 @@ func (c *RecordCommand) Run(ctx context.Context, args []string) error {
 		return fmt.Errorf("failed to parse golden test: %w", err)
 	}
 
+	rfs := &common.RealFS{}
+
+	tempTracker := tempdir.NewDirTracker(rfs, false)
+	defer tempTracker.DeferMaybeRemoveAll(ctx, &rErr)
+
 	// Create a temporary directory to validate golden tests rendered with no
 	// error. If any test fails, no data should be written to file system
 	// for atomicity purpose.
 	tempDir, err := renderTestCases(ctx, testCases, c.flags.Location)
-	defer os.RemoveAll(tempDir)
 	if err != nil {
 		return fmt.Errorf("failed to render test cases: %w", err)
 	}
+	tempTracker.Track(tempDir)
 
 	var merr error
 	logger := logging.FromContext(ctx)
@@ -108,7 +114,7 @@ func (c *RecordCommand) Run(ctx context.Context, args []string) error {
 		params := &common.CopyParams{
 			DstRoot: testDir,
 			SrcRoot: filepath.Join(tempDir, goldenTestDir, tc.TestName, testDataDir),
-			FS:      &common.RealFS{},
+			FS:      rfs,
 			Visitor: visitor,
 		}
 		merr = errors.Join(merr, common.CopyRecursive(ctx, nil, params))

--- a/templates/commands/goldentest/test_funcs.go
+++ b/templates/commands/goldentest/test_funcs.go
@@ -28,6 +28,7 @@ import (
 	"github.com/abcxyz/abc/templates/common"
 	"github.com/abcxyz/abc/templates/common/errs"
 	"github.com/abcxyz/abc/templates/common/render"
+	"github.com/abcxyz/abc/templates/common/tempdir"
 	"github.com/abcxyz/abc/templates/model"
 	"github.com/abcxyz/abc/templates/model/decode"
 	goldentest "github.com/abcxyz/abc/templates/model/goldentest/v1beta3"
@@ -134,9 +135,9 @@ func parseTestConfig(ctx context.Context, path string) (*goldentest.Test, error)
 	return out, nil
 }
 
-// renderTestCases render all test cases in a temporary directory.
-func renderTestCases(ctx context.Context, testCases []*TestCase, location string) (string, error) {
-	tempDir, err := os.MkdirTemp("", "abc-test-*")
+// renderTestCases render all test cases into a temporary directory.
+func renderTestCases(ctx context.Context, testCases []*TestCase, location string) (dir string, _ error) {
+	tempDir, err := os.MkdirTemp("", tempdir.DebugStepDiffsDirNamePart)
 	if err != nil {
 		return "", fmt.Errorf("failed to create temporary directory: %w", err)
 	}
@@ -146,6 +147,7 @@ func renderTestCases(ctx context.Context, testCases []*TestCase, location string
 		merr = errors.Join(merr, renderTestCase(ctx, location, tempDir, tc))
 	}
 	if merr != nil {
+		merr = errors.Join(merr, os.RemoveAll(tempDir))
 		return "", fmt.Errorf("failed to render golden tests: %w", merr)
 	}
 	return tempDir, nil

--- a/templates/commands/goldentest/test_funcs.go
+++ b/templates/commands/goldentest/test_funcs.go
@@ -137,7 +137,7 @@ func parseTestConfig(ctx context.Context, path string) (*goldentest.Test, error)
 
 // renderTestCases render all test cases into a temporary directory.
 func renderTestCases(ctx context.Context, testCases []*TestCase, location string) (dir string, _ error) {
-	tempDir, err := os.MkdirTemp("", tempdir.DebugStepDiffsDirNamePart)
+	tempDir, err := os.MkdirTemp("", tempdir.GoldenTestRenderNamePart)
 	if err != nil {
 		return "", fmt.Errorf("failed to create temporary directory: %w", err)
 	}

--- a/templates/commands/render/render_test.go
+++ b/templates/commands/render/render_test.go
@@ -174,12 +174,12 @@ steps:
   params:
     paths:
       - paths: ['file1.txt', 'dir1', 'dir2/file2.txt']
-- desc: 'Replace "Bob" with [input]'
+- desc: 'Replace "Alice" with [input]'
   action: 'string_replace'
   params:
     paths: ['.']
     replacements:
-    - to_replace: 'Bob'
+    - to_replace: 'Alice'
       with: '{{.name_of_favourite_person}}'
 `
 
@@ -196,7 +196,7 @@ steps:
 			templateContents: map[string]string{
 				"myfile.txt":           "Some random stuff",
 				"spec.yaml":            specContents,
-				"file1.txt":            "my favorite person is Bob",
+				"file1.txt":            "my favorite person is Alice",
 				"dir1/file_in_dir.txt": "file_in_dir contents",
 				"dir2/file2.txt":       "file2 contents",
 			},

--- a/templates/commands/render/render_test.go
+++ b/templates/commands/render/render_test.go
@@ -174,12 +174,12 @@ steps:
   params:
     paths:
       - paths: ['file1.txt', 'dir1', 'dir2/file2.txt']
-- desc: 'Replace "Alice" with [input]'
+- desc: 'Replace "Bob" with [input]'
   action: 'string_replace'
   params:
     paths: ['.']
     replacements:
-    - to_replace: 'Alice'
+    - to_replace: 'Bob'
       with: '{{.name_of_favourite_person}}'
 `
 
@@ -196,7 +196,7 @@ steps:
 			templateContents: map[string]string{
 				"myfile.txt":           "Some random stuff",
 				"spec.yaml":            specContents,
-				"file1.txt":            "my favorite person is Alice",
+				"file1.txt":            "my favorite person is Bob",
 				"dir1/file_in_dir.txt": "file_in_dir contents",
 				"dir2/file2.txt":       "file2 contents",
 			},

--- a/templates/common/render/action_include_test.go
+++ b/templates/common/render/action_include_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/abcxyz/abc/templates/common"
-	"github.com/abcxyz/abc/templates/common/paths"
+	"github.com/abcxyz/abc/templates/common/tempdir"
 	"github.com/abcxyz/abc/templates/model"
 	spec "github.com/abcxyz/abc/templates/model/spec/v1beta3"
 	abctestutil "github.com/abcxyz/abc/templates/testutil"
@@ -894,8 +894,8 @@ func TestActionInclude(t *testing.T) {
 			toPlatformPaths(tc.wantIncludedFromDest)
 
 			tempDir := t.TempDir()
-			templateDir := filepath.Join(tempDir, paths.TemplateDirNamePart)
-			scratchDir := filepath.Join(tempDir, paths.ScratchDirNamePart)
+			templateDir := filepath.Join(tempDir, tempdir.TemplateDirNamePart)
+			scratchDir := filepath.Join(tempDir, tempdir.ScratchDirNamePart)
 			destDir := filepath.Join(tempDir, "dest")
 
 			abctestutil.WriteAll(t, templateDir, tc.templateContents)
@@ -923,12 +923,12 @@ func TestActionInclude(t *testing.T) {
 				t.Error(diff)
 			}
 
-			gotTemplateContents := abctestutil.LoadDirContents(t, filepath.Join(tempDir, paths.TemplateDirNamePart))
+			gotTemplateContents := abctestutil.LoadDirContents(t, filepath.Join(tempDir, tempdir.TemplateDirNamePart))
 			if diff := cmp.Diff(gotTemplateContents, tc.templateContents); diff != "" {
 				t.Errorf("template directory should not have been touched (-got,+want): %s", diff)
 			}
 
-			gotScratchContents := abctestutil.LoadDirContents(t, filepath.Join(tempDir, paths.ScratchDirNamePart))
+			gotScratchContents := abctestutil.LoadDirContents(t, filepath.Join(tempDir, tempdir.ScratchDirNamePart))
 			if diff := cmp.Diff(gotScratchContents, tc.wantScratchContents); diff != "" {
 				t.Errorf("scratch directory contents were not as expected (-got,+want): %s", diff)
 			}

--- a/templates/common/render/render.go
+++ b/templates/common/render/render.go
@@ -163,7 +163,6 @@ func Render(ctx context.Context, p *Params) (rErr error) {
 		return err //nolint:wrapcheck
 	}
 
-	
 	scratchDir, err := tempTracker.MkdirTempTracked(p.TempDirBase, tempdir.ScratchDirNamePart)
 	if err != nil {
 		return fmt.Errorf("failed to create temp directory for scratch directory: %w", err)

--- a/templates/common/render/render_test.go
+++ b/templates/common/render/render_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/abcxyz/abc/templates/common"
 	"github.com/abcxyz/abc/templates/common/builtinvar"
 	"github.com/abcxyz/abc/templates/common/input"
-	"github.com/abcxyz/abc/templates/common/paths"
+	"github.com/abcxyz/abc/templates/common/tempdir"
 	"github.com/abcxyz/abc/templates/model"
 	spec "github.com/abcxyz/abc/templates/model/spec/v1beta3"
 	abctestutil "github.com/abcxyz/abc/templates/testutil"
@@ -1133,7 +1133,7 @@ steps:
 			}
 
 			var gotTemplateContents map[string]string
-			templateDir, ok := abctestutil.TestMustGlob(t, filepath.Join(tempDir, paths.TemplateDirNamePart+"*")) // the * accounts for the random cookie added by mkdirtemp
+			templateDir, ok := abctestutil.TestMustGlob(t, filepath.Join(tempDir, tempdir.TemplateDirNamePart+"*")) // the * accounts for the random cookie added by mkdirtemp
 			if ok {
 				gotTemplateContents = abctestutil.LoadDirWithoutMode(t, templateDir)
 			}
@@ -1142,7 +1142,7 @@ steps:
 			}
 
 			var gotScratchContents map[string]string
-			scratchDir, ok := abctestutil.TestMustGlob(t, filepath.Join(tempDir, paths.ScratchDirNamePart+"*"))
+			scratchDir, ok := abctestutil.TestMustGlob(t, filepath.Join(tempDir, tempdir.ScratchDirNamePart+"*"))
 			if ok {
 				gotScratchContents = abctestutil.LoadDirWithoutMode(t, scratchDir)
 			}
@@ -1165,7 +1165,7 @@ steps:
 			}
 
 			var gotDebugContents map[string]string
-			debugDir, ok := abctestutil.TestMustGlob(t, filepath.Join(tempDir, paths.DebugStepDiffsDirNamePart+"*"))
+			debugDir, ok := abctestutil.TestMustGlob(t, filepath.Join(tempDir, tempdir.DebugStepDiffsDirNamePart+"*"))
 			if ok {
 				gotDebugContents = abctestutil.LoadDirWithoutMode(t, debugDir)
 			}

--- a/templates/common/tempdir/paths.go
+++ b/templates/common/tempdir/paths.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package paths
+package tempdir
 
 const (
 	// These will be used as part of the names of the temporary directories to

--- a/templates/common/tempdir/paths.go
+++ b/templates/common/tempdir/paths.go
@@ -18,7 +18,7 @@ const (
 	// These will be used as part of the names of the temporary directories to
 	// make them identifiable.
 	DebugStepDiffsDirNamePart = "debug-step-diffs-"
-	GoldenTestRenderNamePart = "golden-test-"
+	GoldenTestRenderNamePart  = "golden-test-"
 	ScratchDirNamePart        = "scratch-"
 	TemplateDirNamePart       = "template-copy-"
 )

--- a/templates/common/tempdir/paths.go
+++ b/templates/common/tempdir/paths.go
@@ -17,7 +17,8 @@ package tempdir
 const (
 	// These will be used as part of the names of the temporary directories to
 	// make them identifiable.
-	TemplateDirNamePart       = "template-copy-"
-	ScratchDirNamePart        = "scratch-"
 	DebugStepDiffsDirNamePart = "debug-step-diffs-"
+	GoldenTestRenderNamePart = "golden-test-"
+	ScratchDirNamePart        = "scratch-"
+	TemplateDirNamePart       = "template-copy-"
 )

--- a/templates/common/tempdir/tempremover.go
+++ b/templates/common/tempdir/tempremover.go
@@ -58,7 +58,7 @@ func (t *DirTracker) MkdirTempTracked(dir, pattern string) (string, error) {
 		return "", err
 	}
 	t.Track(tempDir)
-	return dir, nil
+	return tempDir, nil
 }
 
 // DeferMaybeRemoveAll should be called in a defer to clean up temp dirs, like this:

--- a/templates/common/tempdir/tempremover.go
+++ b/templates/common/tempdir/tempremover.go
@@ -55,7 +55,7 @@ func (t *DirTracker) Track(dir string) {
 func (t *DirTracker) MkdirTempTracked(dir, pattern string) (string, error) {
 	tempDir, err := t.fs.MkdirTemp(dir, pattern)
 	if err != nil {
-		return "", err
+		return "", err //nolint:wrapcheck
 	}
 	t.Track(tempDir)
 	return tempDir, nil

--- a/templates/common/tempdir/tempremover.go
+++ b/templates/common/tempdir/tempremover.go
@@ -1,0 +1,80 @@
+// Copyright 2024 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tempdir
+
+import (
+	"context"
+	"errors"
+
+	"github.com/abcxyz/abc/templates/common"
+	"github.com/abcxyz/pkg/logging"
+)
+
+// DirTracker helps manage the removal of temporary directories when
+// rendering is finished.
+type DirTracker struct {
+	fs           common.FS
+	tempDirs     []string
+	keepTempDirs bool
+}
+
+// NewDirTracker constructs a TempDirRemover. Use this instead of creating
+// a TempDirRemover yourself.
+//
+// keepTempDirs is like a no-op flag; it preserves the temp dirs for debugging
+// rather than removing them.
+func NewDirTracker(fs common.FS, keepTempDirs bool) *DirTracker {
+	return &DirTracker{
+		fs:           fs,
+		keepTempDirs: keepTempDirs,
+	}
+}
+
+// Track adds dir to the list of directories to remove.
+func (t *DirTracker) Track(dir string) {
+	if dir == "" {
+		return
+	}
+	t.tempDirs = append(t.tempDirs, dir)
+}
+
+// MkdirTempTracked calls MkdirTemp and also tracks the resulting directory for
+// later cleanup.
+func (t *DirTracker) MkdirTempTracked(dir, pattern string) (string, error) {
+	tempDir, err := t.fs.MkdirTemp(dir, pattern)
+	if err != nil {
+		return "", err
+	}
+	t.Track(tempDir)
+	return dir, nil
+}
+
+// DeferMaybeRemoveAll should be called in a defer to clean up temp dirs, like this:
+//
+//	defer t.DeferMaybeRemoveAll(ctx, &rErr)
+func (t *DirTracker) DeferMaybeRemoveAll(ctx context.Context, outErr *error) {
+	logger := logging.FromContext(ctx).With("logger", "tempDirRemover.Remove")
+	if t.keepTempDirs {
+		logger.WarnContext(ctx, "keeping temporary directories due to --keep-temp-dirs",
+			"paths", t.tempDirs)
+		return
+	}
+
+	logger.DebugContext(ctx, "removing all temporary directories (skip this with --keep-temp-dirs)")
+
+	for _, p := range t.tempDirs {
+		*outErr = errors.Join(*outErr, t.fs.RemoveAll(p))
+	}
+}

--- a/templates/common/tempdir/tempremover.go
+++ b/templates/common/tempdir/tempremover.go
@@ -30,8 +30,8 @@ type DirTracker struct {
 	keepTempDirs bool
 }
 
-// NewDirTracker constructs a TempDirRemover. Use this instead of creating
-// a TempDirRemover yourself.
+// NewDirTracker constructs a DirTracker. Use this instead of creating a
+// DirTracker yourself.
 //
 // keepTempDirs is like a no-op flag; it preserves the temp dirs for debugging
 // rather than removing them.

--- a/templates/common/templatesource/remote_git.go
+++ b/templates/common/templatesource/remote_git.go
@@ -155,7 +155,7 @@ func (g *remoteGitDownloader) Download(ctx context.Context, cwd, destDir string)
 	// for a subdirectory, e.g. "github.com/my-org/my-repo/my-subdir@v1.2.3".
 	tempTracker := tempdir.NewDirTracker(&common.RealFS{}, false)
 	defer tempTracker.DeferMaybeRemoveAll(ctx, &rErr)
-	tmpDir, err := tempTracker.MkdirTempTracked("", "git-clone-")
+	tmpDir, err := tempTracker.MkdirTempTracked(os.TempDir(), "git-clone-")
 	if err != nil {
 		return nil, fmt.Errorf("MkdirTemp: %w", err)
 	}

--- a/templates/common/templatesource/remote_git.go
+++ b/templates/common/templatesource/remote_git.go
@@ -155,7 +155,7 @@ func (g *remoteGitDownloader) Download(ctx context.Context, cwd, destDir string)
 	// for a subdirectory, e.g. "github.com/my-org/my-repo/my-subdir@v1.2.3".
 	tempTracker := tempdir.NewDirTracker(&common.RealFS{}, false)
 	defer tempTracker.DeferMaybeRemoveAll(ctx, &rErr)
-	tmpDir, err := tempTracker.MkdirTempTracked(os.TempDir(), "git-clone-")
+	tmpDir, err := tempTracker.MkdirTempTracked("", "git-clone-")
 	if err != nil {
 		return nil, fmt.Errorf("MkdirTemp: %w", err)
 	}

--- a/templates/common/templatesource/remote_git.go
+++ b/templates/common/templatesource/remote_git.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/abcxyz/abc/templates/common"
 	"github.com/abcxyz/abc/templates/common/git"
+	"github.com/abcxyz/abc/templates/common/tempdir"
 	"github.com/abcxyz/pkg/logging"
 )
 
@@ -132,7 +133,7 @@ type remoteGitDownloader struct {
 }
 
 // Download implements Downloader.
-func (g *remoteGitDownloader) Download(ctx context.Context, cwd, destDir string) (*DownloadMetadata, error) {
+func (g *remoteGitDownloader) Download(ctx context.Context, cwd, destDir string) (_ *DownloadMetadata, rErr error) {
 	logger := logging.FromContext(ctx).With("logger", "remoteGitDownloader.Download")
 
 	// Validate first before doing expensive work
@@ -152,11 +153,12 @@ func (g *remoteGitDownloader) Download(ctx context.Context, cwd, destDir string)
 	// Rather than cloning directly into destDir, we clone into a temp dir. It would
 	// be incorrect to clone the whole repo into destDir if the caller only asked
 	// for a subdirectory, e.g. "github.com/my-org/my-repo/my-subdir@v1.2.3".
-	tmpDir, err := os.MkdirTemp(os.TempDir(), "git-clone-")
+	tempTracker := tempdir.NewDirTracker(&common.RealFS{}, false)
+	defer tempTracker.DeferMaybeRemoveAll(ctx, &rErr)
+	tmpDir, err := tempTracker.MkdirTempTracked("", "git-clone-")
 	if err != nil {
 		return nil, fmt.Errorf("MkdirTemp: %w", err)
 	}
-	defer os.RemoveAll(tmpDir)
 	subdirToCopy := filepath.Join(tmpDir, filepath.FromSlash(subdir))
 
 	if err := g.cloner.Clone(ctx, g.remote, versionToDownload, tmpDir); err != nil {


### PR DESCRIPTION
Handling of temp dirs was slightly incorrect and ugly in several ways:

 - In some places, errors were ignored when removing temp dirs
 - One temp dir was created but never used
 - There was a mishmash of styles, all of which were overly verbose and error prone
 - Some temp dirs were not cleaned up on the error path
 - os.TempDir() was being called unnecessarily, MkdirTemp() accepts `""` to default to using `/tmp`

So we renovate `TempTracker` and use it consistently.