### PR TITLE
Add `AddNode` function to graph, to support edgeless nodes

### DIFF
--- a/templates/common/graph/graph.go
+++ b/templates/common/graph/graph.go
@@ -47,6 +47,19 @@ func (g *Graph[T]) AddEdge(source, destination T) {
 	g.edges[source] = append(g.edges[source], destination)
 }
 
+// AddNode adds a node to the graph without adding any edges. [AddEdge]
+// implicitly creates nodes, so this function is only needed in the case where
+// you have a node with no edges to or from it.
+//
+// This function is always safe to call. You can call it before adding edges to
+// the node or after adding edges. It is idempotent.
+func (g *Graph[T]) AddNode(n T) {
+	if _, ok := g.edges[n]; ok {
+		return // we already know that this node exists
+	}
+	g.edges[n] = nil // node exists in map, but has no outgoing edges
+}
+
 // TopologicalSort performs a topological sort. For all edges a->b, the output
 // will have b before a.
 //

--- a/templates/common/graph/graph_test.go
+++ b/templates/common/graph/graph_test.go
@@ -39,6 +39,28 @@ func TestTopoSort(t *testing.T) {
 			want: [][]string{},
 		},
 		{
+			name: "one_node_no_edges",
+			g: func() *Graph[string] {
+				g := NewGraph[string]()
+				g.AddNode("a")
+				return g
+			}(),
+			want: [][]string{{"a"}},
+		},
+		{
+			name: "two_nodes_no_edges",
+			g: func() *Graph[string] {
+				g := NewGraph[string]()
+				g.AddNode("a")
+				g.AddNode("b")
+				return g
+			}(),
+			want: [][]string{
+				{"a", "b"},
+				{"b", "a"},
+			},
+		},
+		{
 			name: "one_edge",
 			g: func() *Graph[string] {
 				g := NewGraph[string]()
@@ -53,6 +75,28 @@ func TestTopoSort(t *testing.T) {
 				g := NewGraph[string]()
 				g.AddEdge("a", "b")
 				g.AddEdge("b", "c")
+				return g
+			}(),
+			want: [][]string{{"c", "b", "a"}},
+		},
+		{
+			name: "two_edges_superfluous_addnode_first",
+			g: func() *Graph[string] {
+				g := NewGraph[string]()
+				g.AddNode("a")
+				g.AddEdge("a", "b")
+				g.AddEdge("b", "c")
+				return g
+			}(),
+			want: [][]string{{"c", "b", "a"}},
+		},
+		{
+			name: "two_edges_superfluous_addnode_last",
+			g: func() *Graph[string] {
+				g := NewGraph[string]()
+				g.AddEdge("a", "b")
+				g.AddEdge("b", "c")
+				g.AddNode("a")
 				return g
 			}(),
 			want: [][]string{{"c", "b", "a"}},
@@ -79,6 +123,18 @@ func TestTopoSort(t *testing.T) {
 				g.AddEdge("a", "b")
 				g.AddEdge("b", "c")
 				g.AddEdge("c", "a")
+				return g
+			}(),
+			wantErr: &CyclicError[string]{Cycle: []string{"a", "b", "c"}},
+		},
+		{
+			name: "3_cycle_with_unconnected_node",
+			g: func() *Graph[string] {
+				g := NewGraph[string]()
+				g.AddEdge("a", "b")
+				g.AddEdge("b", "c")
+				g.AddEdge("c", "a")
+				g.AddNode("d")
 				return g
 			}(),
 			wantErr: &CyclicError[string]{Cycle: []string{"a", "b", "c"}},


### PR DESCRIPTION
Our dependency graphs often have templates that don't depend on other templates. We still want to include them in the topological sort output.