### PR TITLE
Template rest_server: switch from chi to std library.

### DIFF
--- a/t/rest_server/contents/go.mod
+++ b/t/rest_server/contents/go.mod
@@ -6,7 +6,6 @@ toolchain go1.22.1
 
 require (
 	github.com/abcxyz/pkg v1.0.4
-	github.com/go-chi/chi/v5 v5.0.12
 	github.com/google/go-cmp v0.6.0
 )
 

--- a/t/rest_server/contents/go.sum
+++ b/t/rest_server/contents/go.sum
@@ -1,7 +1,5 @@
 github.com/abcxyz/pkg v1.0.4 h1:0C38LHfKDflehnFDnWuU2zRYOV9qHBotCT4cnEcetDc=
 github.com/abcxyz/pkg v1.0.4/go.mod h1:ibdYDJSLgKg/6sMRv9q18KseLhrD83HulBl4J1yHnt8=
-github.com/go-chi/chi/v5 v5.0.12 h1:9euLV5sTrTNTRUU9POmDUvfxyj6LAABLUcEWO+JJb4s=
-github.com/go-chi/chi/v5 v5.0.12/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=

--- a/t/rest_server/contents/main.go
+++ b/t/rest_server/contents/main.go
@@ -25,8 +25,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/go-chi/chi/v5"
-
 	"github.com/abcxyz/pkg/logging"
 	"github.com/abcxyz/pkg/renderer"
 	"github.com/abcxyz/pkg/serving"
@@ -58,20 +56,12 @@ func realMain(ctx context.Context) error {
 		return fmt.Errorf("failed to create renderer for main server: %w", err)
 	}
 
-	r := chi.NewRouter()
-	r.Mount("/", handleHello(h))
-	walkFunc := func(method, route string, handler http.Handler, middlewares ...func(http.Handler) http.Handler) error {
-		logger.DebugContext(ctx, "Route registered", "http_method", method, "route", route)
-		return nil
-	}
-
-	if err := chi.Walk(r, walkFunc); err != nil {
-		logger.ErrorContext(ctx, "error walking routes", "error", err)
-	}
+	mux := http.NewServeMux()
+	mux.Handle("/", handleHello(h))
 
 	httpServer := &http.Server{
 		Addr:              *port,
-		Handler:           r,
+		Handler:           mux,
 		ReadHeaderTimeout: 2 * time.Second,
 	}
 

--- a/t/rest_server/testdata/golden/basic/data/go.mod
+++ b/t/rest_server/testdata/golden/basic/data/go.mod
@@ -6,7 +6,6 @@ toolchain go1.22.1
 
 require (
 	github.com/abcxyz/pkg v1.0.4
-	github.com/go-chi/chi/v5 v5.0.12
 	github.com/google/go-cmp v0.6.0
 )
 

--- a/t/rest_server/testdata/golden/basic/data/go.sum
+++ b/t/rest_server/testdata/golden/basic/data/go.sum
@@ -1,7 +1,5 @@
 github.com/abcxyz/pkg v1.0.4 h1:0C38LHfKDflehnFDnWuU2zRYOV9qHBotCT4cnEcetDc=
 github.com/abcxyz/pkg v1.0.4/go.mod h1:ibdYDJSLgKg/6sMRv9q18KseLhrD83HulBl4J1yHnt8=
-github.com/go-chi/chi/v5 v5.0.12 h1:9euLV5sTrTNTRUU9POmDUvfxyj6LAABLUcEWO+JJb4s=
-github.com/go-chi/chi/v5 v5.0.12/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=

--- a/t/rest_server/testdata/golden/basic/data/main.go
+++ b/t/rest_server/testdata/golden/basic/data/main.go
@@ -25,8 +25,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/go-chi/chi/v5"
-
 	"github.com/abcxyz/pkg/logging"
 	"github.com/abcxyz/pkg/renderer"
 	"github.com/abcxyz/pkg/serving"
@@ -58,20 +56,12 @@ func realMain(ctx context.Context) error {
 		return fmt.Errorf("failed to create renderer for main server: %w", err)
 	}
 
-	r := chi.NewRouter()
-	r.Mount("/", handleHello(h))
-	walkFunc := func(method, route string, handler http.Handler, middlewares ...func(http.Handler) http.Handler) error {
-		logger.DebugContext(ctx, "Route registered", "http_method", method, "route", route)
-		return nil
-	}
-
-	if err := chi.Walk(r, walkFunc); err != nil {
-		logger.ErrorContext(ctx, "error walking routes", "error", err)
-	}
+	mux := http.NewServeMux()
+	mux.Handle("/", handleHello(h))
 
 	httpServer := &http.Server{
 		Addr:              *port,
-		Handler:           r,
+		Handler:           mux,
 		ReadHeaderTimeout: 2 * time.Second,
 	}
 


### PR DESCRIPTION
Now that the std library supports routing via method: https://go.dev/blog/routing-enhancements the main reason for using Chi is no longer needed.

I removed the walk function as it's not necessary and not easily supported by the standard library.