### PR TITLE
Fix "include from destination" behavior in the upgrade case

### DIFF
--- a/templates/common/render/action_include.go
+++ b/templates/common/render/action_include.go
@@ -143,7 +143,7 @@ func includePath(ctx context.Context, inc *spec.IncludePath, sp *stepParams) err
 	// that already exist in the destination.
 	fromDir := sp.templateDir
 	if inc.From.Val == "destination" {
-		fromDir = sp.rp.OutDir
+		fromDir = sp.rp.DestDir
 	}
 
 	skipPaths, err := processPaths(inc.Skip, sp.scope)

--- a/templates/common/render/action_include_test.go
+++ b/templates/common/render/action_include_test.go
@@ -936,7 +936,7 @@ func TestActionInclude(t *testing.T) {
 				scratchDir:       scratchDir,
 				templateDir:      templateDir,
 				rp: &Params{
-					OutDir: destDir,
+					DestDir: destDir,
 
 					FS: &common.ErrorFS{
 						FS:      &common.RealFS{},

--- a/templates/common/render/render.go
+++ b/templates/common/render/render.go
@@ -155,11 +155,11 @@ func Render(ctx context.Context, p *Params) (rErr error) {
 		"path", templateDir)
 
 	logger.DebugContext(ctx, "downloading/copying template")
-	destDir := p.DestDir
-	if destDir == "" {
-		destDir = p.OutDir
+	p = copyParams(p)
+	if p.DestDir == "" {
+		p.DestDir = p.OutDir
 	}
-	dlMeta, err := p.Downloader.Download(ctx, p.Cwd, templateDir, destDir)
+	dlMeta, err := p.Downloader.Download(ctx, p.Cwd, templateDir, p.DestDir)
 	if err != nil {
 		return fmt.Errorf("failed to download/copy template: %w", err)
 	}
@@ -167,6 +167,13 @@ func Render(ctx context.Context, p *Params) (rErr error) {
 		"destination", templateDir)
 
 	return RenderAlreadyDownloaded(ctx, dlMeta, templateDir, p)
+}
+
+// copyParams returns a shallow copy of the input params. This lets us fill in
+// default values without affect the caller's copy of the params.
+func copyParams(p *Params) *Params {
+	cp := *p
+	return &cp
 }
 
 // RenderAlreadyDownloaded is for the unusual case where the template has


### PR DESCRIPTION
This is kind of a bug, but the upgrade code isn't exposed yet, so not really. In the case where an upgrade operation executes an `include` action with `from: destination`, the file should be copied from the ultimate user-visible destination folder, not the temp dir that we're rendering into (which will just be empty).