### PR TITLE
Minor tweaks to dialog test debugging

### DIFF
--- a/templates/commands/goldentest/test_funcs.go
+++ b/templates/commands/goldentest/test_funcs.go
@@ -30,6 +30,7 @@ import (
 	"github.com/abcxyz/abc/templates/common"
 	"github.com/abcxyz/abc/templates/common/errs"
 	"github.com/abcxyz/abc/templates/common/render"
+	"github.com/abcxyz/abc/templates/common/specutil"
 	"github.com/abcxyz/abc/templates/common/tempdir"
 	"github.com/abcxyz/abc/templates/common/templatesource"
 	"github.com/abcxyz/abc/templates/model"
@@ -316,7 +317,7 @@ func crawlTemplatesWithGoldenTests(dir string) ([]string, error) {
 // checkIfTemplateWithTests tests whether the given path is a template that has golden tests.
 // if hasGoldenTests is true, then isTemplate is always true.
 func checkIfTemplateWithTests(path string) (isTemplate, hasGoldenTests bool, _ error) {
-	ok, err := common.Exists(filepath.Join(path, "spec.yaml"))
+	ok, err := common.Exists(filepath.Join(path, specutil.SpecFileName))
 	if err != nil {
 		return false, false, err //nolint:wrapcheck
 	}

--- a/templates/common/render/action_include.go
+++ b/templates/common/render/action_include.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 
 	"github.com/abcxyz/abc/templates/common"
+	"github.com/abcxyz/abc/templates/common/specutil"
 	"github.com/abcxyz/abc/templates/model"
 	spec "github.com/abcxyz/abc/templates/model/spec/v1beta6"
 	"github.com/abcxyz/pkg/logging"
@@ -189,7 +190,7 @@ func includeFromOneDir(ctx context.Context, inc *spec.IncludePath, sp *stepParam
 		// 2. testdata/golden directory, this is reserved for golden test usage.
 		skipPaths = append(skipPaths,
 			model.String{
-				Val: "spec.yaml",
+				Val: specutil.SpecFileName,
 			},
 			model.String{
 				Val: filepath.Join("testdata", "golden"),

--- a/templates/testutil/prompt.go
+++ b/templates/testutil/prompt.go
@@ -34,8 +34,8 @@ const (
 	// you're done debugging.
 	waitMultiplier = 1
 
-	// Timeouts are arbitrary, basically just "long enough to finish the test
-	// even if we're running on an overloaded CICD VM."
+	// Timeouts are arbitrary, basically just long enough to finish the test
+	// even if we're running on an overloaded CICD VM.
 	readTimeout    = time.Second * waitMultiplier
 	writeTimeout   = time.Second * waitMultiplier
 	overallTimeout = 5 * time.Second * waitMultiplier


### PR DESCRIPTION
 - Improve log messages to indicate what the test is currently trying to
   do
 - Make it easy to disable test timeouts so developers can debug a
   failing test at a leisurely pace.

Also change "spec.yaml" to specutil.SpecFileName. We made a constant for
this so we should use it everywhere.