### PR TITLE
Use the upgrade_track from the manifest

### DIFF
--- a/templates/commands/upgrade/flags.go
+++ b/templates/commands/upgrade/flags.go
@@ -20,7 +20,6 @@ import (
 	"github.com/posener/complete/v2/predict"
 
 	"github.com/abcxyz/abc/templates/common/flags"
-	"github.com/abcxyz/abc/templates/common/templatesource"
 	"github.com/abcxyz/pkg/cli"
 )
 
@@ -75,7 +74,8 @@ type Flags struct {
 
 	Verbose bool
 
-	// The template version to upgrade to; defaults to "latest".
+	// The template version to upgrade to. If not specified, the underlying
+	// upgrade library will use the upgrade track specified in the manifest.
 	Version string
 }
 
@@ -107,9 +107,8 @@ func (f *Flags) Register(set *cli.FlagSet) {
 	r.BoolVar(flags.Prompt(&f.Prompt))
 	r.StringVar(&cli.StringVar{
 		Name:    "version",
-		Usage:   "for remote templates, the version to upgrade to; may be git tag, branch, or SHA",
+		Usage:   "for remote templates, the version to upgrade to; may be a git tag, branch, or SHA",
 		Example: "main",
-		Default: templatesource.Latest,
 		EnvVar:  "ABC_UPGRADE_TO_VERSION",
 		Target:  &f.Version,
 	})

--- a/templates/common/upgrade/upgrade.go
+++ b/templates/common/upgrade/upgrade.go
@@ -123,7 +123,7 @@ type Params struct {
 	TempDirBase string
 
 	// An optional version to update to, overriding the upgrade_track field in
-	// in the manifest.
+	// the manifest.
 	//
 	// For the case of remote git templates, this may be a branch, tag, SHA, or
 	// the special string "latest", which means "the vX.Y.Z tag that is largest
@@ -335,7 +335,7 @@ func upgrade(ctx context.Context, p *Params, absManifestPath string) (_ *Manifes
 	version := oldManifest.UpgradeTrack.Val
 	if p.Version != "" {
 		// The user specified --version, overriding the default, which is to
-		// to the version implied by the upgrade_track in the manifest.
+		// upgrade to the version implied by the upgrade_track in the manifest.
 		version = p.Version
 	}
 

--- a/templates/common/upgrade/upgrade.go
+++ b/templates/common/upgrade/upgrade.go
@@ -49,9 +49,6 @@ import (
 
 // TODO(upgrade):
 //   - add "abort if conflict" feature
-//   - store the branch-to-upgrade-from in the manifest instead of always using
-//     "latest", so we can support use cases that installed from main, and using
-//     "latest" would actually be a downgrade.
 //   - rethink overly complex manifest file name?
 //   - validate that manifest paths don't contain traversals
 //   - add "check for update and exit" feature
@@ -125,12 +122,24 @@ type Params struct {
 	// Empty string, except in tests. Will be used as the parent of temp dirs.
 	TempDirBase string
 
-	// An optional version to update to. In the case of a remote git template,
-	// it defaults to "latest", which means "the vX.Y.Z that is largest by
-	// semver ordering." In the case of a template on the local filesystem, it's
-	// ignored because we only have the one version that's on the filesystem.
+	// An optional version to update to, overriding the upgrade_track field in
+	// in the manifest.
+	//
+	// For the case of remote git templates, this may be a branch, tag, SHA, or
+	// the special string "latest", which means "the vX.Y.Z tag that is largest
+	// by semver ordering." In the case of a template on the local filesystem,
+	// it's ignored because we only have the one version that's on the
+	// filesystem.
 	Version string
+
+	// In tests, this can be overridden to provide a downloader that pretends to
+	// download a remote template. Otherwise nil.
+	downloaderFactory func(context.Context, *templatesource.ForUpgradeParams) (templatesource.Downloader, error)
 }
+
+// This is the type of templatesource.ForUpgrade, but abstracted so it can be
+// substituted with a fake.
+type downloaderFactory func(context.Context, *templatesource.ForUpgradeParams) (templatesource.Downloader, error)
 
 // ResultType is the outcome of attempting an upgrade. It may succeed, may be
 // unnecessary, or may have some sort of merge conflict.
@@ -180,12 +189,13 @@ func (r ResultType) RequiresUserAttention() bool {
 	panic("unreachable") // the go lint exhaustive check prevents this
 }
 
-var interestingnessOrder = []ResultType{AlreadyUpToDate, Success, PatchReversalConflict, MergeConflict}
+// The upgrade results, sorted in increasing order of severity.
+var resultSeverityOrder = []ResultType{AlreadyUpToDate, Success, PatchReversalConflict, MergeConflict}
 
 func resultTypeLess(l, r ResultType) bool {
 	// Subtle note: this will sort the zero value "" as the least/smallest,
 	// since slices.Index returns -1 when not found.
-	return slices.Index(interestingnessOrder, l) < slices.Index(interestingnessOrder, r)
+	return slices.Index(resultSeverityOrder, l) < slices.Index(resultSeverityOrder, r)
 }
 
 // ManifestResult is the result of upgrading a single template installation
@@ -322,12 +332,23 @@ func upgrade(ctx context.Context, p *Params, absManifestPath string) (_ *Manifes
 	tempTracker := tempdir.NewDirTracker(p.FS, p.KeepTempDirs)
 	defer tempTracker.DeferMaybeRemoveAll(ctx, &rErr)
 
-	downloader, err := templatesource.ForUpgrade(ctx, &templatesource.ForUpgradeParams{
+	version := oldManifest.UpgradeTrack.Val
+	if p.Version != "" {
+		// The user specified --version, overriding the default, which is to
+		// to the version implied by the upgrade_track in the manifest.
+		version = p.Version
+	}
+
+	downloaderFactory := p.downloaderFactory
+	if downloaderFactory == nil {
+		downloaderFactory = templatesource.ForUpgrade
+	}
+	downloader, err := downloaderFactory(ctx, &templatesource.ForUpgradeParams{
 		InstalledDir:      installedDir,
 		CanonicalLocation: oldManifest.TemplateLocation.Val,
 		LocType:           templatesource.LocationType(oldManifest.LocationType.Val),
 		GitProtocol:       p.GitProtocol,
-		Version:           p.Version,
+		Version:           version,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed creating downloader for manifest location %q of type %q with git protocol %q: %w",
@@ -449,9 +470,6 @@ func upgrade(ctx context.Context, p *Params, absManifestPath string) (_ *Manifes
 
 func fillDefaults(p *Params) (*Params, error) {
 	out := *p // shallow copy
-	if out.Version == "" {
-		out.Version = templatesource.Latest
-	}
 	if out.CWD == "" {
 		cwd, err := os.Getwd()
 		if err != nil {

--- a/templates/common/upgrade/upgrade_test.go
+++ b/templates/common/upgrade/upgrade_test.go
@@ -123,6 +123,12 @@ func TestUpgradeAll(t *testing.T) {
 		want                         *Result
 		wantErr                      string
 
+		// If these fields are set, then we'll fake a remote download using
+		// fakeXXXDownloaderFactory. This allows testing of the "upgrade_track"
+		// logic.
+		fakeDownloader               *fakeDownloader
+		fakeUpgradeDownloaderFactory *fakeUpgradeDownloaderFactory
+
 		// wantRejectFile, if set, is a path to a file that should contain the
 		// rejected hunks from the patch command. This is a hack since Mac and
 		// Linux `patch` commands generate different formats for their reject
@@ -746,6 +752,96 @@ func TestUpgradeAll(t *testing.T) {
 			}),
 		},
 		{
+			// This test simulates a template being downloaded from a remote
+			// source using a fake downloader.
+			name: "add_file_with_remote_template",
+			origTemplateDirContents: map[string]string{
+				"spec.yaml": includeDotSpec,
+				"out.txt":   "out.txt contents",
+			},
+			wantManifestBeforeUpgrade: manifestWith(outTxtOnlyManifest, func(m *manifest.Manifest) {
+				m.TemplateLocation.Val = "fake_canonical_source"
+				m.LocationType.Val = "fake_location_type"
+				m.TemplateVersion.Val = "fake_version"
+				m.UpgradeTrack.Val = "fake_upgrade_track"
+				m.OutputFiles = []*manifest.OutputFile{
+					{
+						File: mdl.S("out.txt"),
+					},
+				}
+			}),
+			localEdits: func(tb testing.TB, installedDir string) { //nolint:thelper
+				abctestutil.Overwrite(tb, installedDir, "out.txt", "identical contents")
+			},
+			templateUnionForUpgrade: map[string]string{
+				"some_other_file.txt": "some other file contents",
+			},
+			fakeDownloader: &fakeDownloader{
+				outDLMeta: &templatesource.DownloadMetadata{
+					IsCanonical:     true,
+					CanonicalSource: "fake_canonical_source",
+					LocationType:    "fake_location_type",
+					Version:         "fake_version",
+					UpgradeTrack:    "fake_upgrade_track",
+				},
+			},
+			fakeUpgradeDownloaderFactory: &fakeUpgradeDownloaderFactory{
+				wantParams: &templatesource.ForUpgradeParams{
+					LocType:           "fake_location_type",
+					CanonicalLocation: "fake_canonical_source",
+					Version:           "fake_upgrade_track",
+				},
+				outDownloader: &fakeDownloader{
+					outDLMeta: &templatesource.DownloadMetadata{
+						IsCanonical:     true,
+						CanonicalSource: "fake_canonical_source",
+						LocationType:    "fake_location_type",
+						Version:         "fake_version",
+						UpgradeTrack:    "fake_upgrade_track",
+					},
+				},
+			},
+			want: &Result{
+				Overall: Success,
+				Results: []*ManifestResult{
+					{
+						ManifestPath: ".",
+						Type:         Success,
+						NonConflicts: []ActionTaken{
+							{Action: "noop", Path: "out.txt"},
+							{Action: "writeNew", Path: "some_other_file.txt"},
+						},
+						DLMeta: &templatesource.DownloadMetadata{
+							IsCanonical:     true,
+							CanonicalSource: "fake_canonical_source",
+							LocationType:    "fake_location_type",
+							Version:         "fake_version",
+							UpgradeTrack:    "fake_upgrade_track",
+						},
+					},
+				},
+			},
+			wantDestContentsAfterUpgrade: map[string]string{
+				"out.txt":             "identical contents",
+				"some_other_file.txt": "some other file contents",
+			},
+			wantManifestAfterUpgrade: manifestWith(outTxtOnlyManifest, func(m *manifest.Manifest) {
+				m.TemplateLocation.Val = "fake_canonical_source"
+				m.LocationType.Val = "fake_location_type"
+				m.TemplateVersion.Val = "fake_version"
+				m.UpgradeTrack.Val = "fake_upgrade_track"
+				m.ModificationTime = afterUpgradeTime.UTC()
+				m.OutputFiles = []*manifest.OutputFile{
+					{
+						File: mdl.S("out.txt"),
+					},
+					{
+						File: mdl.S("some_other_file.txt"),
+					},
+				}
+			}),
+		},
+		{
 			name: "abort_on_unmerged_conflicts",
 			origTemplateDirContents: map[string]string{
 				"spec.yaml": includeDotSpec,
@@ -1116,9 +1212,6 @@ yellow is my favorite color
 			destDir := filepath.Join(tempBase, "dest_dir")
 			templateDir := filepath.Join(tempBase, "template_dir")
 
-			// Make tempBase into a valid git repo.
-			abctestutil.WriteAll(t, tempBase, abctestutil.WithGitRepoAt("", nil))
-
 			abctestutil.WriteAll(t, destDir, tc.origDestContents)
 
 			ctx := context.Background()
@@ -1126,7 +1219,11 @@ yellow is my favorite color
 			abctestutil.WriteAll(t, templateDir, tc.origTemplateDirContents)
 			clk := clock.NewMock()
 			clk.Set(beforeUpgradeTime)
-			renderResult := mustRender(t, ctx, clk, tempBase, templateDir, destDir)
+
+			if tc.fakeDownloader != nil {
+				tc.fakeDownloader.sourceDir = templateDir // inject per-testcase value that's not known when the testcase is created
+			}
+			renderResult := mustRender(t, ctx, clk, tc.fakeDownloader, tempBase, templateDir, destDir)
 
 			manifestFullPath := filepath.Join(destDir, renderResult.ManifestPath)
 
@@ -1134,12 +1231,20 @@ yellow is my favorite color
 
 			clk.Set(afterUpgradeTime) // simulate time passing between initial installation and upgrade
 
+			var dlFactory downloaderFactory
+			if tc.fakeUpgradeDownloaderFactory != nil {
+				dlFactory = tc.fakeUpgradeDownloaderFactory.New
+				tc.fakeUpgradeDownloaderFactory.tb = t
+				tc.fakeUpgradeDownloaderFactory.outDownloader.sourceDir = templateDir
+			}
+
 			params := &Params{
-				Clock:    clk,
-				CWD:      destDir,
-				FS:       &common.RealFS{},
-				Location: manifestFullPath,
-				Stdout:   os.Stdout,
+				Clock:             clk,
+				CWD:               destDir,
+				FS:                &common.RealFS{},
+				Location:          manifestFullPath,
+				Stdout:            os.Stdout,
+				downloaderFactory: dlFactory,
 			}
 
 			if tc.localEdits != nil {
@@ -1206,6 +1311,39 @@ yellow is my favorite color
 	}
 }
 
+type fakeUpgradeDownloaderFactory struct {
+	tb testing.TB
+
+	wantParams    *templatesource.ForUpgradeParams
+	outDownloader *fakeDownloader
+}
+
+func (f *fakeUpgradeDownloaderFactory) New(_ context.Context, p *templatesource.ForUpgradeParams) (templatesource.Downloader, error) {
+	opts := []cmp.Option{cmpopts.IgnoreFields(templatesource.ForUpgradeParams{}, "InstalledDir")}
+	if diff := cmp.Diff(p, f.wantParams, opts...); diff != "" {
+		f.tb.Fatalf("upgrade params were not as expected (-got,+want): %s", diff)
+	}
+	return f.outDownloader, nil
+}
+
+type fakeDownloader struct {
+	sourceDir string
+	outDLMeta *templatesource.DownloadMetadata
+}
+
+func (f *fakeDownloader) Download(ctx context.Context, cwd, templateDir, destDir string) (*templatesource.DownloadMetadata, error) {
+	if err := common.CopyRecursive(ctx, nil, &common.CopyParams{
+		SrcRoot: f.sourceDir,
+		DstRoot: templateDir,
+		FS:      &common.RealFS{},
+	}); err != nil {
+		return nil, err
+	}
+
+	return f.outDLMeta, nil
+}
+
+// TODO(upgrade): test non-canonical upgrade with manual location and version
 func TestUpgrade_NonCanonical(t *testing.T) {
 	t.Parallel()
 
@@ -1294,7 +1432,7 @@ steps:
 	ctx := context.Background()
 	clk := clock.NewMock()
 	clk.Set(beforeUpgradeTime)
-	renderResult := mustRender(t, ctx, clk, tempBase, templateDir, destDir)
+	renderResult := mustRender(t, ctx, clk, nil, tempBase, templateDir, destDir)
 
 	wantManifestBeforeUpgrade := &manifest.Manifest{
 		CreationTime:     beforeUpgradeTime,
@@ -1538,8 +1676,8 @@ func TestUpgradeAll_MultipleTemplates(t *testing.T) {
 	destDir2 := filepath.Join(destBase, "destDir2")
 	abctestutil.WriteAll(t, templateDir1, template1Files)
 	abctestutil.WriteAll(t, templateDir2, template2Files)
-	mustRender(t, ctx, clk, tempBase, templateDir1, destDir1)
-	mustRender(t, ctx, clk, tempBase, templateDir2, destDir2)
+	mustRender(t, ctx, clk, nil, tempBase, templateDir1, destDir1)
+	mustRender(t, ctx, clk, nil, tempBase, templateDir2, destDir2)
 
 	upgradedTemplate1Files := map[string]string{
 		"spec.yaml":  includeDotSpec,
@@ -1613,8 +1751,8 @@ func TestUpgradeAll_MultipleTemplatesWithResumedConflict(t *testing.T) {
 	destDir2 := filepath.Join(destBase, "destDir2")
 	abctestutil.WriteAll(t, templateDir1, template1Files)
 	abctestutil.WriteAll(t, templateDir2, template2Files)
-	mustRender(t, ctx, clk, tempBase, templateDir1, destDir1)
-	mustRender(t, ctx, clk, tempBase, templateDir2, destDir2)
+	mustRender(t, ctx, clk, nil, tempBase, templateDir1, destDir1)
+	mustRender(t, ctx, clk, nil, tempBase, templateDir2, destDir2)
 
 	abctestutil.Overwrite(t, destDir1, "myfile.txt", "my local edits")
 
@@ -1728,9 +1866,9 @@ func TestUpgradeAll_Dependency(t *testing.T) {
 	destDirC := filepath.Join(destBase, "destDirC")
 	abctestutil.WriteAll(t, templateDir1, template1Files)
 	abctestutil.WriteAll(t, templateDir2, template2Files)
-	mustRender(t, ctx, clk, tempBase, templateDir1, destDirA)
-	mustRender(t, ctx, clk, tempBase, templateDir2, destDirB)
-	mustRender(t, ctx, clk, tempBase, destDirA+"/inner", destDirC)
+	mustRender(t, ctx, clk, nil, tempBase, templateDir1, destDirA)
+	mustRender(t, ctx, clk, nil, tempBase, templateDir2, destDirB)
+	mustRender(t, ctx, clk, nil, tempBase, destDirA+"/inner", destDirC)
 
 	wantRendered := map[string]string{
 		"destDirA/outer_output_file.txt": "my old outer output file",
@@ -1862,15 +2000,19 @@ func assertManifest(ctx context.Context, tb testing.TB, whereAreWe string, want 
 	}
 }
 
-func mustRender(tb testing.TB, ctx context.Context, clk clock.Clock, tempBase, templateDir, destDir string) *render.Result {
+func mustRender(tb testing.TB, ctx context.Context, clk clock.Clock, fakeDL *fakeDownloader, tempBase, templateDir, destDir string) *render.Result {
 	tb.Helper()
 
-	downloader, err := templatesource.ParseSource(ctx, &templatesource.ParseSourceParams{
-		CWD:    tempBase,
-		Source: templateDir,
-	})
-	if err != nil {
-		tb.Fatal(err)
+	var downloader templatesource.Downloader = fakeDL
+	if fakeDL == nil {
+		var err error
+		downloader, err = templatesource.ParseSource(ctx, &templatesource.ParseSourceParams{
+			CWD:    tempBase,
+			Source: templateDir,
+		})
+		if err != nil {
+			tb.Fatal(err)
+		}
 	}
 
 	result, err := render.Render(ctx, &render.Params{

--- a/templates/common/upgrade/upgrade_test.go
+++ b/templates/common/upgrade/upgrade_test.go
@@ -1343,7 +1343,7 @@ func (f *fakeDownloader) Download(ctx context.Context, cwd, templateDir, destDir
 	return f.outDLMeta, nil
 }
 
-// TODO(upgrade): test non-canonical upgrade with manual location and version
+// TODO(upgrade): test non-canonical upgrade with manual location and version.
 func TestUpgrade_NonCanonical(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Building on #589, now we actually use the upgrade_track field that was added to the manifest to determine which branch to upgrade to. This is intended to support the use case where if a user installs from a branch, then future template upgrades will be pulled from that branch.