### PR TITLE
fix: "upgrade all" should halt on merge conflict

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -33,6 +33,18 @@
                 "${workspaceFolder}/examples/templates/render/hello_jupiter",
                 "example_test"
             ]
-        }
+        },
+
+        {
+            "name": "Debug abc upgrade",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            "program": "cmd/abc/abc.go",
+            "args": [
+                "upgrade",
+                "/usr/local/google/home/revell/git/abcxyz/infra-gcp"
+            ]
+        },
     ]
 }


### PR DESCRIPTION
When a template fails to upgrade due to conflicts between the template and local edits, we should stop upgrading any further templates until the merge conflicts are resolved.

It used to work this way, but broke in a refactor by accident. I added a test to prevent regressing on this behavior again.