### PR TITLE
Use cmp Transformers and FilterPath for fuzzy comparison

### DIFF
--- a/templates/common/render/action_include_test.go
+++ b/templates/common/render/action_include_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -977,15 +976,7 @@ func TestActionInclude(t *testing.T) {
 
 			opts := []cmp.Option{
 				cmpopts.EquateEmpty(),
-				cmp.Comparer(func(s1, s2 string) bool {
-					// We can't write our test assertions to include the temp
-					// directory, so dynamically rewrite the paths in the output
-					// files to remove the temp directory name.
-					trim := func(s string) string {
-						return strings.TrimPrefix(s, tempDir+"/")
-					}
-					return trim(s1) == trim(s2)
-				}),
+				abctestutil.TrimStringPrefixTransformer(tempDir + "/"),
 			}
 			if diff := cmp.Diff(sp.includedFromDest, tc.wantIncludedFromDest, opts...); diff != "" {
 				t.Errorf("includedFromDest was not as expected (-got,+want): %s", diff)

--- a/templates/common/templatesource/upgrade_test.go
+++ b/templates/common/templatesource/upgrade_test.go
@@ -17,7 +17,6 @@ package templatesource
 import (
 	"context"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -187,17 +186,11 @@ func TestForUpgrade(t *testing.T) {
 
 			opts := []cmp.Option{
 				cmp.AllowUnexported(remoteGitDownloader{}, LocalDownloader{}),
-
-				// If the downloader is a local downloader, it has an
-				// unpredictable temp directory in its SrcPath field that
-				// couldn't be included in wantDownloader. Therefore, when
-				// comparing the "got" downloader to the "want" downloader, we
-				// want to strip out the temp dir.
-				cmp.Transformer("strip_temp_dir", func(l *LocalDownloader) *LocalDownloader {
-					cp := *l
-					cp.SrcPath = strings.TrimPrefix(cp.SrcPath, tempDir+"/")
-					return &cp
-				}),
+				abctestutil.TransformStructFields(
+					abctestutil.TrimStringPrefixTransformer(tempDir+"/"),
+					LocalDownloader{},
+					"SrcPath",
+				),
 			}
 			if diff := cmp.Diff(downloader, tc.wantDownloader, opts...); diff != "" {
 				t.Errorf("downloader was not as expected: %s", diff)

--- a/templates/testutil/cmp.go
+++ b/templates/testutil/cmp.go
@@ -1,0 +1,60 @@
+// Copyright 2024 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutil
+
+import (
+	"reflect"
+	"slices"
+	"strings"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// TransformStructFields is an Option to use with the cmp library that modifies
+// certain struct fields before doing the comparison. The provided transform is
+// provided to all struct fields who field name is in the "fieldNames" list and
+// whose struct type matches "structExample".
+//
+// Example invocation: trim the string "foo" from the beginning of
+// MyStruct.MyFirstField and MyStruct.MySecondField before doing the comparison.
+//
+//	cmp.Diff(x, y, abctestutil.TransformStructFields(
+//	                  abctestutil.TrimStringPrefixTransformer("foo"),
+//	                  MyStruct{}, "MyFirstField", "MySecondField")
+func TransformStructFields(transform cmp.Option, structExample interface{}, fieldNames ...string) cmp.Option {
+	return cmp.FilterPath(
+		func(p cmp.Path) bool {
+			sf, ok := p.Last().(cmp.StructField)
+			if !ok {
+				return false
+			}
+			structType := p.Index(-2).Type()
+			if structType != reflect.TypeOf(structExample) {
+				return false
+			}
+			return ok && structType == reflect.TypeOf(structExample) &&
+				slices.Contains(fieldNames, sf.Name())
+		},
+		transform)
+}
+
+// TrimStringPrefixTransformer is a Transformer function to use with the cmp
+// library that removes a prefix from strings before comparing them. See
+// the [TransformStructFields] documentation for an example.
+func TrimStringPrefixTransformer(prefix string) cmp.Option {
+	return cmp.Transformer("trim_prefix", func(s string) string {
+		return strings.TrimPrefix(s, prefix)
+	})
+}


### PR DESCRIPTION
In several places we need to discard certain parts of certain fields before comparing got vs want values in tests. This solution is much cleaner than the previous hacks, and is used in the upcoming "upgrade all" feature.