### PR TITLE
Finish implementing --resume-from/--already-resolved

### DIFF
--- a/templates/commands/upgrade/flags.go
+++ b/templates/commands/upgrade/flags.go
@@ -63,7 +63,6 @@ type Flags struct {
 	// The manifest to start with, when upgrading multiple manifests. This is
 	// used when a previous upgrade operation required manual intervention, and
 	// the manual intervention is done, and the user wants to resume.
-	// TODO(upgrade): implement this feature.
 	ResumeFrom string
 
 	// See common/flags.Prompt().

--- a/templates/common/upgrade/upgrade.go
+++ b/templates/common/upgrade/upgrade.go
@@ -69,7 +69,6 @@ type Params struct {
 	// Relative paths where patch reversal has already happened. This is a flag
 	// supplied by the user. This will be set if there were merge conflicts
 	// during patch reversal that were manually resolved by the user.
-	// TODO(upgrade): implement this, should only apply to first upgrade
 	AlreadyResolved []string
 
 	Clock clock.Clock
@@ -470,18 +469,6 @@ func upgrade(ctx context.Context, p *Params, absManifestPath string) (_ *Manifes
 		NonConflicts:   nonConflicts,
 		Type:           resultType,
 	}, nil
-}
-
-func fillDefaults(p *Params) (*Params, error) {
-	out := *p // shallow copy
-	if out.CWD == "" {
-		cwd, err := os.Getwd()
-		if err != nil {
-			return nil, fmt.Errorf("os.Getwd(): %w", err)
-		}
-		out.CWD = cwd
-	}
-	return &out, nil
 }
 
 // mergeTentatively does a dry-run commit followed by a real commit.

--- a/templates/common/upgrade/upgrade_test.go
+++ b/templates/common/upgrade/upgrade_test.go
@@ -1393,7 +1393,7 @@ func TestPatchReversalManualResolution(t *testing.T) {
 	if err != nil {
 		t.Fatalf("time.LoadLocation(): %v", err)
 	}
-	render1Time := time.Date(2024, 3, 1, 4, 5, 6, 7, loc)
+	renderTime1 := time.Date(2024, 3, 1, 4, 5, 6, 7, loc)
 
 	tempBase := t.TempDir()
 	// Make tempBase into a valid git repo.
@@ -1438,12 +1438,12 @@ steps:
 
 	ctx := context.Background()
 	clk := clock.NewMock()
-	clk.Set(render1Time)
-	render1Result := mustRender(t, ctx, clk, nil, tempBase, templateDir, destDir1)
+	clk.Set(renderTime1)
+	renderResult1 := mustRender(t, ctx, clk, nil, tempBase, templateDir, destDir1)
 
 	wantManifestBeforeUpgrade := &manifest.Manifest{
-		CreationTime:     render1Time,
-		ModificationTime: render1Time,
+		CreationTime:     renderTime1,
+		ModificationTime: renderTime1,
 		TemplateLocation: mdl.S("../../template_dir"),
 		LocationType:     mdl.S("local_git"),
 		TemplateVersion:  mdl.S(abctestutil.MinimalGitHeadSHA),
@@ -1460,7 +1460,7 @@ steps:
 			},
 		},
 	}
-	manifestFullPath := filepath.Join(destDir1, render1Result.ManifestPath)
+	manifestFullPath := filepath.Join(destDir1, renderResult1.ManifestPath)
 	assertManifest(ctx, t, "before upgrade", wantManifestBeforeUpgrade, manifestFullPath)
 
 	clk.Add(time.Second)


### PR DESCRIPTION
This code runs when recovering from merge conflicts. After a merge conflict is resolved, the user runs `abc upgrade <directory> --resume-from=some-manifest.yaml --already-resolved=<list-of-files>`. In the case where there are multiple template installations to be upgraded, the `--already-resolved` flag should only apply to the first one, and later upgrades should be attempted from scratch.

The implementation is just one line, and the rest is just test updates and reorganization.