### PR TITLE
Always allow un-clean git workspaces

### DIFF
--- a/templates/commands/upgrade/upgrade.go
+++ b/templates/commands/upgrade/upgrade.go
@@ -151,14 +151,15 @@ func (c *Command) Run(ctx context.Context, args []string) error {
 	//  - suggest diff / meld / vim commands?
 	fmt.Fprint(c.Stdout(), mergeInstructions+"\n\n")
 	for _, cf := range r.Conflicts {
-		fmt.Fprintf(c.Stdout(), "file %s: conflict type %s: ", cf.Path, cf.Action)
+		fmt.Fprintf(c.Stdout(), "file: %s\n", cf.Path)
+		fmt.Fprintf(c.Stdout(), "conflict type: %s\n", cf.Action)
 		if cf.OursPath != "" {
-			fmt.Fprintf(c.Stdout(), "ours: %s", cf.OursPath)
+			fmt.Fprintf(c.Stdout(), "  our file was renamed to: %s\n", cf.OursPath)
 		}
 		if cf.IncomingTemplatePath != "" {
-			fmt.Fprintf(c.Stdout(), "new template version: %s", cf.IncomingTemplatePath)
+			fmt.Fprintf(c.Stdout(), "  incoming file: %s\n", cf.IncomingTemplatePath)
 		}
-		fmt.Fprintf(c.Stdout(), "\n")
+		fmt.Fprintf(c.Stdout(), "--\n")
 	}
 
 	return nil

--- a/templates/common/templatesource/git.go
+++ b/templates/common/templatesource/git.go
@@ -21,7 +21,6 @@ import (
 	"github.com/Masterminds/semver/v3"
 
 	"github.com/abcxyz/abc/templates/common/git"
-	"github.com/abcxyz/pkg/logging"
 )
 
 const (
@@ -37,35 +36,17 @@ const (
 //   - other non-semver tags in reverse alphabetical order
 //   - the HEAD SHA
 //
-// It returns false if:
-//
-//   - the given directory is not in a git workspace
-//   - the git workspace is not clean (uncommitted changes) (for testing, you
-//     can provide allowDirty=true to override this)
+// It returns false if the given directory is not in a git workspace.
 //
 // It returns error only if something weird happened when running git commands.
 // The returned string is always empty if the boolean is false.
-func gitCanonicalVersion(ctx context.Context, dir string, allowDirty bool) (string, bool, error) {
-	logger := logging.FromContext(ctx).With("logger", "CanonicalVersion")
-
+func gitCanonicalVersion(ctx context.Context, dir string) (string, bool, error) {
 	_, ok, err := git.Workspace(ctx, dir)
 	if err != nil {
 		return "", false, err //nolint:wrapcheck
 	}
 	if !ok {
 		return "", false, nil
-	}
-
-	if !allowDirty {
-		ok, err = git.IsClean(ctx, dir)
-		if err != nil {
-			return "", false, err //nolint:wrapcheck
-		}
-		if !ok {
-			logger.WarnContext(ctx, "omitting template git version from manifest because the workspace is dirty",
-				"source_git_workspace", dir)
-			return "", false, nil
-		}
 	}
 
 	tag, ok, err := bestHeadTag(ctx, dir)

--- a/templates/common/templatesource/localsource.go
+++ b/templates/common/templatesource/localsource.go
@@ -69,8 +69,7 @@ func (l *localSourceParser) sourceParse(ctx context.Context, params *ParseSource
 	logger.InfoContext(ctx, "treating src as a local path", "src", absSource)
 
 	return &LocalDownloader{
-		SrcPath:            absSource,
-		allowDirtyTestOnly: params.AllowDirtyTestOnly,
+		SrcPath: absSource,
 	}, true, nil
 }
 
@@ -78,10 +77,6 @@ func (l *localSourceParser) sourceParse(ctx context.Context, params *ParseSource
 type LocalDownloader struct {
 	// This path uses the OS-native file separator and is an absolute path.
 	SrcPath string
-
-	// It's too hard in tests to generate a clean git repo, so we provide
-	// this option to just ignore the fact that the git repo is dirty.
-	allowDirtyTestOnly bool
 }
 
 // installedDir is only used to check for canonical-ness.
@@ -104,7 +99,7 @@ func (l *LocalDownloader) Download(ctx context.Context, cwd, templateDir, destDi
 	if err != nil {
 		return nil, err
 	}
-	canonicalSource, version, locType, err := canonicalize(ctx, cwd, l.SrcPath, destDir, l.allowDirtyTestOnly)
+	canonicalSource, version, locType, err := canonicalize(ctx, cwd, l.SrcPath, destDir)
 	if err != nil {
 		return nil, err
 	}
@@ -123,7 +118,7 @@ func (l *LocalDownloader) Download(ctx context.Context, cwd, templateDir, destDi
 // directories qualify as a canonical source, and if so, returns the
 // canonicalized version of the source. See the docs on DownloadMetadata for an
 // explanation of canonical sources.
-func canonicalize(ctx context.Context, cwd, source, destDir string, allowDirty bool) (canonicalSource, version, locType string, _ error) {
+func canonicalize(ctx context.Context, cwd, source, destDir string) (canonicalSource, version, locType string, _ error) {
 	logger := logging.FromContext(ctx).With("logger", "canonicalize")
 
 	absSource := common.JoinIfRelative(cwd, source)
@@ -157,7 +152,7 @@ func canonicalize(ctx context.Context, cwd, source, destDir string, allowDirty b
 		return "", "", "", fmt.Errorf("filepath.Rel(%q,%q): %w", absDestDir, absSource, err)
 	}
 
-	version, _, err = gitCanonicalVersion(ctx, sourceGitWorkspace, allowDirty)
+	version, _, err = gitCanonicalVersion(ctx, sourceGitWorkspace)
 	if err != nil {
 		return "", "", "", err
 	}

--- a/templates/common/templatesource/localsource_test.go
+++ b/templates/common/templatesource/localsource_test.go
@@ -228,8 +228,7 @@ func TestLocalDownloader_Download(t *testing.T) {
 			tmp := t.TempDir()
 			abctestutil.WriteAll(t, tmp, tc.initialTempDirContents)
 			dl := &LocalDownloader{
-				SrcPath:            filepath.Join(tmp, tc.copyFromDir),
-				allowDirtyTestOnly: true,
+				SrcPath: filepath.Join(tmp, tc.copyFromDir),
 			}
 			dest := filepath.Join(tmp, tc.destDirForCanonicalCheck)
 			templateDir := t.TempDir()

--- a/templates/common/templatesource/remote_git.go
+++ b/templates/common/templatesource/remote_git.go
@@ -132,10 +132,6 @@ type remoteGitDownloader struct {
 
 	cloner cloner
 	tagser tagser
-
-	// It's too hard in tests to generate a clean git repo, so we provide
-	// this option to just ignore the fact that the git repo is dirty.
-	allowDirty bool
 }
 
 // Download implements Downloader.
@@ -209,7 +205,7 @@ func (g *remoteGitDownloader) Download(ctx context.Context, _, templateDir, _ st
 	//   - The user may have specified a branch name, but we don't allow branches
 	//     to be used as template versions in manifests because they change
 	//     frequently.
-	canonicalVersion, ok, err := gitCanonicalVersion(ctx, tmpDir, g.allowDirty)
+	canonicalVersion, ok, err := gitCanonicalVersion(ctx, tmpDir)
 	if err != nil {
 		return nil, err
 	}

--- a/templates/common/templatesource/remote_git_test.go
+++ b/templates/common/templatesource/remote_git_test.go
@@ -43,7 +43,6 @@ func TestRemoteGitDownloader_Download(t *testing.T) {
 		{
 			name: "no_subdir",
 			dl: &remoteGitDownloader{
-				allowDirty:      true,
 				canonicalSource: "mysource",
 				remote:          "fake-remote",
 				subdir:          "",
@@ -73,7 +72,6 @@ func TestRemoteGitDownloader_Download(t *testing.T) {
 		{
 			name: "latest_version_lookup",
 			dl: &remoteGitDownloader{
-				allowDirty:      true,
 				canonicalSource: "mysource",
 				remote:          "fake-remote",
 				subdir:          "",
@@ -111,7 +109,6 @@ func TestRemoteGitDownloader_Download(t *testing.T) {
 		{
 			name: "with_subdir",
 			dl: &remoteGitDownloader{
-				allowDirty:      true,
 				canonicalSource: "mysource",
 				remote:          "fake-remote",
 				subdir:          "my-subdir",
@@ -146,7 +143,6 @@ func TestRemoteGitDownloader_Download(t *testing.T) {
 		{
 			name: "with_deep_subdir",
 			dl: &remoteGitDownloader{
-				allowDirty:      true,
 				canonicalSource: "mysource",
 				remote:          "fake-remote",
 				subdir:          "my/deep",
@@ -223,7 +219,6 @@ func TestRemoteGitDownloader_Download(t *testing.T) {
 		{
 			name: "clone_by_sha",
 			dl: &remoteGitDownloader{
-				allowDirty:      true,
 				canonicalSource: "mysource",
 				remote:          "fake-remote",
 				subdir:          "",
@@ -252,7 +247,6 @@ func TestRemoteGitDownloader_Download(t *testing.T) {
 		{
 			name: "clone_by_sha_with_detected_tag",
 			dl: &remoteGitDownloader{
-				allowDirty:      true,
 				canonicalSource: "mysource",
 				remote:          "fake-remote",
 				subdir:          "",

--- a/templates/common/templatesource/source.go
+++ b/templates/common/templatesource/source.go
@@ -81,12 +81,6 @@ var realSourceParsers = []sourceParser{
 
 // ParseSourceParams contains the arguments to ParseSource.
 type ParseSourceParams struct {
-	// Normally, when determining if a template location is canonical, any
-	// directory that has uncommitted git changes is not canonical. However,
-	// for testing purposes we sometimes bypass this check and allow dirty git
-	// workspaces to be treated as canonical.
-	AllowDirtyTestOnly bool
-
 	// The working directory that we're in. Used to resolve relative paths.
 	CWD string
 

--- a/templates/common/templatesource/source_test.go
+++ b/templates/common/templatesource/source_test.go
@@ -309,12 +309,11 @@ func TestGitCanonicalVersion(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		name       string
-		dir        string
-		allowDirty bool
-		files      map[string]string
-		want       string
-		wantErr    string
+		name    string
+		dir     string
+		files   map[string]string
+		want    string
+		wantErr string
 	}{
 		{
 			name:  "simple_success_no_tag",
@@ -382,17 +381,8 @@ func TestGitCanonicalVersion(t *testing.T) {
 			files: nil,
 		},
 		{
-			name:       "dirty_workspace_not_allowed",
-			dir:        ".",
-			allowDirty: false,
-			files: abctestutil.WithGitRepoAt("", map[string]string{
-				"my_file.txt": "my contents",
-			}),
-		},
-		{
-			name:       "dirty_workspace_allowed",
-			dir:        ".",
-			allowDirty: true,
+			name: "dirty_workspace_allowed",
+			dir:  ".",
 			files: abctestutil.WithGitRepoAt("", map[string]string{
 				"my_file.txt": "my contents",
 			}),
@@ -409,7 +399,7 @@ func TestGitCanonicalVersion(t *testing.T) {
 			tmp := t.TempDir()
 			abctestutil.WriteAll(t, tmp, tc.files)
 			ctx := context.Background()
-			got, gotOK, err := gitCanonicalVersion(ctx, filepath.Join(tmp, tc.dir), tc.allowDirty)
+			got, gotOK, err := gitCanonicalVersion(ctx, filepath.Join(tmp, tc.dir))
 			if diff := testutil.DiffErrString(err, tc.wantErr); diff != "" {
 				t.Error(diff)
 			}

--- a/templates/common/templatesource/upgrade.go
+++ b/templates/common/templatesource/upgrade.go
@@ -75,12 +75,6 @@ type ForUpgradeParams struct {
 
 	// The value of --git-protocol.
 	GitProtocol string
-
-	// Normally, when determining if a template location is canonical, any
-	// directory that has uncommitted git changes is not canonical. However,
-	// for testing purposes we sometimes bypass this check and allow dirty git
-	// workspaces to be treated as canonical.
-	AllowDirtyTestOnly bool
 }
 
 func remoteGitUpgradeDownloaderFactory(ctx context.Context, f *ForUpgradeParams) (Downloader, error) {
@@ -134,7 +128,6 @@ func localGitUpgradeDownloaderFactory(ctx context.Context, f *ForUpgradeParams) 
 	}
 
 	return &LocalDownloader{
-		SrcPath:            absSrcPath,
-		allowDirtyTestOnly: f.AllowDirtyTestOnly,
+		SrcPath: absSrcPath,
 	}, nil
 }

--- a/templates/common/upgrade/upgrade.go
+++ b/templates/common/upgrade/upgrade.go
@@ -105,10 +105,6 @@ type Params struct {
 
 	// Empty string, except in tests. Will be used as the parent of temp dirs.
 	TempDirBase string
-
-	// For testing, allow template directories in dirty git workspaces to be
-	// treated as canonical.
-	AllowDirtyTestOnly bool
 }
 
 type Result struct {
@@ -197,11 +193,10 @@ func Upgrade(ctx context.Context, p *Params) (_ Result, rErr error) {
 	defer tempTracker.DeferMaybeRemoveAll(ctx, &rErr)
 
 	downloader, err := templatesource.ForUpgrade(ctx, &templatesource.ForUpgradeParams{
-		InstalledDir:       installedDir,
-		CanonicalLocation:  oldManifest.TemplateLocation.Val,
-		LocType:            oldManifest.LocationType.Val,
-		GitProtocol:        p.GitProtocol,
-		AllowDirtyTestOnly: p.AllowDirtyTestOnly,
+		InstalledDir:      installedDir,
+		CanonicalLocation: oldManifest.TemplateLocation.Val,
+		LocType:           oldManifest.LocationType.Val,
+		GitProtocol:       p.GitProtocol,
 	})
 	if err != nil {
 		return Result{}, fmt.Errorf("failed creating downloader for manifest location %q of type %q with git protocol %q: %w",

--- a/templates/common/upgrade/upgrade_test.go
+++ b/templates/common/upgrade/upgrade_test.go
@@ -708,12 +708,11 @@ steps:
 			clk.Set(afterUpgradeTime) // simulate time passing between initial installation and upgrade
 
 			params := &Params{
-				Clock:              clk,
-				CWD:                destDir,
-				FS:                 &common.RealFS{},
-				ManifestPath:       manifestFullPath,
-				Stdout:             os.Stdout,
-				AllowDirtyTestOnly: true,
+				Clock:        clk,
+				CWD:          destDir,
+				FS:           &common.RealFS{},
+				ManifestPath: manifestFullPath,
+				Stdout:       os.Stdout,
 			}
 
 			if tc.localEdits != nil {
@@ -797,9 +796,8 @@ func renderAndVerify(tb testing.TB, ctx context.Context, clk clock.Clock, tempBa
 	tb.Helper()
 
 	downloader, err := templatesource.ParseSource(ctx, &templatesource.ParseSourceParams{
-		AllowDirtyTestOnly: true,
-		CWD:                tempBase,
-		Source:             templateDir,
+		CWD:    tempBase,
+		Source: templateDir,
 	})
 	if err != nil {
 		tb.Fatal(err)


### PR DESCRIPTION
Originally, I wanted to avoid saying "this template was installed from SHA x" in the case where the git workspace had pending changes. The pending changes might have been significant to the template output, meaning that we weren't really installing that version of the template.  

Now, I've given up on that. We will very often be installing from a dirty workspace, such as when multiple templates are upgraded at once, and the template directory is in the same repo as the output dir (like in terraform GCP org repos). So we'll just keep it simple and accept a little risk of confusion.
