### PR TITLE
Add the concept of unreleased api_versions

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -37,7 +37,7 @@ var (
 
 // IsReleaseBuild returns true if this binary was built by goreleaser as part of
 // the official release process (as opposed to a user just running "go build",
-// or running in a CI environment, or something else.
+// or running in a CI environment, or something else).
 func IsReleaseBuild() bool {
 	// "source" is a sentinel value returned from buildinfo.Version() when the
 	// build metadata is not present. The build metadata is filled in with the

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -34,3 +34,14 @@ var (
 	// HumanVersion is the compiled version.
 	HumanVersion = Name + " " + Version + " (" + Commit + ", " + OSArch + ")"
 )
+
+// IsReleaseBuild returns true if this binary was built by goreleaser as part of
+// the official release process (as opposed to a user just running "go build",
+// or running in a CI environment, or something else.
+func IsReleaseBuild() bool {
+	// "source" is a sentinel value returned from buildinfo.Version() when the
+	// build metadata is not present. The build metadata is filled in with the
+	// "-X" flag during release builds, so if it's not present, this binary is
+	// not a release build.
+	return Version != "source"
+}

--- a/templates/commands/goldentest/new_test_cli.go
+++ b/templates/commands/goldentest/new_test_cli.go
@@ -26,6 +26,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
+	"github.com/abcxyz/abc/internal/version"
 	"github.com/abcxyz/abc/templates/common"
 	"github.com/abcxyz/abc/templates/common/builtinvar"
 	"github.com/abcxyz/abc/templates/common/input"
@@ -135,9 +136,11 @@ func (c *NewTestCommand) Run(ctx context.Context, args []string) (rErr error) {
 }
 
 func marshalTestCase(inputs, builtinVars map[string]string) ([]byte, error) {
+	apiVersion := decode.LatestSupportedAPIVersion(version.IsReleaseBuild())
+
 	testCase := &goldentest.WithHeader{
 		Header: &header.Fields{
-			NewStyleAPIVersion: model.String{Val: decode.LatestAPIVersion},
+			NewStyleAPIVersion: model.String{Val: apiVersion},
 			Kind:               model.String{Val: decode.KindGoldenTest},
 		},
 		Wrapped: &goldentest.ForMarshaling{

--- a/templates/common/render/manifest.go
+++ b/templates/common/render/manifest.go
@@ -30,6 +30,7 @@ import (
 	"golang.org/x/mod/sumdb/dirhash"
 	"gopkg.in/yaml.v3"
 
+	"github.com/abcxyz/abc/internal/version"
 	"github.com/abcxyz/abc/templates/common"
 	"github.com/abcxyz/abc/templates/common/templatesource"
 	"github.com/abcxyz/abc/templates/model"
@@ -187,10 +188,11 @@ func buildManifest(ctx context.Context, p *writeManifestParams, dlMeta *template
 	})
 
 	now := p.clock.Now().UTC()
+	apiVersion := decode.LatestSupportedAPIVersion(version.IsReleaseBuild())
 
 	return &manifest.WithHeader{
 		Header: &header.Fields{
-			NewStyleAPIVersion: model.String{Val: decode.LatestAPIVersion},
+			NewStyleAPIVersion: model.String{Val: apiVersion},
 			Kind:               model.String{Val: decode.KindManifest},
 		},
 		Wrapped: &manifest.ForMarshaling{

--- a/templates/model/decode/decode.go
+++ b/templates/model/decode/decode.go
@@ -46,6 +46,10 @@ var (
 type apiVersionDef struct {
 	apiVersion string
 
+	// Set this to true for api_versions that are still under construction and
+	// should not be supported in official release builds. We don't want real
+	// users using unreleased api_versions which are still under construction
+	// and may receive breaking changes.
 	unreleased bool
 
 	// Map keys are the "kind" values found in the YAML files.

--- a/templates/model/decode/decode.go
+++ b/templates/model/decode/decode.go
@@ -243,11 +243,11 @@ func decodeFromVersionKind(filename, apiVersion, kind string, buf []byte) (model
 // isReleaseBuild is the value of version.IsReleaseBuild(), but for testing
 // purposes we make it an argument rather than hardcoding.
 func LatestSupportedAPIVersion(isReleaseBuild bool) string {
-	// Release builds (like "I am the official release of version 1.2.3")
-	// will read and write only only officially released, finalized
-	// api_versions. Other builds (e.g. CI builds, local dev builds, devs
-	// running "go test" on workstations) are more permissive and will read
-	// and write the most recent unreleased work-in-progress api_version.
+	// Release builds (like "I am the official release of version 1.2.3") will
+	// read and write only officially released, finalized api_versions. Other
+	// builds (e.g. CI builds, local dev builds, devs running "go test" on
+	// workstations) are more permissive and will read and write the most recent
+	// unreleased work-in-progress api_version.
 	if !isReleaseBuild {
 		return apiVersions[len(apiVersions)-1].apiVersion
 	}

--- a/templates/model/decode/decode_test.go
+++ b/templates/model/decode/decode_test.go
@@ -538,3 +538,38 @@ func TestAPIVersions_ArchetypesArePointers(t *testing.T) {
 		}
 	}
 }
+
+func TestLatestSupportedAPIVersion(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name           string
+		isReleaseBuild bool
+		want           string
+	}{
+		{
+			name:           "is_release_build",
+			isReleaseBuild: true,
+			want:           "cli.abcxyz.dev/v1beta3", // update for each api_version release
+		},
+		{
+			name:           "not_release_build",
+			isReleaseBuild: false,
+			want:           "cli.abcxyz.dev/v1beta4", // update for creation of a new api_version
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := LatestSupportedAPIVersion(tc.isReleaseBuild)
+			if got != tc.want {
+				t.Errorf("LatestSupportedAPIVersion(%t)=%q, want %q",
+					tc.isReleaseBuild, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Currently, it can be hard to release a new binary version because any unfinished features and api_versions will be exposed in that release. For example, we can't release a new binary version if api_version `v1beta4` is unfinished, because the new binary will put `api_version: v1beta4` in all the yaml files that it creates.

Instead, we want the ability to release a new binary version at any time, with unfinished features hidden behind an api_version that is still hidden from the public.

To do this, we mark each release struct with a boolean indicating whether it is released or not. api_versions that are under construction will not be used by official release binaries. When a release build of abc creates a yaml file, the header will use api_version=$last_officially_released_api_version, not the api_version that's under construction at the time of release.