### PR TITLE
Add -version flag to upgrade command

### DIFF
--- a/templates/commands/upgrade/flags.go
+++ b/templates/commands/upgrade/flags.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/abcxyz/abc/templates/common/flags"
+	"github.com/abcxyz/abc/templates/common/templatesource"
 	"github.com/abcxyz/pkg/cli"
 )
 
@@ -66,7 +67,7 @@ func (f *Flags) Register(set *cli.FlagSet) {
 		Name:    "version",
 		Usage:   "for remote templates, the version to upgrade to; may be git tag, branch, or SHA",
 		Example: "main",
-		Default: "latest",
+		Default: templatesource.Latest,
 		EnvVar:  "ABC_UPGRADE_TO_VERSION",
 		Target:  &f.Version,
 	})

--- a/templates/commands/upgrade/flags.go
+++ b/templates/commands/upgrade/flags.go
@@ -48,6 +48,9 @@ type Flags struct {
 
 	// See common/flags.SkipInputValidation().
 	SkipInputValidation bool
+
+	// The template version to upgrade to; defaults to "latest".
+	Version string
 }
 
 func (f *Flags) Register(set *cli.FlagSet) {
@@ -59,7 +62,14 @@ func (f *Flags) Register(set *cli.FlagSet) {
 	r.BoolVar(flags.DebugStepDiffs(&f.DebugStepDiffs))
 	r.BoolVar(flags.KeepTempDirs(&f.KeepTempDirs))
 	r.BoolVar(flags.Prompt(&f.Prompt))
-
+	r.StringVar(&cli.StringVar{
+		Name:    "version",
+		Usage:   "for remote templates, the version to upgrade to; may be git tag, branch, or SHA",
+		Example: "main",
+		Default: "latest",
+		EnvVar:  "ABC_UPGRADE_TO_VERSION",
+		Target:  &f.Version,
+	})
 	t := set.NewSection("TEMPLATE AUTHORS")
 	t.BoolVar(flags.DebugScratchContents(&f.DebugScratchContents))
 

--- a/templates/commands/upgrade/upgrade.go
+++ b/templates/commands/upgrade/upgrade.go
@@ -135,6 +135,7 @@ func (c *Command) Run(ctx context.Context, args []string) error {
 		SkipInputValidation:  c.flags.SkipInputValidation,
 		SkipPromptTTYCheck:   c.skipPromptTTYCheck,
 		Stdout:               c.Stdout(),
+		Version:              c.flags.Version,
 	})
 	if err != nil {
 		return err //nolint:wrapcheck

--- a/templates/common/templatesource/remote_git.go
+++ b/templates/common/templatesource/remote_git.go
@@ -272,7 +272,7 @@ func resolveVersion(ctx context.Context, t tagser, remote, version string) (stri
 	switch version {
 	case "":
 		return "", fmt.Errorf("the template source version cannot be empty")
-	case "latest":
+	case Latest:
 		return resolveLatest(ctx, t, remote)
 	default:
 		logger.DebugContext(ctx, "using user provided version and skipping remote tags lookup", "version", version)

--- a/templates/common/templatesource/source.go
+++ b/templates/common/templatesource/source.go
@@ -23,6 +23,8 @@ import (
 	"github.com/abcxyz/abc/templates/common/specutil"
 )
 
+const Latest = "latest"
+
 // sourceParser is implemented for each particular kind of template source (git,
 // local file, etc.).
 type sourceParser interface {
@@ -74,7 +76,7 @@ var realSourceParsers = []sourceParser{
 				`$`), // Anchor the end, must match the entire input
 		subdirExpansion:  `${subdir}`,
 		versionExpansion: `${version}`,
-		defaultVersion:   "latest",
+		defaultVersion:   Latest,
 		warning:          `go-getter style URL support will be removed in mid-2024, please use the newer format instead, eg github.com/myorg/myrepo[/subdir]@v1.2.3 (or @latest)`,
 	},
 }

--- a/templates/common/templatesource/upgrade.go
+++ b/templates/common/templatesource/upgrade.go
@@ -75,6 +75,10 @@ type ForUpgradeParams struct {
 
 	// The value of --git-protocol.
 	GitProtocol string
+
+	// The version to update to; may be the magic string "latest", a tag, a
+	// branch, or a SHA.
+	Version string
 }
 
 func remoteGitUpgradeDownloaderFactory(ctx context.Context, f *ForUpgradeParams) (Downloader, error) {
@@ -82,7 +86,7 @@ func remoteGitUpgradeDownloaderFactory(ctx context.Context, f *ForUpgradeParams)
 		re:             remoteGitUpgradeLocationRE,
 		input:          f.CanonicalLocation,
 		gitProtocol:    f.GitProtocol,
-		defaultVersion: "latest",
+		defaultVersion: f.Version,
 	})
 	if err != nil {
 		return nil, err

--- a/templates/common/templatesource/upgrade_test.go
+++ b/templates/common/templatesource/upgrade_test.go
@@ -36,6 +36,7 @@ func TestForUpgrade(t *testing.T) {
 		gitProtocol       string
 		installedInSubdir string
 		dirContents       map[string]string
+		version           string
 		wantDownloader    Downloader
 		wantErr           string
 	}{
@@ -44,6 +45,7 @@ func TestForUpgrade(t *testing.T) {
 			canonicalLocation: "github.com/abcxyz/abc",
 			locType:           "remote_git",
 			gitProtocol:       "https",
+			version:           "latest",
 			wantDownloader: &remoteGitDownloader{
 				canonicalSource: "github.com/abcxyz/abc",
 				cloner:          &realCloner{},
@@ -57,6 +59,7 @@ func TestForUpgrade(t *testing.T) {
 			canonicalLocation: "github.com/abcxyz/abc",
 			locType:           "remote_git",
 			gitProtocol:       "ssh",
+			version:           "latest",
 			wantDownloader: &remoteGitDownloader{
 				canonicalSource: "github.com/abcxyz/abc",
 				cloner:          &realCloner{},
@@ -70,6 +73,7 @@ func TestForUpgrade(t *testing.T) {
 			canonicalLocation: "github.com/abcxyz/abc/sub",
 			locType:           "remote_git",
 			gitProtocol:       "https",
+			version:           "latest",
 			wantDownloader: &remoteGitDownloader{
 				canonicalSource: "github.com/abcxyz/abc/sub",
 				cloner:          &realCloner{},
@@ -84,6 +88,7 @@ func TestForUpgrade(t *testing.T) {
 			canonicalLocation: "github.com/abcxyz/abc/sub",
 			locType:           "remote_git",
 			gitProtocol:       "ssh",
+			version:           "latest",
 			wantDownloader: &remoteGitDownloader{
 				canonicalSource: "github.com/abcxyz/abc/sub",
 				cloner:          &realCloner{},
@@ -91,6 +96,20 @@ func TestForUpgrade(t *testing.T) {
 				subdir:          "sub",
 				tagser:          &realTagser{},
 				version:         "latest",
+			},
+		},
+		{
+			name:              "non_default_version",
+			canonicalLocation: "github.com/abcxyz/abc",
+			locType:           "remote_git",
+			gitProtocol:       "https",
+			version:           "someversion",
+			wantDownloader: &remoteGitDownloader{
+				canonicalSource: "github.com/abcxyz/abc",
+				cloner:          &realCloner{},
+				remote:          "https://github.com/abcxyz/abc.git",
+				tagser:          &realTagser{},
+				version:         "someversion",
 			},
 		},
 		{
@@ -160,6 +179,7 @@ func TestForUpgrade(t *testing.T) {
 				CanonicalLocation: location,
 				InstalledDir:      installedInDir,
 				GitProtocol:       tc.gitProtocol,
+				Version:           tc.version,
 			})
 			if diff := testutil.DiffErrString(err, tc.wantErr); diff != "" {
 				t.Fatal(diff)

--- a/templates/common/upgrade/upgrade.go
+++ b/templates/common/upgrade/upgrade.go
@@ -118,6 +118,12 @@ type Params struct {
 
 	// Empty string, except in tests. Will be used as the parent of temp dirs.
 	TempDirBase string
+
+	// An optional version to update to. In the case of a remote git template,
+	// it defaults to "latest", which means "the vX.Y.Z that is largest by
+	// semver ordering." In the case of a template on the local filesystem, it's
+	// ignored because we only have the one version that's on the filesystem.
+	Version string
 }
 
 type ResultType string
@@ -260,6 +266,7 @@ func Upgrade(ctx context.Context, p *Params) (_ *Result, rErr error) {
 		CanonicalLocation: oldManifest.TemplateLocation.Val,
 		LocType:           oldManifest.LocationType.Val,
 		GitProtocol:       p.GitProtocol,
+		Version:           p.Version,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed creating downloader for manifest location %q of type %q with git protocol %q: %w",


### PR DESCRIPTION
In many cases, we'll want to upgrade to a template version that hasn't been formally released as a tag. In these cases, the user can provide `abc upgrade -version=main`.

This will be useful for the gcp-org-terraform-template, which doesn't usually do tagged releases.