### PR TITLE
Implement the `upgrade --resume-from` feature

### DIFF
--- a/templates/common/upgrade/upgrade.go
+++ b/templates/common/upgrade/upgrade.go
@@ -109,6 +109,10 @@ type Params struct {
 	Prompt   bool
 	Prompter input.Prompter
 
+	// The value of --resume-from. Used after a patch reversal conflict to
+	// continue upgrading at the point where the conflict occurred.
+	ResumeFrom string
+
 	// The value of --skip-input-validation.
 	SkipInputValidation bool
 

--- a/templates/common/upgrade/upgradeall.go
+++ b/templates/common/upgrade/upgradeall.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io/fs"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/abcxyz/abc/templates/common"
@@ -107,8 +108,16 @@ func UpgradeAll(ctx context.Context, p *Params) *Result {
 		return &Result{Err: fmt.Errorf("topological sorting of manifest depencies gave an unexpected error: %w", err)}
 	}
 
+	if p.ResumeFrom != "" {
+		resumeFromIdx := slices.Index(sorted, p.ResumeFrom)
+		if resumeFromIdx == -1 {
+			return &Result{Err: fmt.Errorf("the --resume-from value %q is not valid, it must be one of %q", p.ResumeFrom, sorted)}
+		}
+		sorted = sorted[resumeFromIdx:]
+	}
+
 	out := &Result{
-		Results: make([]*ManifestResult, 0, len(manifests)),
+		Results: make([]*ManifestResult, 0, len(sorted)),
 	}
 
 	for _, m := range sorted {


### PR DESCRIPTION
When there is a "patch reversal conflict" (which happens when there's a merge conflict during upgrade on a file that was modified in place), then the user must run `abc upgrade --resume-from=some/manifest.yaml` to resume the upgrade. This PR implements the feature; the flag existed before but was unused.