### PR TITLE
Sort neighbors to make topological sort have stable output

### DIFF
--- a/templates/common/graph/graph.go
+++ b/templates/common/graph/graph.go
@@ -81,8 +81,12 @@ func (g *Graph[T]) TopologicalSort() ([]T, error) {
 	out := make([]T, 0, len(g.edges))
 	cycleDetect := make(map[T]struct{})
 
-	nodes := maps.Keys(g.edges) // output order must be the same across multiple CLI invocations
+	// Output order must be the same across multiple CLI invocations. If we
+	// care about the inefficient asymptotic runtime of this approach, we could
+	// switch to a heap-based algorithm and abandon this DFS algorithm.
+	nodes := maps.Keys(g.edges)
 	slices.Sort(nodes)
+
 	for _, node := range nodes {
 		if _, ok := visited[node]; !ok {
 			if err := g.dfs(node, visited, &out, cycleDetect); err != nil {

--- a/templates/common/graph/graph.go
+++ b/templates/common/graph/graph.go
@@ -15,7 +15,11 @@
 package graph
 
 import (
+	"cmp"
 	"fmt"
+	"slices"
+
+	"golang.org/x/exp/maps"
 )
 
 // CyclicError is returned when the input graph has a cycle.
@@ -28,12 +32,12 @@ func (e *CyclicError[T]) Error() string {
 }
 
 // Graph represents a directed graph.
-type Graph[T comparable] struct {
+type Graph[T cmp.Ordered] struct {
 	edges map[T][]T
 }
 
 // NewGraph creates a new graph.
-func NewGraph[T comparable]() *Graph[T] {
+func NewGraph[T cmp.Ordered]() *Graph[T] {
 	return &Graph[T]{
 		edges: make(map[T][]T),
 	}
@@ -67,6 +71,9 @@ func (g *Graph[T]) EdgesFrom(n T) []T {
 // TopologicalSort performs a topological sort. For all edges a->b, the output
 // will have b before a.
 //
+// For the same graph, the same result will be returned, regardless of the order
+// of Add*() calls, and regardless of Go's random map iteration order.
+//
 // If there is a cycle in the graph, an error message will be returned that
 // names the nodes involved in the cycle.
 func (g *Graph[T]) TopologicalSort() ([]T, error) {
@@ -74,7 +81,9 @@ func (g *Graph[T]) TopologicalSort() ([]T, error) {
 	out := make([]T, 0, len(g.edges))
 	cycleDetect := make(map[T]struct{})
 
-	for node := range g.edges {
+	nodes := maps.Keys(g.edges) // output order must be the same across multiple CLI invocations
+	slices.Sort(nodes)
+	for _, node := range nodes {
 		if _, ok := visited[node]; !ok {
 			if err := g.dfs(node, visited, &out, cycleDetect); err != nil {
 				return nil, err
@@ -91,7 +100,9 @@ func (g *Graph[T]) dfs(node T, visited map[T]struct{}, stack *[]T, cycleDetect m
 	visited[node] = struct{}{}
 	cycleDetect[node] = struct{}{}
 
-	for _, neighbor := range g.edges[node] {
+	neighbors := g.edges[node]
+	slices.Sort(neighbors) // output order must be the same across multiple CLI invocations
+	for _, neighbor := range neighbors {
 		if _, ok := visited[neighbor]; !ok {
 			if err := g.dfs(neighbor, visited, stack, cycleDetect); err != nil {
 				return err

--- a/templates/common/graph/graph_test.go
+++ b/templates/common/graph/graph_test.go
@@ -15,12 +15,13 @@
 package graph
 
 import (
+	"cmp"
 	"fmt"
 	"math"
 	"math/rand"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
+	gocmp "github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
@@ -192,11 +193,11 @@ func TestTopoSort(t *testing.T) {
 
 			got, err := tc.g.TopologicalSort()
 
-			cmp.Equal(err, tc.wantErr,
+			gocmp.Equal(err, tc.wantErr,
 				// Cycles can appear in a variety of forms ({a b c a} or
 				// {c a b c}), so we canonicalize by just checking the *set* of
 				// nodes involved in the cycle.
-				cmp.Transformer("canonicalize_cycle", func(cycle []string) map[string]struct{} {
+				gocmp.Transformer("canonicalize_cycle", func(cycle []string) map[string]struct{} {
 					out := map[string]struct{}{}
 					for _, n := range cycle {
 						out[n] = struct{}{}
@@ -210,7 +211,7 @@ func TestTopoSort(t *testing.T) {
 				anyMatched = true
 			}
 			for _, want := range tc.want {
-				if cmp.Equal(got, want, cmpopts.EquateEmpty()) {
+				if gocmp.Equal(got, want, cmpopts.EquateEmpty()) {
 					anyMatched = true
 					break
 				}
@@ -245,9 +246,8 @@ func TestTopoSortRandomGraph(t *testing.T) {
 
 // makeRandomDAG randomly generates and returns a directed acyclic graph.
 func makeRandomDAG(rand *rand.Rand) *Graph[int] {
-	const (
-		maxNodes = 20
-	)
+	const maxNodes = 20
+
 	// We generate a DAG by just iterating over a list of nodes and randomly
 	// adding edges that only go "forward" in the list. By only adding forward
 	// edges we guarantee that there are no cycles.
@@ -288,7 +288,7 @@ func intMin(x, y int) int {
 	return y
 }
 
-func assertSortIsTopological[T comparable](t *testing.T, g *Graph[T], candidateSort []T) {
+func assertSortIsTopological[T cmp.Ordered](t *testing.T, g *Graph[T], candidateSort []T) {
 	t.Helper()
 
 	seen := make(map[T]struct{}, len(g.edges))


### PR DESCRIPTION
This makes the asymptotic runtime worse, but we don't care so much right now given the anticipated sizes of our graphs.

This is important for the "upgrade all" algorithm. We want to attempt upgrades in the same order every time, especially when the user restarts an "upgrade all" operation partway through after resolving a merge conflict.