### PR TITLE
Allow templates to be upgraded even when installed from a random local dir

### DIFF
--- a/templates/commands/upgrade/flags.go
+++ b/templates/commands/upgrade/flags.go
@@ -72,6 +72,10 @@ type Flags struct {
 	// See common/flags.SkipInputValidation().
 	SkipInputValidation bool
 
+	// Upgrade to the template specified by this location, rather than the
+	// template location stored in the manifest (which is the default).
+	TemplateLocation string
+
 	Verbose bool
 
 	// The template version to upgrade to. If not specified, the underlying
@@ -112,6 +116,14 @@ func (f *Flags) Register(set *cli.FlagSet) {
 		EnvVar:  "ABC_UPGRADE_TO_VERSION",
 		Target:  &f.Version,
 	})
+	r.StringVar(&cli.StringVar{
+		Name:    "template-location",
+		Usage:   "upgrade to the template specified by this location, rather than the template location stored in the manifest (which is the default); this is useful when your template was installed from a non-canonical location and therefore has no template location stored in the manifest",
+		Example: "github.com/abcxyz/abc/t/rest_server@mybranch",
+		EnvVar:  "ABC_UPGRADE_TEMPLATE_LOCATION",
+		Target:  &f.TemplateLocation,
+	})
+
 	t := set.NewSection("TEMPLATE AUTHORS")
 	t.BoolVar(flags.DebugScratchContents(&f.DebugScratchContents))
 

--- a/templates/commands/upgrade/upgrade.go
+++ b/templates/commands/upgrade/upgrade.go
@@ -148,6 +148,7 @@ func (c *Command) Run(ctx context.Context, args []string) error {
 		SkipInputValidation:  c.flags.SkipInputValidation,
 		SkipPromptTTYCheck:   c.skipPromptTTYCheck,
 		Stdout:               c.Stdout(),
+		TemplateLocation:     c.flags.TemplateLocation,
 		Version:              c.flags.Version,
 	})
 	if result.Err != nil {

--- a/templates/common/templatesource/source.go
+++ b/templates/common/templatesource/source.go
@@ -34,12 +34,6 @@ const (
 // LocationType is an enum describing where we got a template from.
 type LocationType string
 
-func (l LocationType) IsRemote() bool {
-	// If we ever add a new remote location type (like "remote_svn") then we
-	// should update this function to return true for that one too.
-	return l == RemoteGit
-}
-
 // sourceParser is implemented for each particular kind of template source (git,
 // local file, etc.).
 type sourceParser interface {

--- a/templates/common/upgrade/upgradeall.go
+++ b/templates/common/upgrade/upgradeall.go
@@ -21,6 +21,7 @@ import (
 	"io/fs"
 	"path/filepath"
 	"slices"
+	"sort"
 	"strings"
 
 	"github.com/abcxyz/abc/templates/common"
@@ -94,18 +95,9 @@ func UpgradeAll(ctx context.Context, p *Params) *Result {
 		return &Result{Err: ErrNoManifests}
 	}
 
-	depGraph, err := depGraph(ctx, p.CWD, p.Location, manifests)
+	sorted, depGraph, err := depOrder(ctx, p.CWD, p.Location, p.TemplateLocation, manifests)
 	if err != nil {
 		return &Result{Err: err}
-	}
-
-	sorted, err := depGraph.TopologicalSort()
-	if err != nil {
-		errCycle := &graph.CyclicError[string]{}
-		if errors.As(err, &errCycle) {
-			return &Result{Err: fmt.Errorf("there is somehow a cyclic dependency among these manifests: %v", errCycle.Cycle)}
-		}
-		return &Result{Err: fmt.Errorf("topological sorting of manifest depencies gave an unexpected error: %w", err)}
 	}
 
 	if p.ResumeFrom != "" {
@@ -138,7 +130,9 @@ func UpgradeAll(ctx context.Context, p *Params) *Result {
 		}
 
 		result.ManifestPath = m
-		result.DependedOn = depGraph.EdgesFrom(m)
+		if depGraph != nil {
+			result.DependedOn = depGraph.EdgesFrom(m)
+		}
 
 		out.Results = append(out.Results, result)
 
@@ -165,6 +159,7 @@ func overallResult(results []*ManifestResult) ResultType {
 // crawlManifests finds all the template manifest files underneath the given
 // file or directory. startFrom can be either a single manifest file or a
 // directory to search recursively. Returned paths are relative to startFrom.
+// The returned slice is sorted lexicographically.
 func crawlManifests(startFrom string) ([]string, error) {
 	var manifests []string
 	err := filepath.WalkDir(startFrom, func(path string, d fs.DirEntry, err error) error {
@@ -198,7 +193,34 @@ func crawlManifests(startFrom string) ([]string, error) {
 		return nil, err //nolint:wrapcheck
 	}
 
+	sort.Strings(manifests)
+
 	return manifests, nil
+}
+
+func depOrder(ctx context.Context, cwd, upgradeLocation, localTemplateLocationOverride string, manifestsRel []string) ([]string, *graph.Graph[string], error) {
+	if localTemplateLocationOverride != "" {
+		// Subtle point: when the user provides --template-location, then that
+		// means that all the manifest cannot logically have any dependencies
+		// between them. They are all being updated from --template-location,
+		// and that is their only depdendency.
+		return manifestsRel, nil, nil
+	}
+
+	depGraph, err := depGraph(ctx, cwd, upgradeLocation, manifestsRel)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	sorted, err := depGraph.TopologicalSort()
+	if err != nil {
+		errCycle := &graph.CyclicError[string]{}
+		if errors.As(err, &errCycle) {
+			return nil, nil, fmt.Errorf("there is somehow a cyclic dependency among these manifests: %v", errCycle.Cycle)
+		}
+		return nil, nil, fmt.Errorf("topological sorting of manifest depencies gave an unexpected error: %w", err)
+	}
+	return sorted, depGraph, nil
 }
 
 // depGraph returns a dependency graph saying which manifests were output by a
@@ -260,6 +282,10 @@ func depGraph(ctx context.Context, cwd, upgradeLocation string, manifestsRel []s
 		if err != nil {
 			return nil, err
 		}
+
+		// If the manifest is at /foo/bar/.abc/manifest.yaml, then the
+		// template was installed to /foo/bar (the parent dir of the dir
+		// that contains the manifest).
 		destDir := filepath.Dir(filepath.Dir(manifestPath))
 
 		for _, outputFile := range manifest.OutputFiles {
@@ -269,9 +295,6 @@ func depGraph(ctx context.Context, cwd, upgradeLocation string, manifestsRel []s
 			}
 		}
 		if manifest.TemplateLocation.Val != "" && templatesource.LocationType(manifest.LocationType.Val) == templatesource.LocalGit {
-			// If the manifest is at /foo/bar/.abc/manifest.yaml, then the
-			// template was installed the /foo/bar (the parent dir of the dir
-			// that contains the manifest).
 			installedBySpec := filepath.Join(destDir, manifest.TemplateLocation.Val, specutil.SpecFileName)
 			manifestToSourceSpec[manifestRel] = installedBySpec
 		}


### PR DESCRIPTION
If a template is rendered from a "canonical" location, such as a github repo, then we store the source of template in the manifest. Future template upgrades will check that location for new versions of the template. But when the template is installed from a non-canonical location, like `abc render ~/alice-silly-temp-dir`, then there's no location stored in the manifest to be checked for updates.

This PR adds the "--template-location" flag to the abc upgrade command to provide a template location to upgrade to, overriding the manifest. So somebody else can come along later and do something like `abc upgrade --template-location github.com/me/myrepo/mytemplate` or `abc upgrade --template-location ~/bob-silly-temp-dir`, even if the manifest doesn't have a stored location.