### PR TITLE
Add "upgrade all" feature

### DIFF
--- a/templates/common/flags/flags.go
+++ b/templates/common/flags/flags.go
@@ -128,3 +128,15 @@ func Prompt(p *bool) *cli.BoolVar {
 		Usage: "Prompt the user for template inputs that weren't provided as flags.",
 	}
 }
+
+// Verbose causes more output to be produced.
+func Verbose(v *bool) *cli.BoolVar {
+	return &cli.BoolVar{
+		Name:    "verbose",
+		Aliases: []string{"v"},
+		Target:  v,
+		Default: false,
+		EnvVar:  "ABC_VERBOSE",
+		Usage:   "include more output; intended for power users",
+	}
+}

--- a/templates/common/graph/graph.go
+++ b/templates/common/graph/graph.go
@@ -60,6 +60,10 @@ func (g *Graph[T]) AddNode(n T) {
 	g.edges[n] = nil // node exists in map, but has no outgoing edges
 }
 
+func (g *Graph[T]) EdgesFrom(n T) []T {
+	return g.edges[n]
+}
+
 // TopologicalSort performs a topological sort. For all edges a->b, the output
 // will have b before a.
 //

--- a/templates/common/templatesource/remote_git.go
+++ b/templates/common/templatesource/remote_git.go
@@ -165,7 +165,7 @@ func (g *remoteGitDownloader) Download(ctx context.Context, _, templateDir, _ st
 	subdirToCopy := filepath.Join(tmpDir, subdir)
 
 	if err := g.cloner.Clone(ctx, g.remote, versionToDownload, tmpDir); err != nil {
-		return nil, fmt.Errorf("Clone(): %w", err)
+		return nil, fmt.Errorf("Clone() of %s: %w", g.remote, err)
 	}
 
 	fi, err := os.Stat(subdirToCopy)


### PR DESCRIPTION
With this PR, users can just run "abc upgrade" and we'll find all the template installations under the current directory and upgrade all of them. The user no longer has to point to a manifest file, or even know what a manifest file is.

It's still missing some tests, which I'll add in a future PR. This one is already huge.

This is alpha quality at best. It probably has many critical bugs. But I've been working on this for months and it's time to get something committed.