### PR TITLE
Trivial renaming of testutil WriteAll/ReadAll

### DIFF
--- a/templates/commands/describe/describe_test.go
+++ b/templates/commands/describe/describe_test.go
@@ -161,7 +161,7 @@ steps:
 
 			tempDir := t.TempDir()
 			sourceDir := filepath.Join(tempDir, "source")
-			abctestutil.WriteAllDefaultMode(t, sourceDir, tc.templateContents)
+			abctestutil.WriteAll(t, sourceDir, tc.templateContents)
 			rfs := &common.RealFS{}
 			stdoutBuf := &strings.Builder{}
 			r := &Command{

--- a/templates/commands/goldentest/new_test_cli_test.go
+++ b/templates/commands/goldentest/new_test_cli_test.go
@@ -223,7 +223,7 @@ kind: GoldenTest
 
 			tempDir := t.TempDir()
 
-			abctestutil.WriteAllDefaultMode(t, tempDir, tc.templateContents)
+			abctestutil.WriteAll(t, tempDir, tc.templateContents)
 
 			ctx := logging.WithLogger(context.Background(), logging.TestLogger(t))
 
@@ -248,7 +248,7 @@ kind: GoldenTest
 				return
 			}
 
-			gotContents := abctestutil.LoadDirWithoutMode(t, filepath.Join(tempDir, "testdata/golden/", tc.newTestName))
+			gotContents := abctestutil.LoadDir(t, filepath.Join(tempDir, "testdata/golden/", tc.newTestName))
 			if diff := cmp.Diff(gotContents, tc.expectedContents); diff != "" {
 				t.Errorf("dest directory contents were not as expected (-got,+want): %s", diff)
 			}
@@ -392,7 +392,7 @@ builtin_vars:
 
 			tempDir := t.TempDir()
 
-			abctestutil.WriteAllDefaultMode(t, tempDir, tc.templateContents)
+			abctestutil.WriteAll(t, tempDir, tc.templateContents)
 
 			ctx := logging.WithLogger(context.Background(), logging.TestLogger(t))
 
@@ -436,7 +436,7 @@ builtin_vars:
 			case <-time.After(time.Second):
 				t.Fatal("timed out waiting for background goroutine to finish")
 			}
-			gotContents := abctestutil.LoadDirWithoutMode(t, filepath.Join(tempDir, "testdata/golden/", tc.newTestName))
+			gotContents := abctestutil.LoadDir(t, filepath.Join(tempDir, "testdata/golden/", tc.newTestName))
 			if diff := cmp.Diff(gotContents, tc.expectedContents); diff != "" {
 				t.Errorf("dest directory contents were not as expected (-got,+want): %s", diff)
 			}

--- a/templates/commands/goldentest/record_test.go
+++ b/templates/commands/goldentest/record_test.go
@@ -278,7 +278,7 @@ kind: 'GoldenTest'`,
 
 			tempDir := t.TempDir()
 
-			abctestutil.WriteAllDefaultMode(t, tempDir, tc.filesContent)
+			abctestutil.WriteAll(t, tempDir, tc.filesContent)
 
 			ctx := logging.WithLogger(context.Background(), logging.TestLogger(t))
 
@@ -295,7 +295,7 @@ kind: 'GoldenTest'`,
 				}
 			}
 
-			gotDestContents := abctestutil.LoadDirWithoutMode(t, filepath.Join(tempDir, "testdata/golden"))
+			gotDestContents := abctestutil.LoadDir(t, filepath.Join(tempDir, "testdata/golden"))
 			if diff := cmp.Diff(gotDestContents, tc.expectedGoldenContent); diff != "" {
 				t.Errorf("dest directory contents were not as expected (-got,+want): %s", diff)
 			}

--- a/templates/commands/goldentest/record_verify_test.go
+++ b/templates/commands/goldentest/record_verify_test.go
@@ -74,7 +74,7 @@ inputs:
 			name: "mismatch_should_fail",
 			messWith: func(t *testing.T, dir string) {
 				t.Helper()
-				abctestutil.WriteAllDefaultMode(t, dir, map[string]string{
+				abctestutil.WriteAll(t, dir, map[string]string{
 					"a.txt": "mismatched content",
 				})
 			},
@@ -89,7 +89,7 @@ inputs:
 
 			tempDir := t.TempDir()
 
-			abctestutil.WriteAllDefaultMode(t, tempDir, templateContent)
+			abctestutil.WriteAll(t, tempDir, templateContent)
 
 			ctx := logging.WithLogger(context.Background(), logging.TestLogger(t))
 

--- a/templates/commands/goldentest/test_funcs_test.go
+++ b/templates/commands/goldentest/test_funcs_test.go
@@ -190,7 +190,7 @@ builtin_vars:
 
 			tempDir := t.TempDir()
 
-			abctestutil.WriteAllDefaultMode(t, tempDir, tc.filesContent)
+			abctestutil.WriteAll(t, tempDir, tc.filesContent)
 
 			ctx := context.Background()
 			got, err := parseTestCases(ctx, tempDir, tc.testNames)
@@ -318,7 +318,7 @@ steps:
 
 			tempDir := t.TempDir()
 
-			abctestutil.WriteAllDefaultMode(t, tempDir, tc.filesContent)
+			abctestutil.WriteAll(t, tempDir, tc.filesContent)
 
 			ctx := context.Background()
 			err := renderTestCase(ctx, tempDir, tempDir, tc.testCase)
@@ -329,7 +329,7 @@ steps:
 				return
 			}
 
-			gotDestContents := abctestutil.LoadDirWithoutMode(t, filepath.Join(tempDir, "testdata/golden/test"))
+			gotDestContents := abctestutil.LoadDir(t, filepath.Join(tempDir, "testdata/golden/test"))
 			if diff := cmp.Diff(gotDestContents, tc.expectedGoldenContent); diff != "" {
 				t.Errorf("dest directory contents were not as expected (-got,+want): %s", diff)
 			}
@@ -577,7 +577,7 @@ steps:
 
 			tempDir := t.TempDir()
 
-			abctestutil.WriteAllDefaultMode(t, tempDir, tc.filesContent)
+			abctestutil.WriteAll(t, tempDir, tc.filesContent)
 
 			ctx := context.Background()
 			err := renderTestCase(ctx, tempDir, tempDir, tc.testCase)
@@ -588,7 +588,7 @@ steps:
 				return
 			}
 
-			gotDestContents := abctestutil.LoadDirWithoutMode(t, filepath.Join(tempDir, "testdata/golden/test"))
+			gotDestContents := abctestutil.LoadDir(t, filepath.Join(tempDir, "testdata/golden/test"))
 			if diff := cmp.Diff(gotDestContents, tc.want); diff != "" {
 				t.Errorf("dest directory contents were not as expected (-got,+want): %s", diff)
 			}
@@ -660,14 +660,14 @@ func TestRenameGitDirsAndFiles(t *testing.T) {
 
 			tempDir := t.TempDir()
 
-			abctestutil.WriteAllDefaultMode(t, tempDir, tc.filesContent)
+			abctestutil.WriteAll(t, tempDir, tc.filesContent)
 
 			err := renameGitDirsAndFiles(tempDir)
 			if diff := testutil.DiffErrString(err, tc.wantErr); diff != "" {
 				t.Fatal(diff)
 			}
 
-			gotDestContents := abctestutil.LoadDirWithoutMode(t, tempDir)
+			gotDestContents := abctestutil.LoadDir(t, tempDir)
 			if diff := cmp.Diff(gotDestContents, tc.want); diff != "" {
 				t.Errorf("dest directory contents were not as expected (-got,+want): %s", diff)
 			}

--- a/templates/commands/goldentest/verify_test.go
+++ b/templates/commands/goldentest/verify_test.go
@@ -389,7 +389,7 @@ kind: 'GoldenTest'`,
 
 			tempDir := t.TempDir()
 
-			abctestutil.WriteAllDefaultMode(t, tempDir, tc.filesContent)
+			abctestutil.WriteAll(t, tempDir, tc.filesContent)
 
 			ctx := logging.WithLogger(context.Background(), logging.TestLogger(t))
 

--- a/templates/commands/render/render_test.go
+++ b/templates/commands/render/render_test.go
@@ -228,7 +228,7 @@ Enter value: `,
 			dest := filepath.Join(tempDir, "dest")
 			sourceDir := filepath.Join(tempDir, "source")
 
-			abctestutil.WriteAllDefaultMode(t, sourceDir, tc.templateContents)
+			abctestutil.WriteAll(t, sourceDir, tc.templateContents)
 
 			ctx := logging.WithLogger(context.Background(), logging.TestLogger(t))
 
@@ -269,7 +269,7 @@ Enter value: `,
 				t.Fatal("timed out waiting for background goroutine to finish")
 			}
 
-			gotDestContents := abctestutil.LoadDirWithoutMode(t, dest)
+			gotDestContents := abctestutil.LoadDir(t, dest)
 			if diff := cmp.Diff(gotDestContents, tc.wantDestContents); diff != "" {
 				t.Errorf("dest directory contents were not as expected (-got,+want): %s", diff)
 			}

--- a/templates/common/dirhash/dirhash_test.go
+++ b/templates/common/dirhash/dirhash_test.go
@@ -55,7 +55,7 @@ func TestHashLatest(t *testing.T) {
 			t.Parallel()
 
 			tempDir := t.TempDir()
-			abctestutil.WriteAllDefaultMode(t, tempDir, tc.files)
+			abctestutil.WriteAll(t, tempDir, tc.files)
 			got, err := HashLatest(filepath.Join(tempDir, tc.subdir))
 			if diff := testutil.DiffErrString(err, tc.wantErr); diff != "" {
 				t.Fatal(diff)
@@ -115,7 +115,7 @@ func TestVerify(t *testing.T) {
 			t.Parallel()
 
 			tempDir := t.TempDir()
-			abctestutil.WriteAllDefaultMode(t, tempDir, tc.files)
+			abctestutil.WriteAll(t, tempDir, tc.files)
 			got, err := Verify(tc.compareToHash, filepath.Join(tempDir, tc.subdir))
 			if diff := testutil.DiffErrString(err, tc.wantErr); diff != "" {
 				t.Fatal(diff)

--- a/templates/common/fs_test.go
+++ b/templates/common/fs_test.go
@@ -412,7 +412,7 @@ func TestCopyRecursive(t *testing.T) {
 			toDir := filepath.Join(tempDir, "to_dir")
 			backupDir := filepath.Join(tempDir, "backups")
 
-			abctestutil.WriteAll(t, fromDir, tc.srcDirContents)
+			abctestutil.WriteAllMode(t, fromDir, tc.srcDirContents)
 
 			from := fromDir
 			to := toDir
@@ -420,7 +420,7 @@ func TestCopyRecursive(t *testing.T) {
 				from = filepath.Join(fromDir, tc.suffix)
 				to = filepath.Join(toDir, tc.suffix)
 			}
-			abctestutil.WriteAll(t, toDir, tc.dstDirInitialContents)
+			abctestutil.WriteAllMode(t, toDir, tc.dstDirInitialContents)
 			fs := &ErrorFS{
 				FS: &RealFS{},
 
@@ -454,12 +454,12 @@ func TestCopyRecursive(t *testing.T) {
 				t.Error(diff)
 			}
 
-			got := abctestutil.LoadDirContents(t, toDir)
+			got := abctestutil.LoadDirMode(t, toDir)
 			if diff := cmp.Diff(got, tc.want, cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("destination directory was not as expected (-got,+want): %s", diff)
 			}
 
-			gotBackups := abctestutil.LoadDirContents(t, backupDir)
+			gotBackups := abctestutil.LoadDirMode(t, backupDir)
 			if diff := cmp.Diff(gotBackups, tc.wantBackups, cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("backups directory was not as expected (-got,+want): %s", diff)
 			}

--- a/templates/common/git/git_test.go
+++ b/templates/common/git/git_test.go
@@ -295,7 +295,7 @@ func TestHeadTags(t *testing.T) {
 			ctx := context.Background()
 
 			tmpDir := t.TempDir()
-			abctestutil.WriteAllDefaultMode(t, tmpDir, tc.files)
+			abctestutil.WriteAll(t, tmpDir, tc.files)
 
 			dir := filepath.Join(tmpDir, tc.dir)
 

--- a/templates/common/render/action_append_test.go
+++ b/templates/common/render/action_append_test.go
@@ -166,7 +166,7 @@ func TestActionAppend(t *testing.T) {
 			t.Parallel()
 
 			scratchDir := t.TempDir()
-			abctestutil.WriteAllDefaultMode(t, scratchDir, tc.initialContents)
+			abctestutil.WriteAll(t, scratchDir, tc.initialContents)
 
 			sr := &spec.Append{
 				Paths: modelStrings(tc.paths),
@@ -194,7 +194,7 @@ func TestActionAppend(t *testing.T) {
 				t.Error(diff)
 			}
 
-			got := abctestutil.LoadDirWithoutMode(t, scratchDir)
+			got := abctestutil.LoadDir(t, scratchDir)
 			if diff := cmp.Diff(got, tc.want); diff != "" {
 				t.Errorf("scratch directory contents were not as expected (-got,+want): %v", diff)
 			}

--- a/templates/common/render/action_gotemplate_test.go
+++ b/templates/common/render/action_gotemplate_test.go
@@ -166,7 +166,7 @@ func TestActionGoTemplate(t *testing.T) {
 			t.Parallel()
 
 			scratchDir := t.TempDir()
-			abctestutil.WriteAllDefaultMode(t, scratchDir, tc.initContents)
+			abctestutil.WriteAll(t, scratchDir, tc.initContents)
 
 			ctx := context.Background()
 			sp := &stepParams{
@@ -181,7 +181,7 @@ func TestActionGoTemplate(t *testing.T) {
 				t.Error(diff)
 			}
 
-			got := abctestutil.LoadDirWithoutMode(t, scratchDir)
+			got := abctestutil.LoadDir(t, scratchDir)
 			if diff := cmp.Diff(got, tc.want); diff != "" {
 				t.Errorf("output differed from expected, (-got,+want): %s", diff)
 			}

--- a/templates/common/render/action_include_test.go
+++ b/templates/common/render/action_include_test.go
@@ -895,10 +895,10 @@ func TestActionInclude(t *testing.T) {
 			scratchDir := filepath.Join(tempDir, tempdir.ScratchDirNamePart)
 			destDir := filepath.Join(tempDir, "dest")
 
-			abctestutil.WriteAll(t, templateDir, tc.templateContents)
+			abctestutil.WriteAllMode(t, templateDir, tc.templateContents)
 
 			// For testing "include from destination"
-			abctestutil.WriteAll(t, destDir, tc.destDirContents)
+			abctestutil.WriteAllMode(t, destDir, tc.destDirContents)
 
 			sp := &stepParams{
 				ignorePatterns: tc.ignorePatterns,
@@ -920,12 +920,12 @@ func TestActionInclude(t *testing.T) {
 				t.Error(diff)
 			}
 
-			gotTemplateContents := abctestutil.LoadDirContents(t, filepath.Join(tempDir, tempdir.TemplateDirNamePart))
+			gotTemplateContents := abctestutil.LoadDirMode(t, filepath.Join(tempDir, tempdir.TemplateDirNamePart))
 			if diff := cmp.Diff(gotTemplateContents, tc.templateContents); diff != "" {
 				t.Errorf("template directory should not have been touched (-got,+want): %s", diff)
 			}
 
-			gotScratchContents := abctestutil.LoadDirContents(t, filepath.Join(tempDir, tempdir.ScratchDirNamePart))
+			gotScratchContents := abctestutil.LoadDirMode(t, filepath.Join(tempDir, tempdir.ScratchDirNamePart))
 			if diff := cmp.Diff(gotScratchContents, tc.wantScratchContents); diff != "" {
 				t.Errorf("scratch directory contents were not as expected (-got,+want): %s", diff)
 			}

--- a/templates/common/render/action_regexnamelookup_test.go
+++ b/templates/common/render/action_regexnamelookup_test.go
@@ -192,7 +192,7 @@ func TestActionRegexNameLookup(t *testing.T) {
 			t.Parallel()
 
 			scratchDir := t.TempDir()
-			abctestutil.WriteAllDefaultMode(t, scratchDir, tc.initContents)
+			abctestutil.WriteAll(t, scratchDir, tc.initContents)
 
 			ctx := context.Background()
 			sp := &stepParams{
@@ -207,7 +207,7 @@ func TestActionRegexNameLookup(t *testing.T) {
 				t.Error(diff)
 			}
 
-			got := abctestutil.LoadDirWithoutMode(t, scratchDir)
+			got := abctestutil.LoadDir(t, scratchDir)
 			if diff := cmp.Diff(got, tc.want); diff != "" {
 				t.Errorf("output differed from expected, (-got,+want): %s", diff)
 			}

--- a/templates/common/render/action_regexreplace_test.go
+++ b/templates/common/render/action_regexreplace_test.go
@@ -399,7 +399,7 @@ gamma`,
 			t.Parallel()
 
 			scratchDir := t.TempDir()
-			abctestutil.WriteAllDefaultMode(t, scratchDir, tc.initContents)
+			abctestutil.WriteAll(t, scratchDir, tc.initContents)
 
 			ctx := context.Background()
 			sp := &stepParams{
@@ -414,7 +414,7 @@ gamma`,
 				t.Error(diff)
 			}
 
-			got := abctestutil.LoadDirWithoutMode(t, scratchDir)
+			got := abctestutil.LoadDir(t, scratchDir)
 			if diff := cmp.Diff(got, tc.want); diff != "" {
 				t.Errorf("output differed from expected, (-got,+want): %s", diff)
 			}

--- a/templates/common/render/action_stringreplace_test.go
+++ b/templates/common/render/action_stringreplace_test.go
@@ -231,7 +231,7 @@ func TestActionStringReplace(t *testing.T) {
 			t.Parallel()
 
 			scratchDir := t.TempDir()
-			abctestutil.WriteAllDefaultMode(t, scratchDir, tc.initialContents)
+			abctestutil.WriteAll(t, scratchDir, tc.initialContents)
 
 			sr := &spec.StringReplace{
 				Paths:        modelStrings(tc.paths),
@@ -252,7 +252,7 @@ func TestActionStringReplace(t *testing.T) {
 				t.Error(diff)
 			}
 
-			got := abctestutil.LoadDirWithoutMode(t, scratchDir)
+			got := abctestutil.LoadDir(t, scratchDir)
 			if diff := cmp.Diff(got, tc.want); diff != "" {
 				t.Errorf("scratch directory contents were not as expected (-got,+want): %v", diff)
 			}

--- a/templates/common/render/action_test.go
+++ b/templates/common/render/action_test.go
@@ -218,7 +218,7 @@ func TestWalkAndModify(t *testing.T) {
 			t.Parallel()
 
 			scratchDir := t.TempDir()
-			abctestutil.WriteAllDefaultMode(t, scratchDir, tc.initialContents)
+			abctestutil.WriteAll(t, scratchDir, tc.initialContents)
 
 			sp := &stepParams{
 				scope:      common.NewScope(nil, nil),
@@ -244,7 +244,7 @@ func TestWalkAndModify(t *testing.T) {
 				t.Error(diff)
 			}
 
-			got := abctestutil.LoadDirWithoutMode(t, scratchDir)
+			got := abctestutil.LoadDir(t, scratchDir)
 			if diff := cmp.Diff(got, tc.want); diff != "" {
 				t.Errorf("scratch directory contents were not as expected (-got,+want): %v", diff)
 			}
@@ -532,7 +532,7 @@ func TestProcessGlobs(t *testing.T) {
 
 			// pre-populate dir contents
 			tempDir := t.TempDir()
-			abctestutil.WriteAll(t, tempDir, tc.dirContents)
+			abctestutil.WriteAllMode(t, tempDir, tc.dirContents)
 			ctx := context.Background()
 
 			gotPaths, err := processGlobs(ctx, tc.paths, tempDir, false) // with globbing enabled

--- a/templates/common/render/manifest_test.go
+++ b/templates/common/render/manifest_test.go
@@ -233,8 +233,8 @@ output_hashes: []
 			templateDir := t.TempDir()
 			destDir := t.TempDir()
 
-			abctestutil.WriteAllDefaultMode(t, templateDir, tc.templateContents)
-			abctestutil.WriteAllDefaultMode(t, destDir, tc.destDirContents)
+			abctestutil.WriteAll(t, templateDir, tc.templateContents)
+			abctestutil.WriteAll(t, destDir, tc.destDirContents)
 
 			err := writeManifest(&writeManifestParams{
 				clock:        clk,
@@ -251,7 +251,7 @@ output_hashes: []
 				t.Fatal(diff)
 			}
 
-			got := abctestutil.LoadDirWithoutMode(t, destDir)
+			got := abctestutil.LoadDir(t, destDir)
 			if diff := cmp.Diff(got, tc.want); diff != "" {
 				t.Errorf("destination directory contents were not as expected (-got,+want): %s", diff)
 			}

--- a/templates/common/render/render_test.go
+++ b/templates/common/render/render_test.go
@@ -1216,18 +1216,18 @@ steps:
 
 			tempDir := t.TempDir()
 			outDir := filepath.Join(tempDir, "out_dir")
-			abctestutil.WriteAllDefaultMode(t, outDir, tc.existingDestContents)
+			abctestutil.WriteAll(t, outDir, tc.existingDestContents)
 
 			inputFilePaths := make([]string, 0, len(tc.inputFileNames))
 			for _, f := range tc.inputFileNames {
 				inputFileDir := filepath.Join(tempDir, "inputs")
-				abctestutil.WriteAllDefaultMode(t, inputFileDir, map[string]string{f: tc.inputFileContents[f]})
+				abctestutil.WriteAll(t, inputFileDir, map[string]string{f: tc.inputFileContents[f]})
 				inputFilePaths = append(inputFilePaths, filepath.Join(inputFileDir, f))
 			}
 
 			backupDir := filepath.Join(tempDir, "backups")
 			sourceDir := filepath.Join(tempDir, "source")
-			abctestutil.WriteAllDefaultMode(t, sourceDir, tc.templateContents)
+			abctestutil.WriteAll(t, sourceDir, tc.templateContents)
 			rfs := &common.RealFS{}
 			stdoutBuf := &strings.Builder{}
 			p := &Params{
@@ -1272,7 +1272,7 @@ steps:
 			var gotTemplateContents map[string]string
 			templateDir, ok := abctestutil.TestMustGlob(t, filepath.Join(tempDir, tempdir.TemplateDirNamePart+"*")) // the * accounts for the random cookie added by mkdirtemp
 			if ok {
-				gotTemplateContents = abctestutil.LoadDirWithoutMode(t, templateDir)
+				gotTemplateContents = abctestutil.LoadDir(t, templateDir)
 			}
 			if diff := cmp.Diff(gotTemplateContents, tc.wantTemplateContents); diff != "" {
 				t.Errorf("template directory contents were not as expected (-got,+want): %s", diff)
@@ -1281,13 +1281,13 @@ steps:
 			var gotScratchContents map[string]string
 			scratchDir, ok := abctestutil.TestMustGlob(t, filepath.Join(tempDir, tempdir.ScratchDirNamePart+"*"))
 			if ok {
-				gotScratchContents = abctestutil.LoadDirWithoutMode(t, scratchDir)
+				gotScratchContents = abctestutil.LoadDir(t, scratchDir)
 			}
 			if diff := cmp.Diff(gotScratchContents, tc.wantScratchContents, cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("scratch directory contents were not as expected (-got,+want): %s", diff)
 			}
 
-			gotDestContents := abctestutil.LoadDirWithoutMode(t, outDir)
+			gotDestContents := abctestutil.LoadDir(t, outDir)
 			if diff := cmp.Diff(gotDestContents, tc.wantDestContents, cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("dest directory contents were not as expected (-got,+want): %s", diff)
 			}
@@ -1295,7 +1295,7 @@ steps:
 			var gotBackupContents map[string]string
 			backupSubdir, ok := abctestutil.TestMustGlob(t, filepath.Join(backupDir, "*")) // When a backup directory is created, an unpredictable timestamp is added, hence the "*"
 			if ok {
-				gotBackupContents = abctestutil.LoadDirWithoutMode(t, backupSubdir)
+				gotBackupContents = abctestutil.LoadDir(t, backupSubdir)
 			}
 			if diff := cmp.Diff(gotBackupContents, tc.wantBackupContents, cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("backups directory contents were not as expected (-got,+want): %s", diff)
@@ -1304,7 +1304,7 @@ steps:
 			var gotDebugContents map[string]string
 			debugDir, ok := abctestutil.TestMustGlob(t, filepath.Join(tempDir, tempdir.DebugStepDiffsDirNamePart+"*"))
 			if ok {
-				gotDebugContents = abctestutil.LoadDirWithoutMode(t, debugDir)
+				gotDebugContents = abctestutil.LoadDir(t, debugDir)
 			}
 			gotDebugDirExists := len(gotDebugContents) > 0
 			if tc.flagDebugStepDiffs != gotDebugDirExists {

--- a/templates/common/templatesource/localsource_test.go
+++ b/templates/common/templatesource/localsource_test.go
@@ -226,7 +226,7 @@ func TestLocalDownloader_Download(t *testing.T) {
 
 			ctx := context.Background()
 			tmp := t.TempDir()
-			abctestutil.WriteAllDefaultMode(t, tmp, tc.initialTempDirContents)
+			abctestutil.WriteAll(t, tmp, tc.initialTempDirContents)
 			dl := &LocalDownloader{
 				SrcPath:            filepath.Join(tmp, tc.copyFromDir),
 				allowDirtyTestOnly: true,
@@ -238,7 +238,7 @@ func TestLocalDownloader_Download(t *testing.T) {
 				t.Fatal(diff)
 			}
 
-			gotTemplateDir := abctestutil.LoadDirWithoutMode(t, templateDir)
+			gotTemplateDir := abctestutil.LoadDir(t, templateDir)
 			if diff := cmp.Diff(gotTemplateDir, tc.wantTemplateDirFiles, cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("template directory contents were not as expected (-got,+want): %s", diff)
 			}

--- a/templates/common/templatesource/remote_git_test.go
+++ b/templates/common/templatesource/remote_git_test.go
@@ -293,7 +293,7 @@ func TestRemoteGitDownloader_Download(t *testing.T) {
 			if diff := testutil.DiffErrString(err, tc.wantErr); diff != "" {
 				t.Fatal(diff)
 			}
-			got := abctestutil.LoadDirWithoutMode(t, tempDir)
+			got := abctestutil.LoadDir(t, tempDir)
 			if diff := cmp.Diff(got, tc.want); diff != "" {
 				t.Errorf("output files were not as expected (-got, +want): %s", diff)
 			}
@@ -450,7 +450,7 @@ func (f *fakeCloner) Clone(ctx context.Context, remote, version, outDir string) 
 		files[".git/refs/tags/"+f.addTag] = abctestutil.MinimalGitHeadSHA
 	}
 
-	abctestutil.WriteAllDefaultMode(f.t, outDir, files)
+	abctestutil.WriteAll(f.t, outDir, files)
 	return nil
 }
 

--- a/templates/common/templatesource/source_test.go
+++ b/templates/common/templatesource/source_test.go
@@ -274,7 +274,7 @@ func TestParseSource(t *testing.T) {
 
 			tempDir := t.TempDir()
 
-			abctestutil.WriteAllDefaultMode(t, tempDir, tc.tempDirContents)
+			abctestutil.WriteAll(t, tempDir, tc.tempDirContents)
 
 			params := &ParseSourceParams{
 				CWD:         tempDir,
@@ -407,7 +407,7 @@ func TestGitCanonicalVersion(t *testing.T) {
 			t.Parallel()
 
 			tmp := t.TempDir()
-			abctestutil.WriteAllDefaultMode(t, tmp, tc.files)
+			abctestutil.WriteAll(t, tmp, tc.files)
 			ctx := context.Background()
 			got, gotOK, err := gitCanonicalVersion(ctx, filepath.Join(tmp, tc.dir), tc.allowDirty)
 			if diff := testutil.DiffErrString(err, tc.wantErr); diff != "" {

--- a/templates/common/templatesource/upgrade_test.go
+++ b/templates/common/templatesource/upgrade_test.go
@@ -149,7 +149,7 @@ func TestForUpgrade(t *testing.T) {
 			ctx := context.Background()
 			tempDir := t.TempDir()
 
-			abctestutil.WriteAllDefaultMode(t, tempDir, tc.dirContents)
+			abctestutil.WriteAll(t, tempDir, tc.dirContents)
 
 			location := tc.canonicalLocation
 

--- a/templates/common/upgrade/upgrade_test.go
+++ b/templates/common/upgrade/upgrade_test.go
@@ -167,7 +167,7 @@ output_hashes:
 			templateDir := filepath.Join(tempBase, "template_dir")
 
 			// Make tempBase into a valid git repo.
-			abctestutil.WriteAllDefaultMode(t, tempBase, abctestutil.WithGitRepoAt("", nil))
+			abctestutil.WriteAll(t, tempBase, abctestutil.WithGitRepoAt("", nil))
 
 			// We don't use UTC time here because we want to make sure local time
 			// gets converted to UTC time before saving.
@@ -180,7 +180,7 @@ output_hashes:
 
 			ctx := context.Background()
 
-			abctestutil.WriteAllDefaultMode(t, templateDir, tc.origTemplateDirContents)
+			abctestutil.WriteAll(t, templateDir, tc.origTemplateDirContents)
 			renderAndVerify(t, ctx, clk, tempBase, templateDir, destDir, tc.wantDestContentsBeforeUpgrade)
 
 			clk.Add(time.Hour) // simulate time passing between initial installation and upgrade
@@ -201,7 +201,7 @@ output_hashes:
 
 			// Now create the "new" template that we'll upgrade to. This is
 			// implemented as a patch over the previous version.
-			abctestutil.WriteAllDefaultMode(t, templateDir, tc.templateChangesForUpgrade)
+			abctestutil.WriteAll(t, templateDir, tc.templateChangesForUpgrade)
 
 			ok, err := Upgrade(ctx, params)
 			if diff := testutil.DiffErrString(err, tc.wantErr); diff != "" {
@@ -212,7 +212,7 @@ output_hashes:
 				t.Errorf("got ok=%t, want %t", ok, tc.wantOK)
 			}
 
-			gotInstalledDirContentsAfter := abctestutil.LoadDirWithoutMode(t, destDir)
+			gotInstalledDirContentsAfter := abctestutil.LoadDir(t, destDir)
 			if diff := cmp.Diff(gotInstalledDirContentsAfter, tc.wantDestContentsAfterUpgrade); diff != "" {
 				t.Errorf("installed directory contents after upgrading were not as expected (-got,+want): %s", diff)
 			}
@@ -245,7 +245,7 @@ func renderAndVerify(tb testing.TB, ctx context.Context, clk clock.Clock, tempBa
 		tb.Fatal(err)
 	}
 
-	got := abctestutil.LoadDirWithoutMode(tb, destDir)
+	got := abctestutil.LoadDir(tb, destDir)
 	if diff := cmp.Diff(got, wantContents); diff != "" {
 		tb.Fatalf("installed directory contents before upgrading were not as expected, there's something wrong with test setup (-got,+want): %s", diff)
 	}

--- a/templates/testutil/fs.go
+++ b/templates/testutil/fs.go
@@ -129,7 +129,7 @@ func LoadDirMode(tb testing.TB, dir string) map[string]ModeAndContents {
 	return out
 }
 
-// Read all the files recursively under "dir", returning their contents as a
+// LoadDir reads all the files recursively under "dir", returning their contents as a
 // map[filename]->contents but without file mode. Returns nil if dir doesn't
 // exist. Keys use slash separators, not native.
 func LoadDir(tb testing.TB, dir string) map[string]string {

--- a/templates/testutil/fs.go
+++ b/templates/testutil/fs.go
@@ -50,8 +50,8 @@ type ModeAndContents struct {
 	Contents string
 }
 
-// WriteAllDefaultMode wraps writeAll and sets file permissions to 0600.
-func WriteAllDefaultMode(tb testing.TB, root string, files map[string]string) {
+// WriteAll wraps writeAll and sets file permissions to 0600.
+func WriteAll(tb testing.TB, root string, files map[string]string) {
 	tb.Helper()
 
 	withMode := map[string]ModeAndContents{}
@@ -61,11 +61,11 @@ func WriteAllDefaultMode(tb testing.TB, root string, files map[string]string) {
 			Contents: contents,
 		}
 	}
-	WriteAll(tb, root, withMode)
+	WriteAllMode(tb, root, withMode)
 }
 
-// WriteAll saves the given file contents with the given permissions.
-func WriteAll(tb testing.TB, root string, files map[string]ModeAndContents) {
+// WriteAllMode saves the given file contents with the given permissions.
+func WriteAllMode(tb testing.TB, root string, files map[string]ModeAndContents) {
 	tb.Helper()
 
 	for path, mc := range files {
@@ -85,10 +85,10 @@ func WriteAll(tb testing.TB, root string, files map[string]ModeAndContents) {
 	}
 }
 
-// LoadDirContents reads all the files recursively under "dir", returning their contents as a
+// LoadDirMode reads all the files recursively under "dir", returning their contents as a
 // map[filename]->contents. Returns nil if dir doesn't exist. Keys use slash separators, not
 // native.
-func LoadDirContents(tb testing.TB, dir string) map[string]ModeAndContents {
+func LoadDirMode(tb testing.TB, dir string) map[string]ModeAndContents {
 	tb.Helper()
 
 	if _, err := os.Stat(dir); err != nil {
@@ -132,10 +132,10 @@ func LoadDirContents(tb testing.TB, dir string) map[string]ModeAndContents {
 // Read all the files recursively under "dir", returning their contents as a
 // map[filename]->contents but without file mode. Returns nil if dir doesn't
 // exist. Keys use slash separators, not native.
-func LoadDirWithoutMode(tb testing.TB, dir string) map[string]string {
+func LoadDir(tb testing.TB, dir string) map[string]string {
 	tb.Helper()
 
-	withMode := LoadDirContents(tb, dir)
+	withMode := LoadDirMode(tb, dir)
 	if withMode == nil {
 		return nil
 	}


### PR DESCRIPTION
These function names were overly long and awkward. WriteAllDefaultMode became very common since it was created, and therefore deserves a shorter, cleaner name. Ditto for Read*.

There are no changes in this PR besides two changed function names and an updated comment.