### PR TITLE
Rename RunMany to Run

### DIFF
--- a/templates/common/render/render.go
+++ b/templates/common/render/render.go
@@ -371,7 +371,7 @@ func initDebugStepDiffsDir(ctx context.Context, p *Params, scratchDir string) (s
 		{"git", "--git-dir", out, "config", "user.email", "abc@abcxyz.com"},
 	}
 
-	if _, _, err := run.RunMany(ctx, cmds...); err != nil {
+	if _, _, err := run.Many(ctx, cmds...); err != nil {
 		return "", fmt.Errorf("failed initializing git repo for --debug-step-diffs: %w", err)
 	}
 	return out, nil
@@ -443,7 +443,7 @@ func executeSteps(ctx context.Context, steps []*spec.Step, sp *stepParams) error
 				{"git", "--git-dir", sp.debugDiffsDir, "add", "-A"},
 				{"git", "--git-dir", sp.debugDiffsDir, "commit", "-a", "-m", m, "--allow-empty", "--no-gpg-sign"},
 			}
-			if _, _, err := run.RunMany(ctx, cmds...); err != nil {
+			if _, _, err := run.Many(ctx, cmds...); err != nil {
 				return fmt.Errorf("failed committing to git for --debug-step-diffs: %w", err)
 			}
 		}

--- a/templates/common/run/run.go
+++ b/templates/common/run/run.go
@@ -54,6 +54,9 @@ func Simple(ctx context.Context, args ...string) (stdout, stderr string, _ error
 // If the incoming context doesn't already have a timeout, then a default
 // timeout will be added (see DefaultRunTimeout).
 //
+// If the command fails, the error message will include the contents of stdout
+// and stderr. This saves boilerplate in the caller.
+//
 // The input args must have len>=1. opts may be nil if no special options are
 // needed.
 //
@@ -90,12 +93,12 @@ func Run(ctx context.Context, opts []*Option, args ...string) (exitCode int, _ e
 	return cmd.ProcessState.ExitCode(), err
 }
 
-// RunMany calls [Simple] for each command in args. If any command returns error,
+// Many calls [Simple] for each command in args. If any command returns error,
 // then no further commands will be run, and that error will be returned. For
 // any commands that were actually executed (not aborted by a previous error),
 // their stdout and stderr will be returned. It's guaranteed that
 // len(stdouts)==len(stderrs).
-func RunMany(ctx context.Context, args ...[]string) (stdouts, stderrs []string, _ error) {
+func Many(ctx context.Context, args ...[]string) (stdouts, stderrs []string, _ error) {
 	for _, cmd := range args {
 		stdout, stderr, err := Simple(ctx, cmd...)
 		stdouts = append(stdouts, stdout)


### PR DESCRIPTION
This code was recently moved into the `run` package, so it can be called as `run.Many` without undue repetition.