### PR TITLE
fix: allow goldentest input values be empty

### DIFF
--- a/templates/model/goldentest/v1alpha1/goldentest.go
+++ b/templates/model/goldentest/v1alpha1/goldentest.go
@@ -41,7 +41,6 @@ func (i *VarValue) UnmarshalYAML(n *yaml.Node) error {
 func (i *VarValue) Validate() error {
 	return errors.Join(
 		model.NotZeroModel(&i.Pos, i.Name, "name"),
-		model.NotZeroModel(&i.Pos, i.Value, "value"),
 	)
 }
 

--- a/templates/model/goldentest/v1alpha1/goldentest_test.go
+++ b/templates/model/goldentest/v1alpha1/goldentest_test.go
@@ -60,10 +60,18 @@ func TestTestUnmarshal(t *testing.T) {
 			want: &Test{},
 		},
 		{
-			name: "missing_field_should_fail",
+			name: "empty_string_value",
 			in: `inputs:
-- name: 'person_name'`,
-			wantErr: `at line 2 column 3: field "value" is required`,
+- name: 'person_name'
+  value: ''`,
+			want: &Test{
+				Inputs: []*VarValue{
+					{
+						Name:  model.String{Val: "person_name"},
+						Value: model.String{Val: ""},
+					},
+				},
+			},
 		},
 		{
 			name: "unknown_field_should_fail",

--- a/templates/model/goldentest/v1beta3/goldentest.go
+++ b/templates/model/goldentest/v1beta3/goldentest.go
@@ -42,7 +42,6 @@ func (i *VarValue) UnmarshalYAML(n *yaml.Node) error {
 func (i *VarValue) Validate() error {
 	return errors.Join(
 		model.NotZeroModel(&i.Pos, i.Name, "name"),
-		model.NotZeroModel(&i.Pos, i.Value, "value"),
 	)
 }
 

--- a/templates/model/goldentest/v1beta3/goldentest_test.go
+++ b/templates/model/goldentest/v1beta3/goldentest_test.go
@@ -64,7 +64,7 @@ func TestTestUnmarshal(t *testing.T) {
 			in: `inputs:
 - name: 'person_name'
   value: ''`,
-  			want: &Test{
+			want: &Test{
 				Inputs: []*VarValue{
 					{
 						Name:  model.String{Val: "person_name"},

--- a/templates/model/goldentest/v1beta3/goldentest_test.go
+++ b/templates/model/goldentest/v1beta3/goldentest_test.go
@@ -60,10 +60,18 @@ func TestTestUnmarshal(t *testing.T) {
 			want: &Test{},
 		},
 		{
-			name: "missing_field_should_fail",
+			name: "empty_string_value",
 			in: `inputs:
-- name: 'person_name'`,
-			wantErr: `at line 2 column 3: field "value" is required`,
+- name: 'person_name'
+  value: ''`,
+  			want: &Test{
+				Inputs: []*VarValue{
+					{
+						Name:  model.String{Val: "person_name"},
+						Value: model.String{Val: ""},
+					},
+				},
+			},
 		},
 		{
 			name: "unknown_field_should_fail",

--- a/templates/model/goldentest/v1beta4/goldentest.go
+++ b/templates/model/goldentest/v1beta4/goldentest.go
@@ -43,7 +43,6 @@ func (i *VarValue) UnmarshalYAML(n *yaml.Node) error {
 func (i *VarValue) Validate() error {
 	return errors.Join(
 		model.NotZeroModel(&i.Pos, i.Name, "name"),
-		model.NotZeroModel(&i.Pos, i.Value, "value"),
 	)
 }
 

--- a/templates/model/goldentest/v1beta4/goldentest_test.go
+++ b/templates/model/goldentest/v1beta4/goldentest_test.go
@@ -64,7 +64,7 @@ func TestTestUnmarshal(t *testing.T) {
 			in: `inputs:
 - name: 'person_name'
   value: ''`,
-  			want: &Test{
+			want: &Test{
 				Inputs: []*VarValue{
 					{
 						Name:  model.String{Val: "person_name"},

--- a/templates/model/goldentest/v1beta4/goldentest_test.go
+++ b/templates/model/goldentest/v1beta4/goldentest_test.go
@@ -60,10 +60,18 @@ func TestTestUnmarshal(t *testing.T) {
 			want: &Test{},
 		},
 		{
-			name: "missing_field_should_fail",
+			name: "empty_string_value",
 			in: `inputs:
-- name: 'person_name'`,
-			wantErr: `at line 2 column 3: field "value" is required`,
+- name: 'person_name'
+  value: ''`,
+  			want: &Test{
+				Inputs: []*VarValue{
+					{
+						Name:  model.String{Val: "person_name"},
+						Value: model.String{Val: ""},
+					},
+				},
+			},
 		},
 		{
 			name: "unknown_field_should_fail",


### PR DESCRIPTION
Before this fix, unmarshaling of test.yaml will fail if any input `value` is missing or empty-string. Empty string is a valid value for many inputs.

Fixes #447 .