### PR TITLE
fix: ignored inputs should not appear in manifest

### DIFF
--- a/templates/common/input/input.go
+++ b/templates/common/input/input.go
@@ -225,8 +225,8 @@ func checkUnknownInputs(spec *spec.Spec, inputs map[string]string) []string {
 }
 
 // filterUnknownInputs returns the subset of the given inputs that appear in the
-// the given spec. Essentially it discards any inputs that aren't declared in
-// the spec.
+// given spec. Essentially it discards any inputs that aren't declared in the
+// spec.
 func filterUnknownInputs(spec *spec.Spec, inputs map[string]string) map[string]string {
 	specInputs := make(map[string]struct{})
 

--- a/templates/common/render/render_test.go
+++ b/templates/common/render/render_test.go
@@ -1389,6 +1389,7 @@ steps:
 				"ending_punctuation": "!",
 			},
 			flagIgnoreUnknownInputs: true,
+			flagManifest:            true,
 			templateContents: map[string]string{
 				"myfile.txt":           "Some random stuff",
 				"spec.yaml":            specContents,
@@ -1401,6 +1402,39 @@ steps:
 				"file1.txt":            "my favorite color is red",
 				"dir1/file_in_dir.txt": "file_in_dir contents",
 				"dir2/file2.txt":       "file2 contents",
+			},
+			wantManifest: &manifest.Manifest{
+				CreationTime:     clk.Now(),
+				ModificationTime: clk.Now(),
+				TemplateDirhash:  mdl.S("h1:Gym1rh37Q4e6h72ELjloc4lfVPR6B6tuRaLnFmakAYo="),
+				Inputs: []*manifest.Input{
+					{
+						Name:  mdl.S("emoji_suffix"),
+						Value: mdl.S("\U0001F408"),
+					},
+					{
+						Name:  mdl.S("ending_punctuation"),
+						Value: mdl.S("!"),
+					},
+					{
+						Name:  mdl.S("name_to_greet"),
+						Value: mdl.S("Bob"),
+					},
+				},
+				OutputFiles: []*manifest.OutputFile{
+					{
+						File: mdl.S("dir1/file_in_dir.txt"),
+						Hash: mdl.S("h1:IeeGbHh8lPKI7ISJDiQTcNzKT/kATZ6IBgL4PbzOE4M="),
+					},
+					{
+						File: mdl.S("dir2/file2.txt"),
+						Hash: mdl.S("h1:AUDAxmpkSrLdJ6xVNvIMw3PW/RiW+YOOy0WVZ13aAfo="),
+					},
+					{
+						File: mdl.S("file1.txt"),
+						Hash: mdl.S("h1:UQ18krF3vW1ggpVvzlSWqmU0l4Fsuskdq7PaT9KHZ/4="),
+					},
+				},
 			},
 		},
 	}

--- a/templates/common/upgrade/upgrade.go
+++ b/templates/common/upgrade/upgrade.go
@@ -50,9 +50,7 @@ import (
 // TODO(upgrade):
 //   - add "abort if conflict" feature
 //   - rethink overly complex manifest file name?
-//   - validate that manifest paths don't contain traversals
 //   - add "check for update and exit" feature
-//   - add "upgrade all template installations within directory"
 //   - maybe switch file hashes to SHA1, so then we can opportunistically get
 //     the common base from the installedDir repo or template repo (which might
 //     be the same repo), so then we can do a 3-way merge (`git merge-file`)


### PR DESCRIPTION
There was a bug in the way unknown inputs were handled. They would be correctly ignored for the purposes of rendering the template, but would still appear in the manifest. This didn't cause serious problems, but was confusing and gross; a manifest should not save any inputs that weren't actually passed to the template during rendering.