### PR TITLE
Clone entire repos instead of only the requested version

### DIFF
--- a/templates/common/fs.go
+++ b/templates/common/fs.go
@@ -124,7 +124,7 @@ type CopyParams struct {
 	// source, to allow customization of the copy operation on a per-file basis.
 	Visitor CopyVisitor
 
-	// Return [ErrSymlinkForbidden] if any symlinks are found when copying.
+	// Return [SymlinkForbiddenError] if any symlinks are found when copying.
 	//
 	// Why are symlinks risky in a template?
 	//
@@ -175,15 +175,15 @@ type CopyHint struct {
 	Skip bool
 }
 
-// ErrSymlinkForbidden is the type returned from CopyRecursive in the case where
+// SymlinkForbiddenError is the type returned from CopyRecursive in the case where
 // ForbidSymlinks is configured to true, and a symlink is encountered in the
 // source directory.
-type ErrSymlinkForbidden struct {
+type SymlinkForbiddenError struct {
 	// The relative path where the symlink was found. Relative to SrcRoot.
 	Path string
 }
 
-func (e *ErrSymlinkForbidden) Error() string {
+func (e *SymlinkForbiddenError) Error() string {
 	return fmt.Sprintf("a symlink was found at %q, but symlinks are forbidden here", e.Path)
 }
 
@@ -209,7 +209,7 @@ func CopyRecursive(ctx context.Context, pos *model.ConfigPos, p *CopyParams) (ou
 
 		isSymlink := (de.Type() & fs.ModeSymlink) > 0
 		if isSymlink && p.ForbidSymlinks {
-			return &ErrSymlinkForbidden{Path: relToSrc}
+			return &SymlinkForbiddenError{Path: relToSrc}
 		}
 
 		var ch CopyHint

--- a/templates/common/fs.go
+++ b/templates/common/fs.go
@@ -133,12 +133,12 @@ type CopyParams struct {
 	//  - Users might be surprised if a template outputs a symlink, which
 	//    could point to any location outside the render destination dir.
 	//
-	// We're trying to provide a bit of protect for template users against
+	// In general, symlinks could cause all kinds of surprising behavior. We're
+	// trying to provide a bit of protection for template users against
 	// malicious or overzealous template authors.
 	//
-	// In general, it could cause all kinds of surprising behavior. We could
-	// be more permissive in the future and allow symlinks to exist in the
-	// repo as long as they're not involved with the template.
+	// We could be more permissive in the future and allow symlinks to exist in
+	// the repo as long as they're not involved with the template.
 	ForbidSymlinks bool
 
 	// If Hasher and OutHashes are not nil, then each copied file will be hashed
@@ -175,7 +175,11 @@ type CopyHint struct {
 	Skip bool
 }
 
+// ErrSymlinkForbidden is the type returned from CopyRecursive in the case where
+// ForbidSymlinks is configured to true, and a symlink is encountered in the
+// source directory.
 type ErrSymlinkForbidden struct {
+	// The relative path where the symlink was found. Relative to SrcRoot.
 	Path string
 }
 

--- a/templates/common/fs_test.go
+++ b/templates/common/fs_test.go
@@ -559,7 +559,7 @@ func TestCopyRecursive_ForbidSymlinks(t *testing.T) {
 			if tc.wantErrPath == "" {
 				t.Fatalf("got an unexpected error %q", err)
 			}
-			var symlinkErr *ErrSymlinkForbidden
+			var symlinkErr *SymlinkForbiddenError
 			if !errors.As(err, &symlinkErr) {
 				t.Fatalf("got unexpected error type %T: %v", err, err)
 			}

--- a/templates/common/fs_test.go
+++ b/templates/common/fs_test.go
@@ -545,10 +545,9 @@ func TestCopyRecursive_ForbidSymlinks(t *testing.T) {
 			destTempDir := t.TempDir()
 			ctx := context.Background()
 			err := CopyRecursive(ctx, nil, &CopyParams{
-				FS:             &RealFS{},
-				SrcRoot:        sourceTempDir,
-				DstRoot:        destTempDir,
-				ForbidSymlinks: true,
+				FS:      &RealFS{},
+				SrcRoot: sourceTempDir,
+				DstRoot: destTempDir,
 			})
 			if err == nil {
 				if tc.wantErrPath != "" {

--- a/templates/common/fs_test.go
+++ b/templates/common/fs_test.go
@@ -481,7 +481,7 @@ func TestCopyRecursive(t *testing.T) {
 	}
 }
 
-func TestCopyRecursive_SymlinkHandling(t *testing.T) {
+func TestCopyRecursive_ForbidSymlinks(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
@@ -530,10 +530,6 @@ func TestCopyRecursive_SymlinkHandling(t *testing.T) {
 			sourceTempDir := t.TempDir()
 
 			for _, r := range tc.regularFiles {
-				path := filepath.Join(sourceTempDir, r)
-				if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-					t.Fatal(err)
-				}
 				abctestutil.Overwrite(t, sourceTempDir, r, "contents")
 			}
 			for _, s := range tc.symlinks {

--- a/templates/common/git/git.go
+++ b/templates/common/git/git.go
@@ -35,7 +35,7 @@ import (
 // "remote" may be any format accepted by git, such as
 // https://github.com/abcxyz/abc.git or git@github.com:abcxyz/abc.git .
 func Clone(ctx context.Context, remote, outDir string) error {
-	_, _, err := run.Simple(ctx, "git", "clone", remote, outDir)
+	_, _, err := run.Simple(ctx, "git", "clone", "--", remote, outDir)
 	if err != nil {
 		return err //nolint:wrapcheck
 	}
@@ -79,6 +79,17 @@ func findSymlinks(dir string) ([]string, error) {
 	}
 
 	return out, nil
+}
+
+// Checkout checks out the provided version (branch, tag, or SHA) from the
+// already-cloned given git workspace. It uses the git CLI already installed on
+// the system.
+func Checkout(ctx context.Context, version, workspaceDir string) error {
+	_, _, err := run.Simple(ctx, "git", "-C", workspaceDir, "checkout", "--", version)
+	if err != nil {
+		return err //nolint:wrapcheck
+	}
+	return nil
 }
 
 // LocalTags looks up the tags in the given locally cloned repo. If there are no tags,

--- a/templates/common/git/git.go
+++ b/templates/common/git/git.go
@@ -21,7 +21,6 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
@@ -29,8 +28,6 @@ import (
 	"github.com/abcxyz/abc/templates/common"
 	"github.com/abcxyz/abc/templates/common/run"
 )
-
-var sha = regexp.MustCompile("^[0-9a-f]{40}$")
 
 // Clone checks out the given repo.
 // It uses the git CLI already installed on the system.

--- a/templates/common/git/git.go
+++ b/templates/common/git/git.go
@@ -52,7 +52,7 @@ func Clone(ctx context.Context, remote, outDir string) error {
 // what "git checkout" does in that case, and check out the branch.
 //
 // If the version does not exist as a branch, tag, or SHA in this repo, then
-// *ErrNoSuchVersion will be returned.
+// *NoSuchVersionError will be returned.
 func Checkout(ctx context.Context, version, workspaceDir string) error {
 	// Note to maintainers: you might be asking: shouldn't we use "--", like
 	// "git checkout -- $branch_tag_or_sha" ? That *seems* like a good idea, except
@@ -71,7 +71,7 @@ func Checkout(ctx context.Context, version, workspaceDir string) error {
 	if err != nil {
 		exitErr := &exec.ExitError{}
 		if errors.As(err, &exitErr) {
-			return &ErrNoSuchVersion{
+			return &NoSuchVersionError{
 				Version: version,
 			}
 		}
@@ -81,11 +81,13 @@ func Checkout(ctx context.Context, version, workspaceDir string) error {
 	return nil
 }
 
-type ErrNoSuchVersion struct {
+// NoSuchVersionError is returned from Checkout when the requested version
+// doesn't exist.
+type NoSuchVersionError struct {
 	Version string
 }
 
-func (e *ErrNoSuchVersion) Error() string {
+func (e *NoSuchVersionError) Error() string {
 	return fmt.Sprintf("the requested version %q doesn't exist", e.Version)
 }
 

--- a/templates/common/git/git_test.go
+++ b/templates/common/git/git_test.go
@@ -62,8 +62,13 @@ func TestLocalTags(t *testing.T) {
 	}
 
 	abctestutil.Overwrite(t, tempDir, "myfile1.txt", "some contents")
+
+	// If we don't do this, there will be an error on commit
+	mustRun(ctx, t, "git", "config", "-f", tempDir+"/.git/config", "user.email", "fake@example.com")
+	mustRun(ctx, t, "git", "config", "-f", tempDir+"/.git/config", "user.name", "Nobody")
+
 	mustRun(ctx, t, "git", "-C", tempDir, "add", "-A")
-	mustRun(ctx, t, "git", "-C", tempDir, "commit", "--no-gpg-sign", "-m", "my first commit")
+	mustRun(ctx, t, "git", "-C", tempDir, "commit", "--no-gpg-sign", "--author", "nobody <nobody>", "-m", "my first commit")
 	mustRun(ctx, t, "git", "-C", tempDir, "tag", "mytag1")
 
 	got, err = LocalTags(ctx, tempDir)
@@ -77,7 +82,7 @@ func TestLocalTags(t *testing.T) {
 
 	abctestutil.Overwrite(t, tempDir, "myfile2.txt", "some contents")
 	mustRun(ctx, t, "git", "-C", tempDir, "add", "-A")
-	mustRun(ctx, t, "git", "-C", tempDir, "commit", "--no-gpg-sign", "-m", "my second commit")
+	mustRun(ctx, t, "git", "-C", tempDir, "commit", "--no-gpg-sign", "--author", "nobody <nobody>", "-m", "my second commit")
 	mustRun(ctx, t, "git", "-C", tempDir, "tag", "mytag2")
 
 	got, err = LocalTags(ctx, tempDir)

--- a/templates/common/git/git_test.go
+++ b/templates/common/git/git_test.go
@@ -107,7 +107,7 @@ func TestClone(t *testing.T) {
 		{
 			name:   "nonexistent_remote",
 			remote: "https://example.com/foo/bar.git",
-			// The error message is completely differnet between linux and mac.
+			// The error message is completely different between linux and mac.
 			// This is the only substring that appears on both platforms. 🙃
 			wantErr: "https://example.com/foo/bar.git",
 		},

--- a/templates/common/git/git_test.go
+++ b/templates/common/git/git_test.go
@@ -105,9 +105,11 @@ func TestClone(t *testing.T) {
 			remote: "https://github.com/abcxyz/abc.git",
 		},
 		{
-			name:    "nonexistent_remote",
-			remote:  "https://example.com/foo/bar.git",
-			wantErr: "repository 'https://example.com/foo/bar.git' not found",
+			name:   "nonexistent_remote",
+			remote: "https://example.com/foo/bar.git",
+			// The error message is completely differnet between linux and mac.
+			// This is the only substring that appears on both platforms. 🙃
+			wantErr: "https://example.com/foo/bar.git",
 		},
 	}
 

--- a/templates/common/git/git_test.go
+++ b/templates/common/git/git_test.go
@@ -260,6 +260,7 @@ func TestCheckout(t *testing.T) {
 	}
 
 	for _, tc := range cases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -282,6 +283,7 @@ func TestCheckout(t *testing.T) {
 }
 
 func mustRun(ctx context.Context, tb testing.TB, args ...string) {
+	tb.Helper()
 	if _, _, err := run.Simple(ctx, args...); err != nil {
 		tb.Fatal(err)
 	}

--- a/templates/common/run/run.go
+++ b/templates/common/run/run.go
@@ -33,7 +33,7 @@ const DefaultRunTimeout = time.Minute
 // This is intended to be used for commands that run non-interactively then
 // exit.
 //
-// If the command exits with a nonzero status code, an *os.ExitError will be
+// If the command exits with a nonzero status code, an *exec.ExitError will be
 // returned.
 //
 // If the command fails, the error message will include the contents of stdout

--- a/templates/common/templatesource/localsource.go
+++ b/templates/common/templatesource/localsource.go
@@ -90,10 +90,9 @@ func (l *LocalDownloader) Download(ctx context.Context, cwd, templateDir, destDi
 		"src_path", l.SrcPath,
 		"template_dir", templateDir)
 	if err := common.CopyRecursive(ctx, nil, &common.CopyParams{
-		SrcRoot:        l.SrcPath,
-		DstRoot:        templateDir,
-		FS:             &common.RealFS{},
-		ForbidSymlinks: true,
+		SrcRoot: l.SrcPath,
+		DstRoot: templateDir,
+		FS:      &common.RealFS{},
 		Visitor: func(relPath string, de fs.DirEntry) (common.CopyHint, error) {
 			return common.CopyHint{
 				Skip: relPath == ".git",

--- a/templates/common/templatesource/localsource_test.go
+++ b/templates/common/templatesource/localsource_test.go
@@ -166,10 +166,10 @@ func TestLocalDownloader_Download(t *testing.T) {
 						"copy_from/spec.yaml": "spec contents",
 						"copy_from/file1.txt": "file1 contents",
 					})),
-			wantTemplateDirFiles: abctestutil.WithGitRepoAt("", map[string]string{
+			wantTemplateDirFiles: map[string]string{
 				"spec.yaml": "spec contents",
 				"file1.txt": "file1 contents",
-			}),
+			},
 			wantDLMeta: &DownloadMetadata{
 				IsCanonical:  false,
 				LocationType: LocalGit,
@@ -189,10 +189,10 @@ func TestLocalDownloader_Download(t *testing.T) {
 					"copy_from/spec.yaml": "spec contents",
 					"copy_from/file1.txt": "file1 contents",
 				}),
-			wantTemplateDirFiles: abctestutil.WithGitRepoAt("", map[string]string{
+			wantTemplateDirFiles: map[string]string{
 				"spec.yaml": "spec contents",
 				"file1.txt": "file1 contents",
-			}),
+			},
 			wantDLMeta: &DownloadMetadata{
 				IsCanonical:  false,
 				LocationType: LocalGit,

--- a/templates/common/templatesource/remote_git.go
+++ b/templates/common/templatesource/remote_git.go
@@ -158,31 +158,29 @@ func (g *remoteGitDownloader) Download(ctx context.Context, _, templateDir, _ st
 		return nil, fmt.Errorf("Clone() of %s: %w", g.remote, err)
 	}
 
-	//
-	versionToDownload, err := resolveVersion(ctx, tmpDir, g.version)
+	versionToCheckout, err := resolveVersion(ctx, tmpDir, g.version)
 	if err != nil {
 		return nil, err
 	}
 	logger.DebugContext(ctx, "resolved version from",
 		"input", g.version,
-		"to", versionToDownload)
+		"to", versionToCheckout)
 
-	// checkout to version or latest
+	// checkout version here @@
 
 	fi, err := os.Stat(subdirToCopy)
 	if err != nil {
 		if common.IsNotExistErr(err) {
-			return nil, fmt.Errorf(`the repo %q at tag %q doesn't contain a subdirectory named %q; it's possible that the template exists in the "main" branch but is not part of the release %q`, g.remote, versionToDownload, subdir, versionToDownload)
+			return nil, fmt.Errorf(`the repo %q at version %q doesn't contain a subdirectory named %q; it's possible that the template exists in the "main" branch but is not part of the release %q`, g.remote, versionToCheckout, subdir, versionToCheckout)
 		}
 		return nil, err //nolint:wrapcheck // Stat() returns a decently informative error
 	}
 	if !fi.IsDir() {
 		return nil, fmt.Errorf("the path %q is not a directory", subdir)
 	}
-
 	logger.DebugContext(ctx, "cloned repo",
 		"remote", g.remote,
-		"version", versionToDownload)
+		"version", versionToCheckout)
 
 	// Copy only the requested subdir to templateDir.
 	if err := common.CopyRecursive(ctx, nil, &common.CopyParams{
@@ -276,7 +274,7 @@ func resolveVersion(ctx context.Context, tmpDir, version string) (string, error)
 	case Latest:
 		return resolveLatest(ctx, tmpDir)
 	default:
-		logger.DebugContext(ctx, "using user provided version and skipping remote tags lookup", "version", version)
+		logger.DebugContext(ctx, "using user provided version and skipping local tags lookup", "version", version)
 		return version, nil
 	}
 }

--- a/templates/common/templatesource/remote_git.go
+++ b/templates/common/templatesource/remote_git.go
@@ -166,7 +166,9 @@ func (g *remoteGitDownloader) Download(ctx context.Context, _, templateDir, _ st
 		"input", g.version,
 		"to", versionToCheckout)
 
-	// checkout version here @@
+	if err := git.Checkout(ctx, versionToCheckout, tmpDir); err != nil {
+		return nil, fmt.Errorf("Checkout(): %w", err)
+	}
 
 	fi, err := os.Stat(subdirToCopy)
 	if err != nil {

--- a/templates/common/templatesource/remote_git.go
+++ b/templates/common/templatesource/remote_git.go
@@ -186,10 +186,9 @@ func (g *remoteGitDownloader) Download(ctx context.Context, _, templateDir, _ st
 
 	// Copy only the requested subdir to templateDir.
 	if err := common.CopyRecursive(ctx, nil, &common.CopyParams{
-		DstRoot:        templateDir,
-		SrcRoot:        subdirToCopy,
-		ForbidSymlinks: true,
-		FS:             &common.RealFS{},
+		DstRoot: templateDir,
+		SrcRoot: subdirToCopy,
+		FS:      &common.RealFS{},
 		Visitor: func(relPath string, de fs.DirEntry) (common.CopyHint, error) {
 			return common.CopyHint{
 				Skip: relPath == ".git",

--- a/templates/common/templatesource/remote_git.go
+++ b/templates/common/templatesource/remote_git.go
@@ -186,9 +186,10 @@ func (g *remoteGitDownloader) Download(ctx context.Context, _, templateDir, _ st
 
 	// Copy only the requested subdir to templateDir.
 	if err := common.CopyRecursive(ctx, nil, &common.CopyParams{
-		DstRoot: templateDir,
-		SrcRoot: subdirToCopy,
-		FS:      &common.RealFS{},
+		DstRoot:        templateDir,
+		SrcRoot:        subdirToCopy,
+		ForbidSymlinks: true,
+		FS:             &common.RealFS{},
 		Visitor: func(relPath string, de fs.DirEntry) (common.CopyHint, error) {
 			return common.CopyHint{
 				Skip: relPath == ".git",

--- a/templates/common/templatesource/remote_git.go
+++ b/templates/common/templatesource/remote_git.go
@@ -112,7 +112,6 @@ func newRemoteGitDownloader(p *newRemoteGitDownloaderParams) (Downloader, bool, 
 		cloner:          &realCloner{},
 		remote:          remote,
 		subdir:          subdir,
-		tagser:          &realTagser{},
 		version:         version,
 	}, true, nil
 }
@@ -131,7 +130,6 @@ type remoteGitDownloader struct {
 	canonicalSource string
 
 	cloner cloner
-	tagser tagser
 }
 
 // Download implements Downloader.
@@ -143,14 +141,6 @@ func (g *remoteGitDownloader) Download(ctx context.Context, _, templateDir, _ st
 	if err != nil {
 		return nil, fmt.Errorf("invalid subdirectory: %w", err)
 	}
-
-	versionToDownload, err := resolveVersion(ctx, g.tagser, g.remote, g.version)
-	if err != nil {
-		return nil, err
-	}
-	logger.DebugContext(ctx, "resolved version from",
-		"input", g.version,
-		"to", versionToDownload)
 
 	// Rather than cloning directly into templateDir, we clone into a temp dir.
 	// It would be incorrect to clone the whole repo into templateDir if the
@@ -164,9 +154,20 @@ func (g *remoteGitDownloader) Download(ctx context.Context, _, templateDir, _ st
 	}
 	subdirToCopy := filepath.Join(tmpDir, subdir)
 
-	if err := g.cloner.Clone(ctx, g.remote, versionToDownload, tmpDir); err != nil {
+	if err := g.cloner.Clone(ctx, g.remote, tmpDir); err != nil {
 		return nil, fmt.Errorf("Clone() of %s: %w", g.remote, err)
 	}
+
+	//
+	versionToDownload, err := resolveVersion(ctx, tmpDir, g.version)
+	if err != nil {
+		return nil, err
+	}
+	logger.DebugContext(ctx, "resolved version from",
+		"input", g.version,
+		"to", versionToDownload)
+
+	// checkout to version or latest
 
 	fi, err := os.Stat(subdirToCopy)
 	if err != nil {
@@ -266,27 +267,27 @@ func gitTemplateVars(ctx context.Context, srcDir string) (*DownloaderVars, error
 // resolveVersion returns the latest release tag if version is "latest", and otherwise
 // just returns the input version. The return value is either a branch, tag, or
 // a long commit SHA (unless there's an error).
-func resolveVersion(ctx context.Context, t tagser, remote, version string) (string, error) {
+func resolveVersion(ctx context.Context, tmpDir, version string) (string, error) {
 	logger := logging.FromContext(ctx).With("logger", "resolveVersion")
 
 	switch version {
 	case "":
 		return "", fmt.Errorf("the template source version cannot be empty")
 	case Latest:
-		return resolveLatest(ctx, t, remote)
+		return resolveLatest(ctx, tmpDir)
 	default:
 		logger.DebugContext(ctx, "using user provided version and skipping remote tags lookup", "version", version)
 		return version, nil
 	}
 }
 
-// resolveLatest retrieves the tags from the remote repository and returns the
+// resolveLatest retrieves the tags from the locally cloned repository and returns the
 // highest semver tag. An error is thrown if no semver tags are found.
-func resolveLatest(ctx context.Context, t tagser, remote string) (string, error) {
+func resolveLatest(ctx context.Context, tmpDir string) (string, error) {
 	logger := logging.FromContext(ctx).With("logger", "resolveVersion")
 
-	logger.DebugContext(ctx, `looking up semver tags to resolve "latest"`, "git_remote", remote)
-	tags, err := t.Tags(ctx, remote)
+	logger.DebugContext(ctx, `looking up semver tags to resolve "latest"`)
+	tags, err := git.LocalTags(ctx, tmpDir)
 	if err != nil {
 		return "", fmt.Errorf("Tags(): %w", err)
 	}
@@ -309,7 +310,7 @@ func resolveLatest(ctx context.Context, t tagser, remote string) (string, error)
 	}
 
 	if len(versions) == 0 {
-		return "", fmt.Errorf(`the template source requested the "latest" release, but there were no semver-formatted tags beginning with "v" in %q. Available tags were: %v`, remote, tags)
+		return "", fmt.Errorf(`the template source requested the "latest" release, but there were no semver-formatted tags beginning with "v". Available tags were: %v`, tags)
 	}
 
 	max := slices.MaxFunc(versions, func(l, r *semver.Version) int {
@@ -321,24 +322,13 @@ func resolveLatest(ctx context.Context, t tagser, remote string) (string, error)
 
 // A fakeable interface around the lower-level git Clone function, for testing.
 type cloner interface {
-	Clone(ctx context.Context, remote, version, destDir string) error
+	Clone(ctx context.Context, remote, destDir string) error
 }
 
 type realCloner struct{}
 
-func (r *realCloner) Clone(ctx context.Context, remote, version, destDir string) error {
-	return git.Clone(ctx, remote, version, destDir) //nolint:wrapcheck
-}
-
-// A fakeable interface around the lower-level git Tags function, for testing.
-type tagser interface {
-	Tags(ctx context.Context, remote string) ([]string, error)
-}
-
-type realTagser struct{}
-
-func (r *realTagser) Tags(ctx context.Context, remote string) ([]string, error) {
-	return git.RemoteTags(ctx, remote) //nolint:wrapcheck
+func (r *realCloner) Clone(ctx context.Context, remote, destDir string) error {
+	return git.Clone(ctx, remote, destDir) //nolint:wrapcheck
 }
 
 // gitRemote returns a git remote string (see "man git-remote") for the given

--- a/templates/common/templatesource/remote_git_test.go
+++ b/templates/common/templatesource/remote_git_test.go
@@ -48,11 +48,10 @@ func TestRemoteGitDownloader_Download(t *testing.T) {
 				subdir:          "",
 				version:         "v1.2.3",
 				cloner: &fakeCloner{
-					t:           t,
-					addTag:      "v1.2.3",
-					out:         basicFiles,
-					wantRemote:  "fake-remote",
-					wantVersion: "v1.2.3",
+					t:          t,
+					addTag:     "v1.2.3",
+					out:        basicFiles,
+					wantRemote: "fake-remote",
 				},
 			},
 			want: basicFiles,
@@ -77,11 +76,10 @@ func TestRemoteGitDownloader_Download(t *testing.T) {
 				subdir:          "",
 				version:         "latest",
 				cloner: &fakeCloner{
-					t:           t,
-					addTag:      "v1.2.3",
-					out:         basicFiles,
-					wantRemote:  "fake-remote",
-					wantVersion: "v1.2.3",
+					t:          t,
+					addTag:     "v1.2.3",
+					out:        basicFiles,
+					wantRemote: "fake-remote",
 				},
 				tagser: &fakeTagser{
 					t:          t,
@@ -120,8 +118,7 @@ func TestRemoteGitDownloader_Download(t *testing.T) {
 						"my-subdir/file1.txt": "hello",
 						"file2.txt":           "world",
 					},
-					wantRemote:  "fake-remote",
-					wantVersion: "v1.2.3",
+					wantRemote: "fake-remote",
 				},
 			},
 			want: map[string]string{
@@ -154,8 +151,7 @@ func TestRemoteGitDownloader_Download(t *testing.T) {
 						"my/deep/subdir/file1.txt": "hello",
 						"file2.txt":                "world",
 					},
-					wantRemote:  "fake-remote",
-					wantVersion: "v1.2.3",
+					wantRemote: "fake-remote",
 				},
 			},
 			want: map[string]string{
@@ -191,10 +187,9 @@ func TestRemoteGitDownloader_Download(t *testing.T) {
 				subdir:  "nonexistent",
 				version: "v1.2.3",
 				cloner: &fakeCloner{
-					t:           t,
-					out:         basicFiles,
-					wantRemote:  "fake-remote",
-					wantVersion: "v1.2.3",
+					t:          t,
+					out:        basicFiles,
+					wantRemote: "fake-remote",
 				},
 			},
 			wantErr: `doesn't contain a subdirectory named "nonexistent"`,
@@ -207,10 +202,9 @@ func TestRemoteGitDownloader_Download(t *testing.T) {
 				subdir:  "file1.txt",
 				version: "v1.2.3",
 				cloner: &fakeCloner{
-					t:           t,
-					out:         basicFiles,
-					wantRemote:  "fake-remote",
-					wantVersion: "v1.2.3",
+					t:          t,
+					out:        basicFiles,
+					wantRemote: "fake-remote",
 				},
 			},
 			wantErr: "is not a directory",
@@ -224,10 +218,9 @@ func TestRemoteGitDownloader_Download(t *testing.T) {
 				subdir:          "",
 				version:         abctestutil.MinimalGitHeadSHA,
 				cloner: &fakeCloner{
-					t:           t,
-					out:         basicFiles,
-					wantRemote:  "fake-remote",
-					wantVersion: abctestutil.MinimalGitHeadSHA,
+					t:          t,
+					out:        basicFiles,
+					wantRemote: "fake-remote",
 				},
 			},
 			want: basicFiles,
@@ -252,11 +245,10 @@ func TestRemoteGitDownloader_Download(t *testing.T) {
 				subdir:          "",
 				version:         abctestutil.MinimalGitHeadSHA,
 				cloner: &fakeCloner{
-					t:           t,
-					addTag:      "v1.2.3",
-					out:         basicFiles,
-					wantRemote:  "fake-remote",
-					wantVersion: abctestutil.MinimalGitHeadSHA,
+					t:          t,
+					addTag:     "v1.2.3",
+					out:        basicFiles,
+					wantRemote: "fake-remote",
 				},
 			},
 			want: basicFiles,
@@ -305,7 +297,8 @@ func TestResolveVersion(t *testing.T) {
 		name     string
 		in       string
 		inRemote string
-		tagser   *fakeTagser
+		branches []string
+		tags     []string
 		want     string
 		wantErr  string
 	}{
@@ -348,56 +341,36 @@ func TestResolveVersion(t *testing.T) {
 			name:     "latest_lookup",
 			in:       "latest",
 			inRemote: "my-remote",
-			tagser: &fakeTagser{
-				t:          t,
-				wantRemote: "my-remote",
-				out:        []string{"v1.2.3", "v2.3.4"},
-			},
-			want: "v2.3.4",
+			tags:     []string{"v1.2.3", "v2.3.4"},
+			want:     "v2.3.4",
 		},
 		{
 			name:     "latest_lookup_v_prefix_is_required",
 			in:       "latest",
 			inRemote: "my-remote",
-			tagser: &fakeTagser{
-				t:          t,
-				wantRemote: "my-remote",
-				out:        []string{"v1.2.3", "2.3.4"},
-			},
-			want: "v1.2.3",
+			tags:     []string{"v1.2.3", "2.3.4"},
+			want:     "v1.2.3",
 		},
 		{
 			name:     "latest_lookup_ignores_alpha",
 			in:       "latest",
 			inRemote: "my-remote",
-			tagser: &fakeTagser{
-				t:          t,
-				wantRemote: "my-remote",
-				out:        []string{"v1.2.3", "v2.3.4-alpha"},
-			},
-			want: "v1.2.3",
+			tags:     []string{"v1.2.3", "v2.3.4-alpha"},
+			want:     "v1.2.3",
 		},
 		{
 			name:     "latest_lookup_ignores_nonsense_tag",
 			in:       "latest",
 			inRemote: "my-remote",
-			tagser: &fakeTagser{
-				t:          t,
-				wantRemote: "my-remote",
-				out:        []string{"v1.2.3", "nonsense"},
-			},
-			want: "v1.2.3",
+			tags:     []string{"v1.2.3", "nonsense"},
+			want:     "v1.2.3",
 		},
 		{
 			name:     "no_tags_exist",
 			in:       "latest",
 			inRemote: "my-remote",
-			tagser: &fakeTagser{
-				t:          t,
-				wantRemote: "my-remote",
-				out:        []string{},
-			},
-			wantErr: `there were no semver-formatted tags beginning with "v" in "my-remote"`,
+			tags:     []string{},
+			wantErr:  `there were no semver-formatted tags beginning with "v" in "my-remote"`,
 		},
 	}
 
@@ -408,8 +381,10 @@ func TestResolveVersion(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()
+			outDir := t.TempDir()
+			createFakeGitRepo(t, ctx, tc.branches, tc.tags, outDir)
 
-			got, err := resolveVersion(ctx, tc.tagser, tc.inRemote, tc.in)
+			got, err := resolveVersion(ctx, outDir, tc.in)
 			if diff := testutil.DiffErrString(err, tc.wantErr); diff != "" {
 				t.Fatal(diff)
 			}
@@ -422,41 +397,38 @@ func TestResolveVersion(t *testing.T) {
 }
 
 type fakeCloner struct {
-	t           *testing.T
-	out         map[string]string
-	addTag      string
-	wantRemote  string
-	wantVersion string
-}
-
-func (f *fakeCloner) Clone(ctx context.Context, remote, version, outDir string) error {
-	if remote != f.wantRemote {
-		f.t.Errorf("got remote %q, want %q", remote, f.wantRemote)
-	}
-	if version != f.wantVersion {
-		f.t.Errorf("got version %q, want %q", version, f.wantVersion)
-	}
-
-	files := abctestutil.WithGitRepoAt("", f.out)
-
-	if f.addTag != "" {
-		// Adding a tag is just creating a file under .git/refs/tags.
-		files[".git/refs/tags/"+f.addTag] = abctestutil.MinimalGitHeadSHA
-	}
-
-	abctestutil.WriteAll(f.t, outDir, files)
-	return nil
-}
-
-type fakeTagser struct {
-	t          *testing.T
-	out        []string
+	tb         testing.TB
+	out        map[string]string
+	addTag     string
 	wantRemote string
 }
 
-func (f *fakeTagser) Tags(ctx context.Context, remote string) ([]string, error) {
+func (f *fakeCloner) Clone(ctx context.Context, remote, outDir string) error {
 	if remote != f.wantRemote {
-		f.t.Errorf("got remote %q, want %q", remote, f.wantRemote)
+		f.tb.Errorf("got remote %q, want %q", remote, f.wantRemote)
 	}
-	return f.out, nil
+
+	tags := []string{}
+	if f.addTag != "" {
+		tags = append(tags, f.addTag)
+	}
+	createFakeGitRepo(f.tb, ctx, nil, tags, outDir)
+	abctestutil.WriteAll(f.tb, outDir, f.out)
+	return nil
+}
+
+func createFakeGitRepo(t testing.TB, ctx context.Context, branches, tags []string, outDir string) error {
+	files := abctestutil.WithGitRepoAt("", nil)
+
+	for _, tag := range tags {
+		// Adding a tag is just creating a file under .git/refs/tags.
+		files[".git/refs/tags/"+tag] = abctestutil.MinimalGitHeadSHA
+	}
+	for _, branch := range branches {
+		// Adding a branch is just creating a file under .git/refs/branch.
+		files[".git/refs/heads/"+branch] = abctestutil.MinimalGitHeadSHA
+	}
+
+	abctestutil.WriteAll(t, outDir, files)
+	return nil
 }

--- a/templates/common/templatesource/remote_git_test.go
+++ b/templates/common/templatesource/remote_git_test.go
@@ -18,9 +18,10 @@ import (
 	"context"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+
 	abctestutil "github.com/abcxyz/abc/templates/testutil"
 	"github.com/abcxyz/pkg/testutil"
-	"github.com/google/go-cmp/cmp"
 )
 
 func TestRemoteGitDownloader_Download(t *testing.T) {
@@ -406,7 +407,9 @@ func (f *fakeCloner) Clone(ctx context.Context, remote, outDir string) error {
 	return nil
 }
 
-func createFakeGitRepo(t testing.TB, branches, tags []string, outDir string) error {
+func createFakeGitRepo(tb testing.TB, branches, tags []string, outDir string) {
+	tb.Helper()
+
 	files := abctestutil.WithGitRepoAt("", nil)
 
 	for _, tag := range tags {
@@ -418,6 +421,5 @@ func createFakeGitRepo(t testing.TB, branches, tags []string, outDir string) err
 		files[".git/refs/heads/"+branch] = abctestutil.MinimalGitHeadSHA
 	}
 
-	abctestutil.WriteAll(t, outDir, files)
-	return nil
+	abctestutil.WriteAll(tb, outDir, files)
 }

--- a/templates/common/templatesource/source_test.go
+++ b/templates/common/templatesource/source_test.go
@@ -19,10 +19,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-
 	abctestutil "github.com/abcxyz/abc/templates/testutil"
 	"github.com/abcxyz/pkg/testutil"
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestParseSource(t *testing.T) {
@@ -48,7 +47,6 @@ func TestParseSource(t *testing.T) {
 				subdir:          "",
 				version:         "latest",
 				cloner:          &realCloner{},
-				tagser:          &realTagser{},
 			},
 		},
 		{
@@ -61,7 +59,6 @@ func TestParseSource(t *testing.T) {
 				subdir:          "",
 				version:         "v1.2.3",
 				cloner:          &realCloner{},
-				tagser:          &realTagser{},
 			},
 		},
 		{
@@ -74,7 +71,6 @@ func TestParseSource(t *testing.T) {
 				subdir:          "",
 				version:         "v1.2.3-foo/bar",
 				cloner:          &realCloner{},
-				tagser:          &realTagser{},
 			},
 		},
 		{
@@ -87,7 +83,6 @@ func TestParseSource(t *testing.T) {
 				subdir:          "mysubdir",
 				version:         "v1.2.3",
 				cloner:          &realCloner{},
-				tagser:          &realTagser{},
 			},
 		},
 		{
@@ -100,7 +95,6 @@ func TestParseSource(t *testing.T) {
 				subdir:          "my/deep/subdir",
 				version:         "v1.2.3",
 				cloner:          &realCloner{},
-				tagser:          &realTagser{},
 			},
 		},
 		{
@@ -180,7 +174,6 @@ func TestParseSource(t *testing.T) {
 				subdir:          "mysubdir",
 				version:         "latest",
 				cloner:          &realCloner{},
-				tagser:          &realTagser{},
 			},
 		},
 		{
@@ -193,7 +186,6 @@ func TestParseSource(t *testing.T) {
 				subdir:          "sub/dir",
 				version:         "latest",
 				cloner:          &realCloner{},
-				tagser:          &realTagser{},
 			},
 		},
 		{
@@ -206,7 +198,6 @@ func TestParseSource(t *testing.T) {
 				subdir:          "",
 				version:         "latest",
 				cloner:          &realCloner{},
-				tagser:          &realTagser{},
 			},
 		},
 		{
@@ -219,7 +210,6 @@ func TestParseSource(t *testing.T) {
 				subdir:          "",
 				version:         "latest",
 				cloner:          &realCloner{},
-				tagser:          &realTagser{},
 			},
 		},
 		{
@@ -232,7 +222,6 @@ func TestParseSource(t *testing.T) {
 				subdir:          "sub/dir",
 				version:         "latest",
 				cloner:          &realCloner{},
-				tagser:          &realTagser{},
 			},
 		},
 		{
@@ -245,7 +234,6 @@ func TestParseSource(t *testing.T) {
 				subdir:          "subdir",
 				version:         "latest",
 				cloner:          &realCloner{},
-				tagser:          &realTagser{},
 			},
 		},
 		{
@@ -258,7 +246,6 @@ func TestParseSource(t *testing.T) {
 				subdir:          "",
 				version:         "v1.2.3",
 				cloner:          &realCloner{},
-				tagser:          &realTagser{},
 			},
 		},
 	}

--- a/templates/common/templatesource/source_test.go
+++ b/templates/common/templatesource/source_test.go
@@ -19,9 +19,10 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+
 	abctestutil "github.com/abcxyz/abc/templates/testutil"
 	"github.com/abcxyz/pkg/testutil"
-	"github.com/google/go-cmp/cmp"
 )
 
 func TestParseSource(t *testing.T) {

--- a/templates/common/templatesource/upgrade_test.go
+++ b/templates/common/templatesource/upgrade_test.go
@@ -19,9 +19,10 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+
 	abctestutil "github.com/abcxyz/abc/templates/testutil"
 	"github.com/abcxyz/pkg/testutil"
-	"github.com/google/go-cmp/cmp"
 )
 
 func TestForUpgrade(t *testing.T) {

--- a/templates/common/templatesource/upgrade_test.go
+++ b/templates/common/templatesource/upgrade_test.go
@@ -19,10 +19,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-
 	abctestutil "github.com/abcxyz/abc/templates/testutil"
 	"github.com/abcxyz/pkg/testutil"
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestForUpgrade(t *testing.T) {
@@ -49,7 +48,6 @@ func TestForUpgrade(t *testing.T) {
 				canonicalSource: "github.com/abcxyz/abc",
 				cloner:          &realCloner{},
 				remote:          "https://github.com/abcxyz/abc.git",
-				tagser:          &realTagser{},
 				version:         "latest",
 			},
 		},
@@ -63,7 +61,6 @@ func TestForUpgrade(t *testing.T) {
 				canonicalSource: "github.com/abcxyz/abc",
 				cloner:          &realCloner{},
 				remote:          "git@github.com:abcxyz/abc.git",
-				tagser:          &realTagser{},
 				version:         "latest",
 			},
 		},
@@ -78,7 +75,6 @@ func TestForUpgrade(t *testing.T) {
 				cloner:          &realCloner{},
 				remote:          "https://github.com/abcxyz/abc.git",
 				subdir:          "sub",
-				tagser:          &realTagser{},
 				version:         "latest",
 			},
 		},
@@ -93,7 +89,6 @@ func TestForUpgrade(t *testing.T) {
 				cloner:          &realCloner{},
 				remote:          "git@github.com:abcxyz/abc.git",
 				subdir:          "sub",
-				tagser:          &realTagser{},
 				version:         "latest",
 			},
 		},
@@ -107,7 +102,6 @@ func TestForUpgrade(t *testing.T) {
 				canonicalSource: "github.com/abcxyz/abc",
 				cloner:          &realCloner{},
 				remote:          "https://github.com/abcxyz/abc.git",
-				tagser:          &realTagser{},
 				version:         "someversion",
 			},
 		},

--- a/templates/testutil/fs.go
+++ b/templates/testutil/fs.go
@@ -247,11 +247,15 @@ func TestMustGlob(tb testing.TB, glob string) (string, bool) {
 	panic("unreachable") // silence compiler warning for "missing return"
 }
 
-// Overwrite writes the given contents to dir/baseName, failing the test on
-// error.
-func Overwrite(tb testing.TB, dir, baseName, contents string) {
+// Overwrite writes the given contents to the path created by filepath.Join(dir,
+// name), failing the test on error. If the enclosing directory doesn't exist,
+// it will be created.
+func Overwrite(tb testing.TB, dir, name, contents string) {
 	tb.Helper()
-	filename := filepath.Join(dir, baseName)
+	filename := filepath.Join(dir, name)
+	if err := os.MkdirAll(filepath.Dir(filename), 0o700); err != nil {
+		tb.Fatal(err)
+	}
 	if err := os.WriteFile(filename, []byte(contents), 0o600); err != nil {
 		tb.Fatal(err)
 	}


### PR DESCRIPTION
Fixes #324 .

Before this, downloading the `latest` template version from a git repo involved two steps: querying the list of tags in the remote repo using `git ls-remote`, then running `git clone --branch` to get a particular template without downloading unnecessary history. This design was intended to avoid unnecessarily large downloads. However, there were some issues:

 - Opening a connection and authenticating twice is slow for SSH connections.
 - For users of physical security keys, two touches are needed.

So now we just do a plain `git clone` (no `--branch`), and then `git checkout` the requested version.

Also, we remove `findSymlinks()` and instead implement anti-symlink protection as a feature on `CopyRecursive` (this is the `ForbidSymlink` change).

A kevya and drevell pair-programming joint.