### PR TITLE
Move the exec-wrapper Run* functions into their own package

### DIFF
--- a/templates/commands/goldentest/verify.go
+++ b/templates/commands/goldentest/verify.go
@@ -31,6 +31,7 @@ import (
 	"github.com/mattn/go-isatty"
 
 	"github.com/abcxyz/abc/templates/common"
+	"github.com/abcxyz/abc/templates/common/run"
 	"github.com/abcxyz/abc/templates/common/tempdir"
 	"github.com/abcxyz/pkg/cli"
 )
@@ -281,7 +282,7 @@ func execDiff(ctx context.Context, color bool, file1, file2 string) (string, err
 		args = append(args, "--color=always")
 	}
 	args = append(args, file1, file2)
-	stdout, stderr, exitCode, err := common.RunAllowNonzero(ctx, args...)
+	stdout, stderr, exitCode, err := run.RunAllowNonzero(ctx, args...)
 	if err != nil {
 		return "", fmt.Errorf("error exec'ing diff: %w", err)
 	}

--- a/templates/common/git/git.go
+++ b/templates/common/git/git.go
@@ -27,6 +27,7 @@ import (
 	"github.com/Masterminds/semver/v3"
 
 	"github.com/abcxyz/abc/templates/common"
+	"github.com/abcxyz/abc/templates/common/run"
 )
 
 var sha = regexp.MustCompile("^[0-9a-f]{40}$")
@@ -40,17 +41,17 @@ var sha = regexp.MustCompile("^[0-9a-f]{40}$")
 // https://github.com/abcxyz/abc.git or git@github.com:abcxyz/abc.git .
 func Clone(ctx context.Context, remote, version, outDir string) error {
 	if sha.MatchString(version) {
-		_, _, err := common.Run(ctx, "git", "clone", remote, outDir)
+		_, _, err := run.Run(ctx, "git", "clone", remote, outDir)
 		if err != nil {
 			return err //nolint:wrapcheck
 		}
 
-		_, _, err = common.Run(ctx, "git", "-C", outDir, "reset", "--hard", version)
+		_, _, err = run.Run(ctx, "git", "-C", outDir, "reset", "--hard", version)
 		if err != nil {
 			return err //nolint:wrapcheck
 		}
 	} else {
-		_, _, err := common.Run(ctx, "git", "clone", "--depth", "1", "--branch", version, remote, outDir)
+		_, _, err := run.Run(ctx, "git", "clone", "--depth", "1", "--branch", version, remote, outDir)
 		if err != nil {
 			return err //nolint:wrapcheck
 		}
@@ -103,7 +104,7 @@ func findSymlinks(dir string) ([]string, error) {
 // "remote" may be any format accepted by git, such as
 // https://github.com/abcxyz/abc.git or git@github.com:abcxyz/abc.git .
 func RemoteTags(ctx context.Context, remote string) ([]string, error) {
-	stdout, _, err := common.Run(ctx, "git", "ls-remote", "--tags", remote)
+	stdout, _, err := run.Run(ctx, "git", "ls-remote", "--tags", remote)
 	if err != nil {
 		return nil, err //nolint:wrapcheck
 	}
@@ -173,7 +174,7 @@ func IsClean(ctx context.Context, dir string) (bool, error) {
 	// promises stable output, so it's good enough.
 	// https://stackoverflow.com/a/2658301
 	args := []string{"git", "-C", dir, "status", "--porcelain"}
-	stdout, _, err := common.Run(ctx, args...)
+	stdout, _, err := run.Run(ctx, args...)
 	if err != nil {
 		return false, err //nolint:wrapcheck
 	}
@@ -185,7 +186,7 @@ func IsClean(ctx context.Context, dir string) (bool, error) {
 // empty slice, this is not an error.
 func HeadTags(ctx context.Context, dir string) ([]string, error) {
 	args := []string{"git", "-C", dir, "for-each-ref", "--points-at", "HEAD", "refs/tags/*"}
-	stdout, _, err := common.Run(ctx, args...)
+	stdout, _, err := run.Run(ctx, args...)
 	if err != nil {
 		return nil, err //nolint:wrapcheck
 	}
@@ -213,7 +214,7 @@ func HeadTags(ctx context.Context, dir string) ([]string, error) {
 // workspace.
 func CurrentSHA(ctx context.Context, dir string) (string, error) {
 	args := []string{"git", "-C", dir, "rev-parse", "HEAD"}
-	stdout, _, err := common.Run(ctx, args...)
+	stdout, _, err := run.Run(ctx, args...)
 	if err != nil {
 		return "", err //nolint:wrapcheck
 	}

--- a/templates/common/render/render.go
+++ b/templates/common/render/render.go
@@ -32,6 +32,7 @@ import (
 	"github.com/abcxyz/abc/templates/common/input"
 	"github.com/abcxyz/abc/templates/common/render/gotmpl/funcs"
 	"github.com/abcxyz/abc/templates/common/rules"
+	"github.com/abcxyz/abc/templates/common/run"
 	"github.com/abcxyz/abc/templates/common/specutil"
 	"github.com/abcxyz/abc/templates/common/tempdir"
 	"github.com/abcxyz/abc/templates/common/templatesource"
@@ -363,7 +364,7 @@ func initDebugStepDiffsDir(ctx context.Context, p *Params, scratchDir string) (s
 		{"git", "--git-dir", out, "config", "user.email", "abc@abcxyz.com"},
 	}
 
-	if _, _, err := common.RunMany(ctx, cmds...); err != nil {
+	if _, _, err := run.RunMany(ctx, cmds...); err != nil {
 		return "", fmt.Errorf("failed initializing git repo for --debug-step-diffs: %w", err)
 	}
 	return out, nil
@@ -435,7 +436,7 @@ func executeSteps(ctx context.Context, steps []*spec.Step, sp *stepParams) error
 				{"git", "--git-dir", sp.debugDiffsDir, "add", "-A"},
 				{"git", "--git-dir", sp.debugDiffsDir, "commit", "-a", "-m", m, "--allow-empty", "--no-gpg-sign"},
 			}
-			if _, _, err := common.RunMany(ctx, cmds...); err != nil {
+			if _, _, err := run.RunMany(ctx, cmds...); err != nil {
 				return fmt.Errorf("failed committing to git for --debug-step-diffs: %w", err)
 			}
 		}

--- a/templates/common/run/run.go
+++ b/templates/common/run/run.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package common
+package run
 
 import (
 	"bytes"

--- a/templates/common/run/run_test.go
+++ b/templates/common/run/run_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package common
+package run
 
 import (
 	"context"


### PR DESCRIPTION
I'm about to make these more complex, and common shouldn't be such a dumping ground of unrelated functionality.

There's nothing interesting in this PR, just moved code.