### PR TITLE
fix: include-from-destination bit should be reset on re-include

### DIFF
--- a/templates/common/render/action_include.go
+++ b/templates/common/render/action_include.go
@@ -99,7 +99,7 @@ func copyToDst(ctx context.Context, sp *stepParams, skipPaths []model.String, po
 					//     (indicating an intent to modify a preexisting file in
 					//     place).
 					//  2. The same path is `include`d normally (not with
-					//     from==destination. This represents a completely
+					//     from==destination). This represents a completely
 					//     separate file that comes from the template dir and
 					//     not from the dest dir.
 					//  3. The second include should completely replace the

--- a/templates/common/render/action_include.go
+++ b/templates/common/render/action_include.go
@@ -90,8 +90,24 @@ func copyToDst(ctx context.Context, sp *stepParams, skipPaths []model.String, po
 					Skip: true,
 				}, nil
 			}
-			if !de.IsDir() && fromVal == "destination" {
-				sp.includedFromDest = append(sp.includedFromDest, relToFromDir)
+			if !de.IsDir() {
+				if fromVal == "destination" {
+					sp.includedFromDest[relToFromDir] = struct{}{}
+				} else {
+					// Edge case: suppose this sequence of events occurs:
+					//  1. A given path is `include`d with from==destination
+					//     (indicating an intent to modify a preexisting file in
+					//     place).
+					//  2. The same path is `include`d normally (not with
+					//     from==destination. This represents a completely
+					//     separate file that comes from the template dir and
+					//     not from the dest dir.
+					//  3. The second include should completely replace the
+					//     first. In the metadata that tracks whether the file
+					//     was included from destination, we should delete the
+					//     record of this path being included from destination.
+					delete(sp.includedFromDest, relToFromDir)
+				}
 			}
 
 			return common.CopyHint{

--- a/templates/common/render/action_include_test.go
+++ b/templates/common/render/action_include_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/abcxyz/abc/templates/common"
 	"github.com/abcxyz/abc/templates/common/tempdir"
@@ -43,7 +44,7 @@ func TestActionInclude(t *testing.T) {
 		inputs               map[string]string
 		ignorePatterns       []model.String
 		wantScratchContents  map[string]abctestutil.ModeAndContents
-		wantIncludedFromDest []string
+		wantIncludedFromDest map[string]struct{}
 		statErr              error
 		wantErr              string
 	}{
@@ -642,7 +643,7 @@ func TestActionInclude(t *testing.T) {
 			wantScratchContents: map[string]abctestutil.ModeAndContents{
 				"file1.txt": {Mode: 0o600, Contents: "file1 contents"},
 			},
-			wantIncludedFromDest: []string{"file1.txt"},
+			wantIncludedFromDest: map[string]struct{}{"file1.txt": {}},
 		},
 		{
 			name: "include_subdir_from_destination",
@@ -665,7 +666,7 @@ func TestActionInclude(t *testing.T) {
 			wantScratchContents: map[string]abctestutil.ModeAndContents{
 				"subdir/file2.txt": {Mode: 0o600, Contents: "file2 contents"},
 			},
-			wantIncludedFromDest: []string{"subdir/file2.txt"},
+			wantIncludedFromDest: map[string]struct{}{"subdir/file2.txt": {}},
 		},
 		{
 			name: "include_glob_from_destination",
@@ -690,9 +691,9 @@ func TestActionInclude(t *testing.T) {
 				"file1.txt": {Mode: 0o600, Contents: "file1 contents"},
 				"file2.txt": {Mode: 0o600, Contents: "file1 contents"},
 			},
-			wantIncludedFromDest: []string{
-				"file1.txt",
-				"file2.txt",
+			wantIncludedFromDest: map[string]struct{}{
+				"file1.txt": {},
+				"file2.txt": {},
 			},
 		},
 		{
@@ -717,7 +718,10 @@ func TestActionInclude(t *testing.T) {
 				"file1.txt":        {Mode: 0o600, Contents: "file1 contents"},
 				"subdir/file2.txt": {Mode: 0o600, Contents: "file2 contents"},
 			},
-			wantIncludedFromDest: []string{"file1.txt", "subdir/file2.txt"},
+			wantIncludedFromDest: map[string]struct{}{
+				"file1.txt":        {},
+				"subdir/file2.txt": {},
+			},
 		},
 		{
 			name: "skip_paths_with_custom_ignore",
@@ -756,7 +760,7 @@ func TestActionInclude(t *testing.T) {
 				"folder1/folder3/file3.txt": {Mode: 0o600, Contents: "file 3 contents"},
 				"file2.txt":                 {Mode: 0o600, Contents: "file2 contents"},
 			},
-			wantIncludedFromDest: []string{"file2.txt"},
+			wantIncludedFromDest: map[string]struct{}{"file2.txt": {}},
 		},
 		{
 			name: "skip_paths_with_custom_ignore_glob",
@@ -796,7 +800,7 @@ func TestActionInclude(t *testing.T) {
 				"folder1/folder3/file3.txt": {Mode: 0o600, Contents: "file 3 contents"},
 				"file2.txt":                 {Mode: 0o600, Contents: "file2 contents"},
 			},
-			wantIncludedFromDest: []string{"file2.txt"},
+			wantIncludedFromDest: map[string]struct{}{"file2.txt": {}},
 		},
 		{
 			name: "skip_paths_with_custom_ignore_leading_slash",
@@ -844,12 +848,12 @@ func TestActionInclude(t *testing.T) {
 				"folder1/folder3/file3.txt":              {Mode: 0o600, Contents: "file 3 contents"},
 				"file2.txt":                              {Mode: 0o600, Contents: "file2 contents"},
 			},
-			wantIncludedFromDest: []string{
-				"dest_folder1/file1.txt",
-				"dest_folder1/folder0/file0.txt",
-				"dest_folder1/folder1/file1.txt",
-				"dest_folder1/folder1/folder0/file0.txt",
-				"file2.txt",
+			wantIncludedFromDest: map[string]struct{}{
+				"dest_folder1/file1.txt":                 {},
+				"dest_folder1/folder0/file0.txt":         {},
+				"dest_folder1/folder1/file1.txt":         {},
+				"dest_folder1/folder1/folder0/file0.txt": {},
+				"file2.txt":                              {},
 			},
 		},
 		{
@@ -879,7 +883,31 @@ func TestActionInclude(t *testing.T) {
 				"folder1/file1.txt": {Mode: 0o600, Contents: "file 1 contents"},
 				"file1.txt":         {Mode: 0o600, Contents: "file1 contents"},
 			},
-			wantIncludedFromDest: []string{"file1.txt"},
+			wantIncludedFromDest: map[string]struct{}{"file1.txt": {}},
+		},
+		{
+			name: "include_from_dest_forgotten_on_reinclude",
+			include: &spec.Include{
+				Paths: []*spec.IncludePath{
+					{
+						Paths: mdl.Strings("."),
+						From:  mdl.S("destination"),
+					},
+					{
+						Paths: mdl.Strings("."),
+					},
+				},
+			},
+			templateContents: map[string]abctestutil.ModeAndContents{
+				"file1.txt": {Mode: 0o600, Contents: "file 1 template contents"},
+			},
+			destDirContents: map[string]abctestutil.ModeAndContents{
+				"file1.txt": {Mode: 0o600, Contents: "file 1 dest contents"},
+			},
+			wantScratchContents: map[string]abctestutil.ModeAndContents{
+				"file1.txt": {Mode: 0o600, Contents: "file 1 template contents"},
+			},
+			wantIncludedFromDest: map[string]struct{}{},
 		},
 	}
 
@@ -902,10 +930,11 @@ func TestActionInclude(t *testing.T) {
 			abctestutil.WriteAllMode(t, destDir, tc.destDirContents)
 
 			sp := &stepParams{
-				ignorePatterns: tc.ignorePatterns,
-				scope:          common.NewScope(tc.inputs, nil),
-				scratchDir:     scratchDir,
-				templateDir:    templateDir,
+				ignorePatterns:   tc.ignorePatterns,
+				includedFromDest: make(map[string]struct{}),
+				scope:            common.NewScope(tc.inputs, nil),
+				scratchDir:       scratchDir,
+				templateDir:      templateDir,
 				rp: &Params{
 					OutDir: destDir,
 
@@ -931,7 +960,7 @@ func TestActionInclude(t *testing.T) {
 				t.Errorf("scratch directory contents were not as expected (-got,+want): %s", diff)
 			}
 
-			if diff := cmp.Diff(sp.includedFromDest, tc.wantIncludedFromDest); diff != "" {
+			if diff := cmp.Diff(sp.includedFromDest, tc.wantIncludedFromDest, cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("includedFromDest was not as expected (-got,+want): %s", diff)
 			}
 		})

--- a/templates/common/render/action_test.go
+++ b/templates/common/render/action_test.go
@@ -222,8 +222,9 @@ func TestWalkAndModify(t *testing.T) {
 			abctestutil.WriteAll(t, scratchDir, tc.initialContents)
 
 			sp := &stepParams{
-				scope:      common.NewScope(nil, nil),
-				scratchDir: scratchDir,
+				scope:            common.NewScope(nil, nil),
+				scratchDir:       scratchDir,
+				includedFromDest: make(map[string]struct{}),
 				rp: &Params{
 					FS: &common.ErrorFS{
 						FS:           &common.RealFS{},

--- a/templates/common/render/render.go
+++ b/templates/common/render/render.go
@@ -222,14 +222,15 @@ func RenderAlreadyDownloaded(ctx context.Context, dlMeta *templatesource.Downloa
 	}
 
 	sp := &stepParams{
-		debugDiffsDir:  debugStepDiffsDir,
-		ignorePatterns: spec.Ignore,
-		extraPrintVars: extraPrintVars,
-		features:       spec.Features,
-		rp:             p,
-		scope:          scope,
-		scratchDir:     scratchDir,
-		templateDir:    templateDir,
+		debugDiffsDir:    debugStepDiffsDir,
+		ignorePatterns:   spec.Ignore,
+		includedFromDest: make(map[string]struct{}),
+		extraPrintVars:   extraPrintVars,
+		features:         spec.Features,
+		rp:               p,
+		scope:            scope,
+		scratchDir:       scratchDir,
+		templateDir:      templateDir,
 	}
 
 	logger.DebugContext(ctx, "executing template steps")
@@ -241,7 +242,7 @@ func RenderAlreadyDownloaded(ctx context.Context, dlMeta *templatesource.Downloa
 	logger.DebugContext(ctx, "committing rendered output")
 	if err := commitTentatively(ctx, p, &commitParams{
 		dlMeta:           dlMeta,
-		includedFromDest: sliceToSet(sp.includedFromDest),
+		includedFromDest: sp.includedFromDest,
 		inputs:           resolvedInputs,
 		scratchDir:       scratchDir,
 		templateDir:      templateDir,
@@ -392,7 +393,7 @@ type stepParams struct {
 	// These are paths relative to the --dest directory (which is the same thing
 	// as being relative to the scratch directory, the paths within these dirs
 	// are the same).
-	includedFromDest []string
+	includedFromDest map[string]struct{}
 
 	// scope contains all variable names that are in scope. This includes
 	// user-provided scope, as well as any programmatically created variables
@@ -642,12 +643,4 @@ func commit(ctx context.Context, dryRun bool, p *Params, scratchDir string, incl
 		logger.InfoContext(ctx, "template render succeeded")
 	}
 	return params.OutHashes, nil
-}
-
-func sliceToSet[T comparable](vals []T) map[T]struct{} {
-	out := make(map[T]struct{}, len(vals))
-	for _, v := range vals {
-		out[v] = struct{}{}
-	}
-	return out
 }


### PR DESCRIPTION
There was a bug here that we haven't actually hit, but could be important for the template upgrade logic that will build on top of this. The bug could cause files to be considered "included from destination" even when they're not. The bug arises when the same path is included multiple times with a mix of regular include and "include from destination."

The fix is just to reset the state for "included from destination" when a path is re-included.