### PR TITLE
Fix "impossible condition" warning

### DIFF
--- a/templates/common/render/action.go
+++ b/templates/common/render/action.go
@@ -140,7 +140,9 @@ func processGlobs(ctx context.Context, paths []model.String, fromDir string, ski
 	out := make([]model.String, 0, len(paths))
 
 	for _, p := range paths {
-		// This supports older api_versions which didn't have glob support.
+		// This supports older api_versions which didn't have glob support. When
+		// not globbing, we don't try to determine whether the file exists or
+		// not. That's a job for a later phase.
 		if skipGlobs {
 			out = append(out, model.String{
 				Val: filepath.Join(fromDir, p.Val),

--- a/templates/common/render/action_test.go
+++ b/templates/common/render/action_test.go
@@ -385,12 +385,12 @@ func TestProcessGlobs(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		name           string
-		dirContents    map[string]abctestutil.ModeAndContents
-		paths          []model.String
-		wantPaths      []model.String
-		wantGlobErr    string
-		wantNonGlobErr string
+		name        string
+		dirContents map[string]abctestutil.ModeAndContents
+		paths       []model.String
+		wantPaths   []model.String
+		skipGlobs   bool
+		wantErr     string
 	}{
 		{
 			name: "non_glob_paths",
@@ -504,10 +504,17 @@ func TestProcessGlobs(t *testing.T) {
 			),
 		},
 		{
-			name:           "no_glob_matches",
-			paths:          mdl.Strings("file_not_found.txt"),
-			wantGlobErr:    fmt.Sprintf(`glob %q did not match any files`, "file_not_found.txt"),
-			wantNonGlobErr: fmt.Sprintf(`include path doesn't exist: %q`, "file_not_found.txt"),
+			name:      "no_glob_matches_with_globs",
+			paths:     mdl.Strings("file_not_found.txt"),
+			skipGlobs: false,
+			wantErr:   fmt.Sprintf(`glob %q did not match any files`, "file_not_found.txt"),
+		},
+		{
+			name:      "no_glob_matches_with_skipglobs",
+			paths:     mdl.Strings("file_not_found.txt"),
+			skipGlobs: true,
+			// When not globbing, paths are returned regardless of whether they exist
+			wantPaths: mdl.Strings("file_not_found.txt"),
 		},
 		{
 			name: "character_range_paths",
@@ -530,14 +537,8 @@ func TestProcessGlobs(t *testing.T) {
 			abctestutil.WriteAllMode(t, tempDir, tc.dirContents)
 			ctx := context.Background()
 
-			gotPaths, err := processGlobs(ctx, tc.paths, tempDir, false) // with globbing enabled
-			if diff := testutil.DiffErrString(err, tc.wantGlobErr); diff != "" {
-				t.Error(diff)
-			}
-			if err != nil {
-				return // err was expected as part of the test
-			}
-			if diff := testutil.DiffErrString(err, tc.wantNonGlobErr); diff != "" {
+			gotPaths, err := processGlobs(ctx, tc.paths, tempDir, tc.skipGlobs)
+			if diff := testutil.DiffErrString(err, tc.wantErr); diff != "" {
 				t.Error(diff)
 			}
 			if err != nil {


### PR DESCRIPTION
There was a bug in this test case; the "wanted" error for the case where skipGlobs==true was never actually being tested.

Fixes #508 .