### PR TITLE
Fix terminal color test failure on mac 14

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ toolchain go1.22.1
 require (
 	github.com/Masterminds/semver/v3 v3.2.1
 	github.com/abcxyz/pkg v1.0.4
+	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
 	github.com/benbjohnson/clock v1.3.5
 	github.com/fatih/color v1.16.0
 	github.com/google/cel-go v0.20.1

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/Masterminds/semver/v3 v3.2.1 h1:RN9w6+7QoMeJVGyfmbcgs28Br8cvmnucEXnY0
 github.com/Masterminds/semver/v3 v3.2.1/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
 github.com/abcxyz/pkg v1.0.4 h1:0C38LHfKDflehnFDnWuU2zRYOV9qHBotCT4cnEcetDc=
 github.com/abcxyz/pkg v1.0.4/go.mod h1:ibdYDJSLgKg/6sMRv9q18KseLhrD83HulBl4J1yHnt8=
+github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=
+github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
 github.com/antlr4-go/antlr/v4 v4.13.0 h1:lxCg3LAv+EUK6t1i0y1V6/SLeUi0eKEKdhQAlS8TVTI=
 github.com/antlr4-go/antlr/v4 v4.13.0/go.mod h1:pfChB/xh/Unjila75QW7+VU4TSnWnnk9UTnmpPaOR2g=
 github.com/benbjohnson/clock v1.3.5 h1:VvXlSJBzZpA/zum6Sj74hxwYI2DIxRWuNIoXAzHZz5o=

--- a/templates/common/run/diff_test.go
+++ b/templates/common/run/diff_test.go
@@ -204,8 +204,9 @@ func TestDiff(t *testing.T) {
 			}
 
 			// Hex 1b is the ASCII "escape" char, which always appears when setting colors.
-			if tc.wantColor && !strings.Contains(gotDiff, "\x1b") {
-				t.Error("got non-colorized output, but want colorized output")
+			outputHasColor := strings.Contains(gotDiff, "\x1b")
+			if outputHasColor != tc.wantColor {
+				t.Errorf("hasColor=%t, but want hasColor=%t", outputHasColor, tc.wantColor)
 			}
 
 			colorStripped := stripansi.Strip(gotDiff)

--- a/templates/common/run/diff_test.go
+++ b/templates/common/run/diff_test.go
@@ -17,8 +17,10 @@ package run
 import (
 	"context"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/acarl005/stripansi"
 	"github.com/google/go-cmp/cmp"
 
 	abctestutil "github.com/abcxyz/abc/templates/testutil"
@@ -37,6 +39,7 @@ func TestDiff(t *testing.T) {
 		file2       string
 		file2RelTo  string
 		want        string
+		wantColor   bool
 	}{
 		{
 			name: "both_empty",
@@ -121,7 +124,8 @@ func TestDiff(t *testing.T) {
 			file1RelTo: ".",
 			file2:      "file2.txt",
 			file2RelTo: ".",
-			want:       "\x1b[1m--- a/file1.txt\x1b[0m\n\x1b[1m+++ b/file2.txt\x1b[0m\n\x1b[36m@@ -1 +1 @@\x1b[0m\n\x1b[31m-file1 contents\x1b[0m\n\x1b[32m+file2 contents\x1b[0m\n",
+			wantColor:  true,
+			want:       "--- a/file1.txt\n+++ b/file2.txt\n@@ -1 +1 @@\n-file1 contents\n+file2 contents\n",
 		},
 		{
 			name:  "files_differ_with_color_on_machine_without_color_support",
@@ -198,7 +202,14 @@ func TestDiff(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if diff := cmp.Diff(gotDiff, tc.want); diff != "" {
+
+			// Hex 1b is the ASCII "escape" char, which always appears when setting colors.
+			if tc.wantColor && !strings.Contains(gotDiff, "\x1b") {
+				t.Error("got non-colorized output, but want colorized output")
+			}
+
+			colorStripped := stripansi.Strip(gotDiff)
+			if diff := cmp.Diff(colorStripped, tc.want); diff != "" {
 				t.Errorf("diff was not as expected (-got,+want): %s", diff)
 			}
 		})


### PR DESCRIPTION
Fixes #534 

The problem is that macOS 14 `diff`, which comes from freebsd, colors its output differently than GNU diff, which is common on Linux.

We didn't catch this in CI because github actions `macos-latest` uses macos 12, whose `diff` binary has no color support at all.

The fix is just to test for the presence of *any* colors rather than looking for exact color codes.