### PR TITLE
Run GH actions on macos 14 instead of 12

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         runner:
-          - 'macos-latest'
+          - 'macos-14'
           - 'ubuntu-latest'
     with:
       runs-on: '"${{ matrix.runner }}"'
@@ -62,7 +62,7 @@ jobs:
       fail-fast: false
       matrix:
         runner:
-          - 'macos-latest'
+          - 'macos-14'
           - 'ubuntu-latest'
     runs-on: '${{ matrix.runner }}'
     steps:

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -63,6 +63,7 @@ jobs:
       matrix:
         runner:
           - 'macos-14'
+          - 'macos-12'
           - 'ubuntu-latest'
     runs-on: '${{ matrix.runner }}'
     steps:


### PR DESCRIPTION
Why this is uncontroversial: macos 14 is about to become the default for the github runner label `macos-latest`, according to GitHub's blog. We're just changing it early.

Why do this now?
 - macos 12 is causing repeated problems by having weird versions of `diff` and `patch` that format their output differently.
 - we get test failures on macos 14 (the most common macos version) that don't show up in CI.