### PR TITLE
Return DownloadMetadata from Upgrade()

### DIFF
--- a/templates/common/render/manifest.go
+++ b/templates/common/render/manifest.go
@@ -193,6 +193,11 @@ func buildManifest(p *writeManifestParams) (*manifest.WithHeader, error) {
 	now := p.clock.Now().UTC()
 	apiVersion := decode.LatestSupportedAPIVersion(version.IsReleaseBuild())
 
+	locType := string(p.dlMeta.LocationType)
+	if p.dlMeta.CanonicalSource == "" {
+		locType = "" // we only save the location type in the manifest if the location is canonical
+	}
+
 	return &manifest.WithHeader{
 		Header: &header.Fields{
 			NewStyleAPIVersion: model.String{Val: apiVersion},
@@ -200,7 +205,7 @@ func buildManifest(p *writeManifestParams) (*manifest.WithHeader, error) {
 		},
 		Wrapped: &manifest.ForMarshaling{
 			TemplateLocation: model.String{Val: p.dlMeta.CanonicalSource}, // may be empty string if location isn't canonical
-			LocationType:     model.String{Val: p.dlMeta.LocationType},
+			LocationType:     model.String{Val: locType},                  // may be empty string if location isn't canonical
 			TemplateDirhash:  model.String{Val: templateDirhash},
 			TemplateVersion:  model.String{Val: p.dlMeta.Version},
 			CreationTime:     now,

--- a/templates/common/render/manifest_test.go
+++ b/templates/common/render/manifest_test.go
@@ -54,7 +54,8 @@ func TestWriteManifest(t *testing.T) {
 				"a.txt": "some other stuff",
 			},
 			dlMeta: &templatesource.DownloadMetadata{
-				IsCanonical: false,
+				IsCanonical:  false,
+				LocationType: templatesource.LocalNonGit,
 			},
 			inputs: map[string]string{
 				"pizza":     "hawaiian",
@@ -98,7 +99,7 @@ output_files:
 			dlMeta: &templatesource.DownloadMetadata{
 				IsCanonical:     true,
 				CanonicalSource: "github.com/foo/bar",
-				LocationType:    "remote_git",
+				LocationType:    templatesource.RemoteGit,
 				HasVersion:      true,
 				Version:         "v1.2.3",
 			},
@@ -135,7 +136,8 @@ output_files:
 		{
 			name: "dryrun_no_output",
 			dlMeta: &templatesource.DownloadMetadata{
-				IsCanonical:     false,
+				IsCanonical:     true,
+				LocationType:    templatesource.RemoteGit,
 				CanonicalSource: "github.com/foo/bar",
 			},
 			dryRun: true,
@@ -166,9 +168,7 @@ output_files:
 			destDirContents: map[string]string{
 				"a.txt": "some other stuff",
 			},
-			dlMeta: &templatesource.DownloadMetadata{
-				IsCanonical: false,
-			},
+			dlMeta: &templatesource.DownloadMetadata{},
 			inputs: map[string]string{},
 			outputHashes: map[string][]byte{
 				"a.txt": []byte("fake_output_hash_32_bytes_sha256"),
@@ -199,9 +199,7 @@ output_files:
 				"a.txt":     "some other stuff",
 			},
 			destDirContents: map[string]string{},
-			dlMeta: &templatesource.DownloadMetadata{
-				IsCanonical: false,
-			},
+			dlMeta:          &templatesource.DownloadMetadata{},
 			inputs: map[string]string{
 				"pizza":     "hawaiian",
 				"pineapple": "deal with it",

--- a/templates/common/templatesource/download.go
+++ b/templates/common/templatesource/download.go
@@ -64,7 +64,7 @@ type DownloadMetadata struct {
 	// non-empty.
 	IsCanonical     bool
 	CanonicalSource string
-	LocationType    string
+	LocationType    LocationType
 
 	// Depending on where the template was taken from, there might be a version
 	// string associated with it (e.g. a git tag or a git SHA).

--- a/templates/common/templatesource/git.go
+++ b/templates/common/templatesource/git.go
@@ -23,11 +23,6 @@ import (
 	"github.com/abcxyz/abc/templates/common/git"
 )
 
-const (
-	LocTypeLocalGit  = "local_git"
-	LocTypeRemoteGit = "remote_git"
-)
-
 // gitCanonicalVersion examines a template directory and tries to determine the
 // "best" template version by looking at .git. The "best" template version is
 // defined as (in decreasing order of precedence):

--- a/templates/common/templatesource/localsource_test.go
+++ b/templates/common/templatesource/localsource_test.go
@@ -52,7 +52,8 @@ func TestLocalDownloader_Download(t *testing.T) {
 				"a/file2.txt": "file2 contents",
 			},
 			wantDLMeta: &DownloadMetadata{
-				IsCanonical: false,
+				IsCanonical:  false,
+				LocationType: LocalNonGit,
 			},
 		},
 		{
@@ -170,7 +171,8 @@ func TestLocalDownloader_Download(t *testing.T) {
 				"file1.txt": "file1 contents",
 			}),
 			wantDLMeta: &DownloadMetadata{
-				IsCanonical: false,
+				IsCanonical:  false,
+				LocationType: LocalGit,
 				Vars: DownloaderVars{
 					GitSHA:      abctestutil.MinimalGitHeadSHA,
 					GitShortSHA: abctestutil.MinimalGitHeadShortSHA,
@@ -192,7 +194,8 @@ func TestLocalDownloader_Download(t *testing.T) {
 				"file1.txt": "file1 contents",
 			}),
 			wantDLMeta: &DownloadMetadata{
-				IsCanonical: false,
+				IsCanonical:  false,
+				LocationType: LocalGit,
 				Vars: DownloaderVars{
 					GitSHA:      abctestutil.MinimalGitHeadSHA,
 					GitShortSHA: abctestutil.MinimalGitHeadShortSHA,
@@ -213,7 +216,8 @@ func TestLocalDownloader_Download(t *testing.T) {
 				"file1.txt": "file1 contents",
 			},
 			wantDLMeta: &DownloadMetadata{
-				IsCanonical: false,
+				IsCanonical:  false,
+				LocationType: LocalNonGit,
 			},
 		},
 	}

--- a/templates/common/templatesource/remote_git.go
+++ b/templates/common/templatesource/remote_git.go
@@ -221,7 +221,7 @@ func (g *remoteGitDownloader) Download(ctx context.Context, _, templateDir, _ st
 	dlMeta := &DownloadMetadata{
 		IsCanonical:     true, // Remote git sources are always canonical.
 		CanonicalSource: g.canonicalSource,
-		LocationType:    LocTypeRemoteGit,
+		LocationType:    RemoteGit,
 		HasVersion:      true, // Remote git sources always have a tag or SHA.
 		Version:         canonicalVersion,
 		Vars:            *vars,

--- a/templates/common/templatesource/remote_git_test.go
+++ b/templates/common/templatesource/remote_git_test.go
@@ -59,7 +59,7 @@ func TestRemoteGitDownloader_Download(t *testing.T) {
 			wantDLMeta: &DownloadMetadata{
 				IsCanonical:     true,
 				CanonicalSource: "mysource",
-				LocationType:    "remote_git",
+				LocationType:    RemoteGit,
 				HasVersion:      true,
 				Version:         "v1.2.3",
 				Vars: DownloaderVars{
@@ -96,7 +96,7 @@ func TestRemoteGitDownloader_Download(t *testing.T) {
 			wantDLMeta: &DownloadMetadata{
 				IsCanonical:     true,
 				CanonicalSource: "mysource",
-				LocationType:    "remote_git",
+				LocationType:    RemoteGit,
 				HasVersion:      true,
 				Version:         "v1.2.3",
 				Vars: DownloaderVars{
@@ -130,7 +130,7 @@ func TestRemoteGitDownloader_Download(t *testing.T) {
 			wantDLMeta: &DownloadMetadata{
 				IsCanonical:     true,
 				CanonicalSource: "mysource",
-				LocationType:    "remote_git",
+				LocationType:    RemoteGit,
 				HasVersion:      true,
 				Version:         "v1.2.3",
 				Vars: DownloaderVars{
@@ -164,7 +164,7 @@ func TestRemoteGitDownloader_Download(t *testing.T) {
 			wantDLMeta: &DownloadMetadata{
 				IsCanonical:     true,
 				CanonicalSource: "mysource",
-				LocationType:    "remote_git",
+				LocationType:    RemoteGit,
 				HasVersion:      true,
 				Version:         "v1.2.3",
 				Vars: DownloaderVars{
@@ -234,7 +234,7 @@ func TestRemoteGitDownloader_Download(t *testing.T) {
 			wantDLMeta: &DownloadMetadata{
 				IsCanonical:     true,
 				CanonicalSource: "mysource",
-				LocationType:    "remote_git",
+				LocationType:    RemoteGit,
 				HasVersion:      true,
 				Version:         abctestutil.MinimalGitHeadSHA,
 				Vars: DownloaderVars{
@@ -263,7 +263,7 @@ func TestRemoteGitDownloader_Download(t *testing.T) {
 			wantDLMeta: &DownloadMetadata{
 				IsCanonical:     true,
 				CanonicalSource: "mysource",
-				LocationType:    "remote_git",
+				LocationType:    RemoteGit,
 				HasVersion:      true,
 				Version:         "v1.2.3",
 				Vars: DownloaderVars{

--- a/templates/common/templatesource/source.go
+++ b/templates/common/templatesource/source.go
@@ -23,7 +23,22 @@ import (
 	"github.com/abcxyz/abc/templates/common/specutil"
 )
 
-const Latest = "latest"
+const (
+	Latest = "latest"
+
+	LocalNonGit LocationType = "local" // local never appears in a manifest, because only canonical template sources appear in a manifest
+	LocalGit    LocationType = "local_git"
+	RemoteGit   LocationType = "remote_git"
+)
+
+// LocationType is an enum describing where we got a template from.
+type LocationType string
+
+func (l LocationType) IsRemote() bool {
+	// If we ever add a new remote location type (like "remote_svn") then we
+	// should update this function to return true for that one too.
+	return l == RemoteGit
+}
 
 // sourceParser is implemented for each particular kind of template source (git,
 // local file, etc.).

--- a/templates/common/templatesource/upgrade.go
+++ b/templates/common/templatesource/upgrade.go
@@ -28,9 +28,9 @@ var (
 	// will be parsed. E.g. with location type "remote_git" we expect the
 	// location to look like "github.com/foo/bar/baz". With location type
 	// "local_git" we expect the location to look like a local path like "a/b".
-	upgradeDownloaderFactories = map[string]upgradeDownloaderFactory{
-		LocTypeRemoteGit: remoteGitUpgradeDownloaderFactory,
-		LocTypeLocalGit:  localGitUpgradeDownloaderFactory,
+	upgradeDownloaderFactories = map[LocationType]upgradeDownloaderFactory{
+		RemoteGit: remoteGitUpgradeDownloaderFactory,
+		LocalGit:  localGitUpgradeDownloaderFactory,
 	}
 
 	// Used only when location type is remote_git. Parses a string like
@@ -71,7 +71,7 @@ type ForUpgradeParams struct {
 	CanonicalLocation string
 
 	// One of local_git, remote_git, etc.
-	LocType string
+	LocType LocationType
 
 	// The value of --git-protocol.
 	GitProtocol string

--- a/templates/common/templatesource/upgrade_test.go
+++ b/templates/common/templatesource/upgrade_test.go
@@ -32,7 +32,7 @@ func TestForUpgrade(t *testing.T) {
 	cases := []struct {
 		name              string
 		canonicalLocation string
-		locType           string
+		locType           LocationType
 		gitProtocol       string
 		installedInSubdir string
 		dirContents       map[string]string
@@ -43,7 +43,7 @@ func TestForUpgrade(t *testing.T) {
 		{
 			name:              "remote_git_https_no_subdir",
 			canonicalLocation: "github.com/abcxyz/abc",
-			locType:           "remote_git",
+			locType:           RemoteGit,
 			gitProtocol:       "https",
 			version:           "latest",
 			wantDownloader: &remoteGitDownloader{
@@ -57,7 +57,7 @@ func TestForUpgrade(t *testing.T) {
 		{
 			name:              "remote_git_ssh_no_subdir",
 			canonicalLocation: "github.com/abcxyz/abc",
-			locType:           "remote_git",
+			locType:           RemoteGit,
 			gitProtocol:       "ssh",
 			version:           "latest",
 			wantDownloader: &remoteGitDownloader{
@@ -71,7 +71,7 @@ func TestForUpgrade(t *testing.T) {
 		{
 			name:              "remote_git_https_subdir",
 			canonicalLocation: "github.com/abcxyz/abc/sub",
-			locType:           "remote_git",
+			locType:           RemoteGit,
 			gitProtocol:       "https",
 			version:           "latest",
 			wantDownloader: &remoteGitDownloader{
@@ -86,7 +86,7 @@ func TestForUpgrade(t *testing.T) {
 		{
 			name:              "remote_git_ssh_subdir",
 			canonicalLocation: "github.com/abcxyz/abc/sub",
-			locType:           "remote_git",
+			locType:           RemoteGit,
 			gitProtocol:       "ssh",
 			version:           "latest",
 			wantDownloader: &remoteGitDownloader{
@@ -101,7 +101,7 @@ func TestForUpgrade(t *testing.T) {
 		{
 			name:              "non_default_version",
 			canonicalLocation: "github.com/abcxyz/abc",
-			locType:           "remote_git",
+			locType:           RemoteGit,
 			gitProtocol:       "https",
 			version:           "someversion",
 			wantDownloader: &remoteGitDownloader{
@@ -115,7 +115,7 @@ func TestForUpgrade(t *testing.T) {
 		{
 			name:              "malformed_remote_git",
 			canonicalLocation: "asdfasdfasdf",
-			locType:           "remote_git",
+			locType:           RemoteGit,
 			gitProtocol:       "https",
 			wantErr:           `failed parsing canonical location "asdfasdfasdf"`,
 		},
@@ -153,7 +153,7 @@ func TestForUpgrade(t *testing.T) {
 		{
 			name:              "unknown_git_protocol",
 			canonicalLocation: "github.com/abcxyz/abc",
-			locType:           "remote_git",
+			locType:           RemoteGit,
 			gitProtocol:       "nonexistent",
 			wantErr:           `protocol "nonexistent" isn't usable with a template sourced from a remote git repo`,
 		},


### PR DESCRIPTION
In an upcoming PR, we need to distinguish between remote templates (e.g. from GitHub) and local templates (e.g. in some local directory). This distinction matters for the "upgrade all templates under this directory" feature, for complex reasons that probably aren't worth going into here (feel free to ask if you're interested).

As part of this, we change the DownloadMetadata.LocationType field from a string to an enum, because we want to add an IsRemote() method to LocationType. And also because this is an exported API now, and that suggests being cleaner with types.