### PR TITLE
Add a flag for patches that the user already resolved

### DIFF
--- a/templates/commands/upgrade/flags.go
+++ b/templates/commands/upgrade/flags.go
@@ -18,10 +18,11 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/posener/complete/v2/predict"
+
 	"github.com/abcxyz/abc/templates/common/flags"
 	"github.com/abcxyz/abc/templates/common/templatesource"
 	"github.com/abcxyz/pkg/cli"
-	"github.com/posener/complete/v2/predict"
 )
 
 type Flags struct {

--- a/templates/commands/upgrade/upgrade.go
+++ b/templates/commands/upgrade/upgrade.go
@@ -120,6 +120,7 @@ func (c *Command) Run(ctx context.Context, args []string) error {
 	}
 
 	r, err := upgrade.Upgrade(ctx, &upgrade.Params{
+		AlreadyResolved: c.flags.AlreadyResolved,
 		Clock:                clock.New(),
 		CWD:                  cwd,
 		DebugStepDiffs:       c.flags.DebugStepDiffs,

--- a/templates/commands/upgrade/upgrade.go
+++ b/templates/commands/upgrade/upgrade.go
@@ -120,7 +120,7 @@ func (c *Command) Run(ctx context.Context, args []string) error {
 	}
 
 	r, err := upgrade.Upgrade(ctx, &upgrade.Params{
-		AlreadyResolved: c.flags.AlreadyResolved,
+		AlreadyResolved:      c.flags.AlreadyResolved,
 		Clock:                clock.New(),
 		CWD:                  cwd,
 		DebugStepDiffs:       c.flags.DebugStepDiffs,

--- a/templates/common/upgrade/upgrade.go
+++ b/templates/common/upgrade/upgrade.go
@@ -305,11 +305,11 @@ func Upgrade(ctx context.Context, p *Params) (_ *Result, rErr error) {
 	}
 
 	reversalConflicts, err := reversePatches(ctx, &reversePatchesParams{
-		fs:           p.FS,
-		alreadyResolved:  p.AlreadyResolved,
-		installedDir: installedDir,
-		reversedDir:  reversedDir,
-		oldManifest:  oldManifest,
+		fs:              p.FS,
+		alreadyResolved: p.AlreadyResolved,
+		installedDir:    installedDir,
+		reversedDir:     reversedDir,
+		oldManifest:     oldManifest,
 	})
 	if err != nil {
 		return nil, err

--- a/templates/common/upgrade/upgrade.go
+++ b/templates/common/upgrade/upgrade.go
@@ -65,6 +65,11 @@ const rejectedPatchSuffix = ".patch.rej"
 
 // Params contains all the arguments to Upgrade().
 type Params struct {
+	// Relative paths where patch reversal has already happened. This is a flag
+	// supplied by the user. This will be set if there were merge conflicts
+	// during patch reversal that were manually resolved by the user.
+	AlreadyResolved []string
+
 	Clock clock.Clock
 
 	// CWD is the value of os.Getwd(), or in testing, a temp directory.
@@ -99,12 +104,6 @@ type Params struct {
 	// The value of --prompt.
 	Prompt   bool
 	Prompter input.Prompter
-
-	// Relative paths where patch reversal has already happened. This is a flag
-	// supplied by the user. This will be set if there were merge conflicts
-	// during patch reversal that were manually resolved by the user.
-	// TODO(upgrade): add this as a CLI flag and plumb it through to here.
-	ReversalAlreadyDone []string
 
 	// The value of --skip-input-validation.
 	SkipInputValidation bool
@@ -307,7 +306,7 @@ func Upgrade(ctx context.Context, p *Params) (_ *Result, rErr error) {
 
 	reversalConflicts, err := reversePatches(ctx, &reversePatchesParams{
 		fs:           p.FS,
-		preReversed:  p.ReversalAlreadyDone,
+		alreadyResolved:  p.AlreadyResolved,
 		installedDir: installedDir,
 		reversedDir:  reversedDir,
 		oldManifest:  oldManifest,
@@ -557,7 +556,7 @@ type reversePatchesParams struct {
 
 	// The set of files whose patches have already been applied by the user, so
 	// they should be skipped by the user. This comes from a command line flag.
-	preReversed []string
+	alreadyResolved []string
 
 	// installedDir is the directory where the template output is going.
 	installedDir string
@@ -582,7 +581,7 @@ func reversePatches(ctx context.Context, p *reversePatchesParams) ([]*ReversalCo
 		}
 
 		outPath := filepath.Join(p.reversedDir, f.File.Val)
-		if slices.Contains(p.preReversed, f.File.Val) {
+		if slices.Contains(p.alreadyResolved, f.File.Val) {
 			// In the case where a previous run of abc raised a merge conflict,
 			// and the user resolved it, and provided the command-line flag
 			// indicating that they already resolved it, then we skip applying

--- a/templates/common/upgrade/upgrade_test.go
+++ b/templates/common/upgrade/upgrade_test.go
@@ -1279,7 +1279,7 @@ steps:
 	abctestutil.Remove(t, destDir, "file.txt.patch.rej")
 
 	// Inform the upgrade command that patch reversal has already happened
-	upgradeParams.ReversalAlreadyDone = []string{"file.txt"}
+	upgradeParams.AlreadyResolved = []string{"file.txt"}
 
 	gotResult, err := Upgrade(ctx, upgradeParams)
 	if err != nil {


### PR DESCRIPTION
When an upgrade operation fails to apply a patch to an included-from-destination file, we'll ask the user to manually resolve the conflict, then re-run the upgrade operation with `--already-resolved=filename.txt` to indicate that they resolved the conflict.