### PR TITLE
fix: --manifest-only was failing if unrelated files exist in the dest

### DIFF
--- a/templates/commands/goldentest/record.go
+++ b/templates/commands/goldentest/record.go
@@ -133,7 +133,7 @@ func recordTestCase(ctx context.Context, templateLocation string, tc *TestCase, 
 				"testdata", relToAbsSrc)
 		}
 		return common.CopyHint{
-			Overwrite: true,
+			AllowPreexisting: true,
 		}, nil
 	}
 	params := &common.CopyParams{

--- a/templates/commands/render/render.go
+++ b/templates/commands/render/render.go
@@ -124,6 +124,7 @@ func (c *Command) Run(ctx context.Context, args []string) error {
 		InputFiles:           c.flags.InputFiles,
 		KeepTempDirs:         c.flags.KeepTempDirs,
 		Manifest:             c.flags.Manifest,
+		ManifestOnly:         c.flags.ManifestOnly,
 		Prompt:               c.flags.Prompt,
 		Prompter:             c,
 		SkipInputValidation:  c.flags.SkipInputValidation,

--- a/templates/common/fs.go
+++ b/templates/common/fs.go
@@ -105,19 +105,21 @@ type CopyParams struct {
 	// either relative to the cwd or absolute. Use os.MkdirTemp() in real code
 	// and something hardcoded in tests.
 	BackupDirMaker func(FS) (string, error)
-	// // backupDir provides the path at which files will be saved before they're
-	// // overwritten.
-	// backupDir string
-	// dryRun skips actually copy anything, just checks whether the copy would
-	// be likely to succeed.
+
+	// DryRun skips actually copying anything, just checks whether the copy
+	// would be likely to succeed.
 	DryRun bool
-	// dstRoot is the output directory. May be absolute or relative.
+
+	// DstRoot is the output directory. May be absolute or relative.
 	DstRoot string
-	// srcRoot is the file or directory from which to copy. May be absolute or
+
+	// SrcRoot is the file or directory from which to copy. May be absolute or
 	// relative.
 	SrcRoot string
+
 	// FS is the filesytem to use.
 	FS FS
+
 	// visitor is an optional function that will be called for each file in the
 	// source, to allow customization of the copy operation on a per-file basis.
 	Visitor CopyVisitor
@@ -144,11 +146,11 @@ type CopyHint struct {
 	// This has no effect on directories, only files.
 	BackupIfExists bool
 
-	// Overwrite files in the destination if they already exist. The default is
-	// to conservatively fail.
+	// AllowPreexisting prevents CopyRecursive from returning error when copying
+	// over an existing file. The default is to conservatively fail.
 	//
 	// This has no effect on directories, only files.
-	Overwrite bool
+	AllowPreexisting bool
 
 	// Whether to skip this file or directory (don't write it to the
 	// destination). For directories, this will cause all files underneath the
@@ -213,7 +215,7 @@ func CopyRecursive(ctx context.Context, pos *model.ConfigPos, p *CopyParams) (ou
 			if dstInfo.IsDir() {
 				return pos.Errorf("cannot overwrite a directory with a file of the same name; destination is %q, source is %q", dst, path)
 			}
-			if !ch.Overwrite {
+			if !ch.AllowPreexisting {
 				return pos.Errorf("destination file %s already exists and overwriting was not enabled with --force-overwrite", relToSrc)
 			}
 			if ch.BackupIfExists && !p.DryRun {

--- a/templates/common/fs_test.go
+++ b/templates/common/fs_test.go
@@ -81,7 +81,7 @@ func TestCopyRecursive(t *testing.T) {
 			mkdirAllErr: fmt.Errorf("MkdirAll shouldn't be called in dry run mode"),
 		},
 		{
-			name: "dry_run_with_overwrite_doesnt_make_backups",
+			name: "dry_run_with_allow_preexisting_doesnt_make_backups",
 			srcDirContents: map[string]abctestutil.ModeAndContents{
 				"file1.txt": {Mode: 0o600, Contents: "new contents"},
 			},
@@ -90,8 +90,8 @@ func TestCopyRecursive(t *testing.T) {
 			},
 			visitor: func(relPath string, de fs.DirEntry) (CopyHint, error) {
 				return CopyHint{
-					BackupIfExists: true,
-					Overwrite:      true,
+					BackupIfExists:   true,
+					AllowPreexisting: true,
 				}, nil
 			},
 			want: map[string]abctestutil.ModeAndContents{
@@ -101,7 +101,7 @@ func TestCopyRecursive(t *testing.T) {
 			dryRun: true,
 		},
 		{
-			name: "dry_run_without_overwrite_should_detect_conflicting_files",
+			name: "dry_run_without_allow_preexisting_should_detect_conflicting_files",
 			dstDirInitialContents: map[string]abctestutil.ModeAndContents{
 				"file1.txt": {Mode: 0o600, Contents: "old contents"},
 			},
@@ -115,7 +115,7 @@ func TestCopyRecursive(t *testing.T) {
 			dryRun: true,
 			visitor: func(relPath string, de fs.DirEntry) (CopyHint, error) {
 				return CopyHint{
-					Overwrite: false,
+					AllowPreexisting: false,
 				}, nil
 			},
 			openFileErr: fmt.Errorf("OpenFile shouldn't be called in dry run mode"),
@@ -191,7 +191,7 @@ func TestCopyRecursive(t *testing.T) {
 			},
 		},
 		{
-			name: "overwriting_with_overwrite_true_should_succeed",
+			name: "overwriting_with_allow_preexisting_true_should_succeed",
 			srcDirContents: map[string]abctestutil.ModeAndContents{
 				"file1.txt": {Mode: 0o600, Contents: "new contents"},
 			},
@@ -200,7 +200,7 @@ func TestCopyRecursive(t *testing.T) {
 			},
 			visitor: func(relPath string, de fs.DirEntry) (CopyHint, error) {
 				return CopyHint{
-					Overwrite: true,
+					AllowPreexisting: true,
 				}, nil
 			},
 			want: map[string]abctestutil.ModeAndContents{
@@ -208,7 +208,7 @@ func TestCopyRecursive(t *testing.T) {
 			},
 		},
 		{
-			name: "overwriting_with_overwrite_false_should_fail",
+			name: "overwriting_with_allow_preexisting_false_should_fail",
 			srcDirContents: map[string]abctestutil.ModeAndContents{
 				"file1.txt": {Mode: 0o600, Contents: "new contents"},
 			},
@@ -224,7 +224,7 @@ func TestCopyRecursive(t *testing.T) {
 			name: "overwriting_dir_with_child_file_should_fail",
 			visitor: func(relPath string, de fs.DirEntry) (CopyHint, error) {
 				return CopyHint{
-					Overwrite: true,
+					AllowPreexisting: true,
 				}, nil
 			},
 			srcDirContents: map[string]abctestutil.ModeAndContents{
@@ -242,7 +242,7 @@ func TestCopyRecursive(t *testing.T) {
 			name: "overwriting_file_with_dir_should_fail",
 			visitor: func(relPath string, de fs.DirEntry) (CopyHint, error) {
 				return CopyHint{
-					Overwrite: true,
+					AllowPreexisting: true,
 				}, nil
 			},
 			srcDirContents: map[string]abctestutil.ModeAndContents{
@@ -312,8 +312,8 @@ func TestCopyRecursive(t *testing.T) {
 			},
 			visitor: func(relPath string, de fs.DirEntry) (CopyHint, error) {
 				return CopyHint{
-					BackupIfExists: true,
-					Overwrite:      true,
+					BackupIfExists:   true,
+					AllowPreexisting: true,
 				}, nil
 			},
 			want: map[string]abctestutil.ModeAndContents{

--- a/templates/common/render/action_include.go
+++ b/templates/common/render/action_include.go
@@ -117,7 +117,7 @@ func copyToDst(ctx context.Context, sp *stepParams, skipPaths []model.String, po
 				// scratch directory. This doesn't affect whether files in
 				// the final *destination* directory will be overwritten;
 				// that comes later.
-				Overwrite: true,
+				AllowPreexisting: true,
 			}, nil
 		},
 	}

--- a/templates/common/render/render.go
+++ b/templates/common/render/render.go
@@ -672,11 +672,11 @@ func commit(ctx context.Context, commitDryRun bool, p *Params, scratchDir string
 		// Edge case 3: we're in "manifest only" mode, which means that we don't
 		// want to output any files except the manifest.
 		_, ok := includedFromDest[relPath]
-		overwrite := ok || p.ForceOverwrite || p.ManifestOnly
+		allowPreexisting := ok || p.ForceOverwrite || p.ManifestOnly
 
 		return common.CopyHint{
 			BackupIfExists:   p.Backups,
-			AllowPreexisting: overwrite,
+			AllowPreexisting: allowPreexisting,
 		}, nil
 	}
 

--- a/templates/common/render/render.go
+++ b/templates/common/render/render.go
@@ -604,8 +604,7 @@ func commitTentatively(ctx context.Context, p *Params, cp *commitParams) (manife
 	}
 
 	for _, dryRun := range []bool{true, false} {
-		commitDryRun := dryRun || p.ManifestOnly
-		outputHashes, err := commit(ctx, commitDryRun, p, cp.scratchDir, cp.includedFromDest)
+		outputHashes, err := commit(ctx, dryRun, p, cp.scratchDir, cp.includedFromDest)
 		if err != nil {
 			return "", err
 		}
@@ -638,10 +637,10 @@ func commitTentatively(ctx context.Context, p *Params, cp *commitParams) (manife
 // The return value is a map containing a SHA256 hash of each file in
 // scratchDir. The keys are paths relative to scratchDir, using forward slashes
 // regardless of the OS.
-func commit(ctx context.Context, dryRun bool, p *Params, scratchDir string, includedFromDest map[string]string) (map[string][]byte, error) {
+func commit(ctx context.Context, commitDryRun bool, p *Params, scratchDir string, includedFromDest map[string]string) (map[string][]byte, error) {
 	logger := logging.FromContext(ctx).With("logger", "commit")
 
-	if !dryRun {
+	if !commitDryRun {
 		// Output dirs will be created as needed, but we'll still create the
 		// output dir here to handle the edge case where the template generates
 		// no output files. In that case, the output directory should be created
@@ -658,18 +657,26 @@ func commit(ctx context.Context, dryRun bool, p *Params, scratchDir string, incl
 				relPath, common.ABCInternalDir)
 		}
 
+		// In any of these cases, we enable overwriting:
+		//
+		// Edge case 1: this file was "include"d from the *destination*
+		// directory (rather than the template directory), and is therefore
+		// always allowed to be overwritten. For example, if we grab
+		// file_to_modify.txt from the --dest dir, then we always allow ourself
+		// to write back to that file, even when --force-overwrite=false. When
+		// the template uses this feature, we know that the intent is to modify
+		// the files in place.
+		//
+		// Edge case 2: the user specified --force-overwrite.
+		//
+		// Edge case 3: we're in "manifest only" mode, which means that we don't
+		// want to output any files except the manifest.
 		_, ok := includedFromDest[relPath]
-		return common.CopyHint{
-			BackupIfExists: p.Backups,
+		overwrite := ok || p.ForceOverwrite || p.ManifestOnly
 
-			// Special case: files that were "include"d from the
-			// *destination* directory (rather than the template directory),
-			// are always allowed to be overwritten. For example, if we grab
-			// file_to_modify.txt from the --dest dir, then we always allow
-			// ourself to write back to that file, even when
-			// --force-overwrite=false. When the template uses this feature,
-			// we know that the intent is to modify the files in place.
-			Overwrite: ok || p.ForceOverwrite,
+		return common.CopyHint{
+			BackupIfExists:   p.Backups,
+			AllowPreexisting: overwrite,
 		}, nil
 	}
 
@@ -689,9 +696,17 @@ func commit(ctx context.Context, dryRun bool, p *Params, scratchDir string, incl
 		return backupDir, err //nolint:wrapcheck // err already contains path, and it will be wrapped later
 	}
 
+	// Perhaps confusing: there are two separate concepts of "dry run" happening
+	// here. There's the "commit dry run mode" and the "CopyRecursive dry run
+	// mode." If the commit dry run mode is enabled, then the CopyRecursive dry
+	// run mode is also enabled. There's also another case where CopyRecursive
+	// dry run mode is enabled: when --manifest-only is turned on, which means
+	// we never write any output files except the manifest.
+	copyDryRun := commitDryRun || p.ManifestOnly
+
 	params := &common.CopyParams{
 		BackupDirMaker: backupDirMaker,
-		DryRun:         dryRun,
+		DryRun:         copyDryRun,
 		DstRoot:        p.OutDir,
 		Hasher:         sha256.New,
 		OutHashes:      map[string][]byte{},
@@ -702,7 +717,7 @@ func commit(ctx context.Context, dryRun bool, p *Params, scratchDir string, incl
 	if err := common.CopyRecursive(ctx, nil, params); err != nil {
 		return nil, fmt.Errorf("failed writing to --dest directory: %w", err)
 	}
-	if dryRun {
+	if commitDryRun {
 		logger.DebugContext(ctx, "template render (dry run) succeeded")
 	} else {
 		logger.InfoContext(ctx, "template render succeeded")

--- a/templates/common/render/render_test.go
+++ b/templates/common/render/render_test.go
@@ -263,6 +263,62 @@ steps:
 			},
 		},
 		{
+			name: "preexisting_dest_files_with_manifest_only_flag",
+			flagInputs: map[string]string{
+				"name_to_greet":      "Bob",
+				"emoji_suffix":       "🐈",
+				"ending_punctuation": "!",
+			},
+			templateContents: map[string]string{
+				"myfile.txt":           "Some random stuff",
+				"spec.yaml":            specContents,
+				"file1.txt":            "my favorite color is blue",
+				"dir1/file_in_dir.txt": "file_in_dir contents",
+				"dir2/file2.txt":       "file2 contents",
+			},
+			flagManifest:     true,
+			flagManifestOnly: true,
+			existingDestContents: map[string]string{
+				"file1.txt": "existing contents",
+			},
+			wantDestContents: map[string]string{
+				"file1.txt": "existing contents",
+			},
+			wantManifest: &manifest.Manifest{
+				CreationTime:     clk.Now(),
+				ModificationTime: clk.Now(),
+				TemplateDirhash:  mdl.S("h1:Gym1rh37Q4e6h72ELjloc4lfVPR6B6tuRaLnFmakAYo="),
+				Inputs: []*manifest.Input{
+					{
+						Name:  mdl.S("emoji_suffix"),
+						Value: mdl.S("\U0001F408"),
+					},
+					{
+						Name:  mdl.S("ending_punctuation"),
+						Value: mdl.S("!"),
+					},
+					{
+						Name:  mdl.S("name_to_greet"),
+						Value: mdl.S("Bob"),
+					},
+				},
+				OutputFiles: []*manifest.OutputFile{
+					{
+						File: mdl.S("dir1/file_in_dir.txt"),
+						Hash: mdl.S("h1:IeeGbHh8lPKI7ISJDiQTcNzKT/kATZ6IBgL4PbzOE4M="),
+					},
+					{
+						File: mdl.S("dir2/file2.txt"),
+						Hash: mdl.S("h1:AUDAxmpkSrLdJ6xVNvIMw3PW/RiW+YOOy0WVZ13aAfo="),
+					},
+					{
+						File: mdl.S("file1.txt"),
+						Hash: mdl.S("h1:UQ18krF3vW1ggpVvzlSWqmU0l4Fsuskdq7PaT9KHZ/4="),
+					},
+				},
+			},
+		},
+		{
 			name:           "simple_success_with_input_file_flag",
 			inputFileNames: []string{"inputs.yaml"},
 			inputFileContents: map[string]string{


### PR DESCRIPTION
In the just submitted PR #582, there was a bug: if the template outputted any files that already existed in the destination, the render operation would fail. However, in --manifest-only mode, this is fine and expected. These files *should* already exist.

Renamed CopyParams.Overwrite to CopyParams.AllowExisting to reflect that it's now used in situations where an overwrite is not actually occurring; now it's just a flag to indicate "don't fail if the file exists in the destination, which doesn't necessarily imply that it will be overwritten."