### PR TITLE
Adjust the suggested commands to continue an upgrade

### DIFF
--- a/templates/commands/upgrade/upgrade.go
+++ b/templates/commands/upgrade/upgrade.go
@@ -231,10 +231,9 @@ func summarizeResult(r *upgrade.ManifestResult, location string) string {
 		}
 		fmt.Fprintf(&out, `
 
-After manually resolving the merge conflict, run this command to continue
-upgrading other template installations that may exist:
-
-  abc upgrade %s`, location)
+After manually resolving the merge conflict, re-run the upgrade command to
+upgrade any other rendered templates in this location that may still need
+upgrading.`)
 
 		return out.String()
 	case upgrade.PatchReversalConflict:
@@ -259,10 +258,9 @@ upgrading other template installations that may exist:
 			resumeFrom = fmt.Sprintf(" --resume-from=%s", r.ManifestPath)
 		}
 		fmt.Fprintf(&out, `
-After manually applying the rejected hunks, run this command to continue:
-
-  abc upgrade %s --already-resolved=%s%s`,
-			shellescape.Quote(location), strings.Join(relPaths, ","), resumeFrom)
+After manually applying the rejected hunks, re-run the upgrade command with
+--already-resolved=%s%s`,
+			strings.Join(relPaths, ","), resumeFrom)
 		return out.String()
 	}
 	panic("unreachable") // the go lint exhaustive check prevents this

--- a/templates/commands/upgrade/upgrade.go
+++ b/templates/commands/upgrade/upgrade.go
@@ -258,8 +258,11 @@ upgrading.`)
 			resumeFrom = fmt.Sprintf(" --resume-from=%s", r.ManifestPath)
 		}
 		fmt.Fprintf(&out, `
+
 After manually applying the rejected hunks, re-run the upgrade command with
---already-resolved=%s%s`,
+these flags:
+
+  --already-resolved=%s%s`,
 			strings.Join(relPaths, ","), resumeFrom)
 		return out.String()
 	}

--- a/templates/commands/upgrade/upgrade_test.go
+++ b/templates/commands/upgrade/upgrade_test.go
@@ -129,10 +129,9 @@ your file was renamed to: greet.txt.abcmerge_locally_edited
 incoming file: greet.txt.abcmerge_from_new_template
 --
 
-After manually resolving the merge conflict, run this command to continue
-upgrading other template installations that may exist:
-
-  abc upgrade TEMPDIR/dest_dir/.abc/manifest_..%2Ftemplate_dir_1970-01-01T00:00:00Z.lock.yaml
+After manually resolving the merge conflict, re-run the upgrade command to
+upgrade any other rendered templates in this location that may still need
+upgrading.
 `,
 		},
 		{

--- a/templates/commands/upgrade/upgrade_test.go
+++ b/templates/commands/upgrade/upgrade_test.go
@@ -191,9 +191,11 @@ steps:
 your file: TEMPDIR/dest_dir/hello.txt
 Rejected hunks for you to apply: TEMPDIR/dest_dir/hello.txt.patch.rej
 --
-After manually applying the rejected hunks, run this command to continue:
 
-  abc upgrade TEMPDIR/dest_dir/.abc/manifest_..%2Ftemplate_dir_1970-01-01T00:00:00Z.lock.yaml --already-resolved=hello.txt
+After manually applying the rejected hunks, re-run the upgrade command with
+these flags:
+
+  --already-resolved=hello.txt
 `,
 			wantErr: []string{"exit code 2"},
 		},
@@ -567,10 +569,9 @@ your file was renamed to: some/other/file.txt.abcmerge_locally_edited
 incoming file: some/other/file.txt.abcmerge_from_new_template
 --
 
-After manually resolving the merge conflict, run this command to continue
-upgrading other template installations that may exist:
-
-  abc upgrade my-location`,
+After manually resolving the merge conflict, re-run the upgrade command to
+upgrade any other rendered templates in this location that may still need
+upgrading.`,
 		},
 		{
 			name: "reversal_conflict",
@@ -600,9 +601,11 @@ Rejected hunks for you to apply: /my/template/output/dir/some/path.txt.patch.rej
 your file: /my/template/output/dir/some/other/path.txt
 Rejected hunks for you to apply: /my/template/output/dir/some/other/path.txt.patch.rej
 --
-After manually applying the rejected hunks, run this command to continue:
 
-  abc upgrade my-location --already-resolved=some/path.txt,some/other/path.txt --resume-from=/foo/bar/my_manifest.yaml`,
+After manually applying the rejected hunks, re-run the upgrade command with
+these flags:
+
+  --already-resolved=some/path.txt,some/other/path.txt --resume-from=/foo/bar/my_manifest.yaml`,
 		},
 
 		{
@@ -633,9 +636,11 @@ Rejected hunks for you to apply: /my/template/output/dir/some/?!@#$%^&*()[]{}.tx
 your file: /my/template/output/dir/some/?!@#$%^&*()[]{}.txt
 Rejected hunks for you to apply: /my/template/output/dir/some/?!@#$%^&*()[]{}.txt.patch.rej
 --
-After manually applying the rejected hunks, run this command to continue:
 
-  abc upgrade my-location --already-resolved='a?b!c@d#e$f` + "`" + `g-h^i&j'"'"'k*l(m)n[o]p{q}r.txt','a;b'"'"'c,d.e?f~g"h'"'"'i.txt' --resume-from=/foo/bar/my_manifest.yaml`,
+After manually applying the rejected hunks, re-run the upgrade command with
+these flags:
+
+  --already-resolved='a?b!c@d#e$f` + "`" + `g-h^i&j'"'"'k*l(m)n[o]p{q}r.txt','a;b'"'"'c,d.e?f~g"h'"'"'i.txt' --resume-from=/foo/bar/my_manifest.yaml`,
 		},
 	}
 

--- a/templates/common/upgrade/upgrade.go
+++ b/templates/common/upgrade/upgrade.go
@@ -49,6 +49,9 @@ import (
 
 // TODO(upgrade):
 //   - add "abort if conflict" feature
+//   - store the branch-to-upgrade-from in the manifest instead of always using
+//     "latest", so we can support use cases that installed from main, and using
+//     "latest" would actually be a downgrade.
 //   - rethink overly complex manifest file name?
 //   - validate that manifest paths don't contain traversals
 //   - add "check for update and exit" feature


### PR DESCRIPTION
When the upgrade operation is interrupted due to a merge conflict that needs to be manually resolved, we instruct the user how to continue the upgrade by running a command. Before this PR, we attempted to print the exact command to run to continue the upgrade. But I realized that this approach was flawed because we need to print all the flag values that might be needed (like --version). These flags may or may not have been provided by the user in their upgrade command.

That would have been too complex. So the new solution in this PR is to tell the user to re-run their previous upgrade command with a certain flag added, without attempting to provide the full set of flags.