### PR TITLE
feat: detect previous unmerged files and abort upgrade

### DIFF
--- a/templates/common/upgrade/merge.go
+++ b/templates/common/upgrade/merge.go
@@ -251,11 +251,15 @@ func mergeAll(ctx context.Context, p *commitParams, dryRun bool) error {
 }
 
 const (
+	// These are appended to files that need manual merge conflict resolution.
 	suffixLocallyAdded                  = ".abcmerge_locally_added"
 	suffixLocallyEdited                 = ".abcmerge_locally_edited"
 	suffixFromNewTemplate               = ".abcmerge_from_new_template"
 	suffixFromNewTemplateLocallyDeleted = ".abcmerge_locally_deleted_vs_new_template_version"
 	suffixWantToDelete                  = ".abcmerge_template_wants_to_delete"
+
+	// This is the beginning of  among all the above suffies
+	conflictSuffixBegins = ".abcmerge_"
 )
 
 // TODO return a detailed report of what action was taken?

--- a/templates/common/upgrade/merge.go
+++ b/templates/common/upgrade/merge.go
@@ -258,7 +258,7 @@ const (
 	suffixFromNewTemplateLocallyDeleted = ".abcmerge_locally_deleted_vs_new_template_version"
 	suffixWantToDelete                  = ".abcmerge_template_wants_to_delete"
 
-	// This is the beginning of  among all the above suffies
+	// This is the beginning of all the above suffixes.
 	conflictSuffixBegins = ".abcmerge_"
 )
 

--- a/templates/common/upgrade/upgrade.go
+++ b/templates/common/upgrade/upgrade.go
@@ -102,7 +102,6 @@ type Params struct {
 // Returns true if the upgrade occurred, or false if the upgrade was skipped
 // because we're already on the latest version of the template.
 func Upgrade(ctx context.Context, p *Params) (_ bool, rErr error) {
-	// TODO(upgrade): this function is too long, break it up
 	if !filepath.IsAbs(p.ManifestPath) {
 		return false, fmt.Errorf("internal error: manifest path must be absolute, but got %q", p.ManifestPath)
 	}

--- a/templates/common/upgrade/upgrade.go
+++ b/templates/common/upgrade/upgrade.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -102,6 +103,14 @@ type Params struct {
 // Returns true if the upgrade occurred, or false if the upgrade was skipped
 // because we're already on the latest version of the template.
 func Upgrade(ctx context.Context, p *Params) (_ bool, rErr error) {
+	// For now, manifest files are always located in the .abc directory under
+	// the directory where they were installed.
+	installedDir := filepath.Join(filepath.Dir(p.ManifestPath), "..")
+
+	if err := detectUnmergedConflicts(installedDir); err != nil {
+		return false, err
+	}
+
 	if !filepath.IsAbs(p.ManifestPath) {
 		return false, fmt.Errorf("internal error: manifest path must be absolute, but got %q", p.ManifestPath)
 	}
@@ -113,10 +122,6 @@ func Upgrade(ctx context.Context, p *Params) (_ bool, rErr error) {
 
 	tempTracker := tempdir.NewDirTracker(p.FS, p.KeepTempDirs)
 	defer tempTracker.DeferMaybeRemoveAll(ctx, &rErr)
-
-	// For now, manifest files are always located in the .abc directory under
-	// the directory where they were installed.
-	installedDir := filepath.Join(filepath.Dir(p.ManifestPath), "..")
 
 	downloader, err := templatesource.ForUpgrade(ctx, &templatesource.ForUpgradeParams{
 		InstalledDir:       installedDir,
@@ -249,9 +254,6 @@ type commitParams struct {
 // commit merges the contents of the merge directory into the installed
 // directory and writes the new manifest.
 func commit(ctx context.Context, p *commitParams, dryRun bool) error {
-	// TODO(upgrade): detect any unresolved conflicts (.abc_merge_* files maybe?) and refuse to
-	//                upgrade if there are any.
-
 	if err := mergeAll(ctx, p, dryRun); err != nil {
 		return err
 	}
@@ -348,4 +350,34 @@ func findManifest(dir string) (string, error) {
 	}
 
 	return filepath.Base(matches[0]), nil
+}
+
+// detectUnmergedConflicts looks for any *.abcmerge_* files in the given directory,
+// which would indicate that a previous upgrade operation had some unresolved
+// merge conflicts.
+func detectUnmergedConflicts(installedDir string) error {
+	var unmergedFiles []string
+	if err := filepath.WalkDir(installedDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		relPath, err := filepath.Rel(installedDir, path)
+		if err != nil {
+			return fmt.Errorf("filepath.Rel: %w", err)
+		}
+		if relPath == common.ABCInternalDir && d.IsDir() {
+			return fs.SkipDir
+		}
+		if strings.Contains(path, conflictSuffixBegins) {
+			unmergedFiles = append(unmergedFiles, path)
+		}
+		return nil
+	}); err != nil {
+		return fmt.Errorf("failed crawling directory %q looking for unmerged files: %w", installedDir, err)
+	}
+
+	if len(unmergedFiles) > 0 {
+		return fmt.Errorf("aborting the upgrade because it looks like there's already an upgrade in progress. These files need to be resolved: %v", unmergedFiles)
+	}
+	return nil
 }

--- a/templates/common/upgrade/upgrade_test.go
+++ b/templates/common/upgrade/upgrade_test.go
@@ -576,6 +576,7 @@ steps:
 				"out.txt":   "foo",
 			},
 			localEdits: func(tb testing.TB, installedDir string) {
+				tb.Helper()
 				newFile := filepath.Join(installedDir, "foo.abcmerge_locally_added")
 				contents := []byte("whatever")
 				if err := os.WriteFile(newFile, contents, common.OwnerRWPerms); err != nil {


### PR DESCRIPTION
This is similar to how git won't let you proceed until you resolve merge conflicts. When an upgrade operation begins, we look for any `*.abcmerge_*` files that would indicate that there was a previous upgrade operation that still needs to be manually resolved. If we were to ignore this and upgrade anyway, the user would likely be incredibly confused, and that would be bad.