### PR TITLE
For certain conflict types, leave local filenames unchanged

### DIFF
--- a/templates/commands/upgrade/upgrade_test.go
+++ b/templates/commands/upgrade/upgrade_test.go
@@ -535,9 +535,9 @@ func TestSummarizeResult(t *testing.T) {
 				ManifestPath: "foo/bar/my_manifest.yaml",
 				MergeConflicts: []upgrade.ActionTaken{
 					{
-						Action:      upgrade.EditEditConflict,
-						Explanation: "ignored",
-						Path:        "some/file.txt",
+						Action:               upgrade.EditEditConflict,
+						Explanation:          "ignored",
+						Path:                 "some/file.txt",
 						IncomingTemplatePath: "some/file.txt" + upgrade.SuffixFromNewTemplate,
 					},
 					{

--- a/templates/commands/upgrade/upgrade_test.go
+++ b/templates/commands/upgrade/upgrade_test.go
@@ -120,12 +120,10 @@ List of conflicting files:
 --
 file: color.txt
 conflict type: addAddConflict
-your file was renamed to: color.txt.abcmerge_locally_added
 incoming file: color.txt.abcmerge_from_new_template
 --
 file: greet.txt
 conflict type: editEditConflict
-your file was renamed to: greet.txt.abcmerge_locally_edited
 incoming file: greet.txt.abcmerge_from_new_template
 --
 
@@ -537,18 +535,16 @@ func TestSummarizeResult(t *testing.T) {
 				ManifestPath: "foo/bar/my_manifest.yaml",
 				MergeConflicts: []upgrade.ActionTaken{
 					{
-						Action:               upgrade.EditEditConflict,
-						Explanation:          "ignored",
-						Path:                 "some/file.txt",
-						OursPath:             "some/file.txt" + upgrade.SuffixLocallyEdited,
+						Action:      upgrade.EditEditConflict,
+						Explanation: "ignored",
+						Path:        "some/file.txt",
 						IncomingTemplatePath: "some/file.txt" + upgrade.SuffixFromNewTemplate,
 					},
 					{
 						Action:               upgrade.DeleteEditConflict,
 						Explanation:          "ignored",
 						Path:                 "some/other/file.txt",
-						OursPath:             "some/other/file.txt" + upgrade.SuffixLocallyEdited,
-						IncomingTemplatePath: "some/other/file.txt" + upgrade.SuffixFromNewTemplate,
+						IncomingTemplatePath: "some/other/file.txt" + upgrade.SuffixFromNewTemplateLocallyDeleted,
 					},
 				},
 				NonConflicts: []upgrade.ActionTaken{{Path: "should_not_appear.txt", Action: upgrade.WriteNew}},
@@ -560,13 +556,11 @@ List of conflicting files:
 --
 file: some/file.txt
 conflict type: editEditConflict
-your file was renamed to: some/file.txt.abcmerge_locally_edited
 incoming file: some/file.txt.abcmerge_from_new_template
 --
 file: some/other/file.txt
 conflict type: deleteEditConflict
-your file was renamed to: some/other/file.txt.abcmerge_locally_edited
-incoming file: some/other/file.txt.abcmerge_from_new_template
+incoming file: some/other/file.txt.abcmerge_locally_deleted_vs_new_template_version
 --
 
 After manually resolving the merge conflict, re-run the upgrade command to

--- a/templates/common/upgrade/merge.go
+++ b/templates/common/upgrade/merge.go
@@ -279,8 +279,7 @@ func mergeAll(ctx context.Context, p *commitParams, dryRun bool) ([]ActionTaken,
 
 const (
 	// These are appended to files that need manual merge conflict resolution.
-	SuffixLocallyAdded                  = ".abcmerge_locally_added"
-	SuffixLocallyEdited                 = ".abcmerge_locally_edited"
+	SuffixLocallyAdded = ".abcmerge_locally_added"
 	SuffixFromNewTemplate               = ".abcmerge_from_new_template"
 	SuffixFromNewTemplateLocallyDeleted = ".abcmerge_locally_deleted_vs_new_template_version"
 	SuffixWantToDelete                  = ".abcmerge_template_wants_to_delete"
@@ -382,33 +381,17 @@ func actuateMergeDecision(ctx context.Context, p *commitParams, dryRun bool, dec
 		actionTaken.OursPath = paths.relative + SuffixWantToDelete
 		return actionTaken, nil
 	case EditEditConflict:
-		renamedPath := installedPath + SuffixLocallyEdited
 		incomingPath := installedPath + SuffixFromNewTemplate
-		if err := common.CopyFile(ctx, nil, p.fs, paths.fromOldLocal, renamedPath, dryRun, nil); err != nil {
-			return ActionTaken{}, err //nolint:wrapcheck
-		}
-		if err := removeOrDryRun(p.fs, dryRun, installedPath); err != nil {
-			return ActionTaken{}, err
-		}
 		if err := common.CopyFile(ctx, nil, p.fs, paths.fromNewTemplate, incomingPath, dryRun, nil); err != nil {
 			return ActionTaken{}, err //nolint:wrapcheck
 		}
-		actionTaken.OursPath = paths.relative + SuffixLocallyEdited
 		actionTaken.IncomingTemplatePath = paths.relative + SuffixFromNewTemplate
 		return actionTaken, nil
 	case AddAddConflict:
-		renamedPath := installedPath + SuffixLocallyAdded
-		if err := common.CopyFile(ctx, nil, p.fs, paths.fromOldLocal, renamedPath, dryRun, nil); err != nil {
-			return ActionTaken{}, err //nolint:wrapcheck
-		}
-		if err := removeOrDryRun(p.fs, dryRun, installedPath); err != nil {
-			return ActionTaken{}, err
-		}
 		incomingPath := installedPath + SuffixFromNewTemplate
 		if err := common.CopyFile(ctx, nil, p.fs, paths.fromNewTemplate, incomingPath, dryRun, nil); err != nil {
 			return ActionTaken{}, err //nolint:wrapcheck
 		}
-		actionTaken.OursPath = paths.relative + SuffixLocallyAdded
 		actionTaken.IncomingTemplatePath = paths.relative + SuffixFromNewTemplate
 		return actionTaken, nil
 	default:

--- a/templates/common/upgrade/merge.go
+++ b/templates/common/upgrade/merge.go
@@ -279,7 +279,7 @@ func mergeAll(ctx context.Context, p *commitParams, dryRun bool) ([]ActionTaken,
 
 const (
 	// These are appended to files that need manual merge conflict resolution.
-	SuffixLocallyAdded = ".abcmerge_locally_added"
+	SuffixLocallyAdded                  = ".abcmerge_locally_added"
 	SuffixFromNewTemplate               = ".abcmerge_from_new_template"
 	SuffixFromNewTemplateLocallyDeleted = ".abcmerge_locally_deleted_vs_new_template_version"
 	SuffixWantToDelete                  = ".abcmerge_template_wants_to_delete"

--- a/templates/common/upgrade/upgrade_test.go
+++ b/templates/common/upgrade/upgrade_test.go
@@ -430,7 +430,6 @@ func TestUpgradeAll(t *testing.T) {
 							{
 								Action:               EditEditConflict,
 								Path:                 "out.txt",
-								OursPath:             "out.txt.abcmerge_locally_edited",
 								IncomingTemplatePath: "out.txt.abcmerge_from_new_template",
 							},
 						},
@@ -439,7 +438,7 @@ func TestUpgradeAll(t *testing.T) {
 				},
 			},
 			wantDestContentsAfterUpgrade: map[string]string{
-				"out.txt.abcmerge_locally_edited":    "my edited contents",
+				"out.txt":                            "my edited contents",
 				"out.txt.abcmerge_from_new_template": "goodbye",
 			},
 			wantManifestAfterUpgrade: manifestWith(outTxtOnlyManifest, func(m *manifest.Manifest) {
@@ -665,7 +664,6 @@ func TestUpgradeAll(t *testing.T) {
 							{
 								Action:               "addAddConflict",
 								Path:                 "out.txt",
-								OursPath:             "out.txt.abcmerge_locally_added",
 								IncomingTemplatePath: "out.txt.abcmerge_from_new_template",
 							},
 						},
@@ -674,7 +672,7 @@ func TestUpgradeAll(t *testing.T) {
 				},
 			},
 			wantDestContentsAfterUpgrade: map[string]string{
-				"out.txt.abcmerge_locally_added":     "my cool new file",
+				"out.txt":                            "my cool new file",
 				"out.txt.abcmerge_from_new_template": "template now outputs this",
 				"some_other_file.txt":                "some other file contents",
 			},
@@ -1888,7 +1886,7 @@ func TestUpgradeAll_MultipleTemplatesWithResumedConflict(t *testing.T) {
 
 	wantDestContents := map[string]string{
 		"destDir1/myfile.txt" + SuffixFromNewTemplate: "my new template1 file contents",
-		"destDir1/myfile.txt" + SuffixLocallyEdited:   "my local edits",
+		"destDir1/myfile.txt":                         "my local edits",
 		"destDir2/myfile.txt":                         "my old template2 file contents",
 	}
 	opt := abctestutil.SkipGlob("*/.abc/manifest*") // manifest are too unpredictable, don't assert their contents
@@ -1899,7 +1897,6 @@ func TestUpgradeAll_MultipleTemplatesWithResumedConflict(t *testing.T) {
 
 	abctestutil.Overwrite(t, destDir1, "myfile.txt", "my resolved contents")
 	abctestutil.Remove(t, destDir1, "myfile.txt"+SuffixFromNewTemplate)
-	abctestutil.Remove(t, destDir1, "myfile.txt"+SuffixLocallyEdited)
 
 	allResult = UpgradeAll(ctx, upgradeParams)
 	if allResult.Err != nil {


### PR DESCRIPTION
Before this PR, when there was a conflict between a local edit and an edited file in the upstream template, abc would rename the user's local file to something like `foo.abcmerge_locally_edited` and drop the template's edited version of the file as `foo.abcmerge_new_from_template`.

However, after using `abc` as a user, I think a better user experience is to leave the user's filename unchanged. The sensible workflow for a user who's facing a merge conflict is to diff their local file with the incoming file and selectively incorporate changes from the upstream template file. These files don't have equal standing from the user's point of view: the user wants to keep what they have and carefully vet and integrate the upstream changes. This PR makes that change.