### PR TITLE
Add the --upgrade-channel flag

### DIFF
--- a/templates/commands/render/flags.go
+++ b/templates/commands/render/flags.go
@@ -78,6 +78,10 @@ type RenderFlags struct {
 	// Whether to *only* create a manifest file without outputting any other
 	// files from the template.
 	ManifestOnly bool
+
+	// Overrides the `upgrade_channel` field in the output manifest. Can be
+	// either a branch name or the special string "latest".
+	UpgradeChannel string
 }
 
 func (r *RenderFlags) Register(set *cli.FlagSet) {
@@ -121,6 +125,14 @@ func (r *RenderFlags) Register(set *cli.FlagSet) {
 		EnvVar:  "ABC_MANIFEST",
 		// TODO(upgrade): remove "(experimental)"
 		Usage: "(experimental) write a manifest file containing metadata that will allow future template upgrades.",
+	})
+
+	f.StringVar(&cli.StringVar{
+		Name: "upgrade-channel",
+		Target: &r.UpgradeChannel,
+		Default: "",
+		EnvVar: "ABC_UPGRADE_CHANNEL",
+		Usage: `overrides the "upgrade_channel" field in the output manifest, which controls where upgraded template versions will be pulled from in the future by "abc uprade". Can be either a branch name or the special string "latest". The default is to upgrade from the branch that the template was originally rendered from if rendered from a branch, or in any other case to use the value "latest" to upgrade to the latest release tag by semver order.`,
 	})
 
 	f.BoolVar(&cli.BoolVar{

--- a/templates/commands/render/flags.go
+++ b/templates/commands/render/flags.go
@@ -128,11 +128,11 @@ func (r *RenderFlags) Register(set *cli.FlagSet) {
 	})
 
 	f.StringVar(&cli.StringVar{
-		Name: "upgrade-channel",
-		Target: &r.UpgradeChannel,
+		Name:    "upgrade-channel",
+		Target:  &r.UpgradeChannel,
 		Default: "",
-		EnvVar: "ABC_UPGRADE_CHANNEL",
-		Usage: `overrides the "upgrade_channel" field in the output manifest, which controls where upgraded template versions will be pulled from in the future by "abc uprade". Can be either a branch name or the special string "latest". The default is to upgrade from the branch that the template was originally rendered from if rendered from a branch, or in any other case to use the value "latest" to upgrade to the latest release tag by semver order.`,
+		EnvVar:  "ABC_UPGRADE_CHANNEL",
+		Usage:   `overrides the "upgrade_channel" field in the output manifest, which controls where upgraded template versions will be pulled from in the future by "abc uprade". Can be either a branch name or the special string "latest". The default is to upgrade from the branch that the template was originally rendered from if rendered from a branch, or in any other case to use the value "latest" to upgrade to the latest release tag by semver order.`,
 	})
 
 	f.BoolVar(&cli.BoolVar{

--- a/templates/commands/render/render.go
+++ b/templates/commands/render/render.go
@@ -131,6 +131,7 @@ func (c *Command) Run(ctx context.Context, args []string) error {
 		SkipPromptTTYCheck:   c.skipPromptTTYCheck,
 		SourceForMessages:    c.flags.Source,
 		Stdout:               c.Stdout(),
+		UpgradeChannel: c.flags.UpgradeChannel,
 	})
 
 	return err //nolint:wrapcheck

--- a/templates/commands/render/render.go
+++ b/templates/commands/render/render.go
@@ -131,7 +131,7 @@ func (c *Command) Run(ctx context.Context, args []string) error {
 		SkipPromptTTYCheck:   c.skipPromptTTYCheck,
 		SourceForMessages:    c.flags.Source,
 		Stdout:               c.Stdout(),
-		UpgradeChannel: c.flags.UpgradeChannel,
+		UpgradeChannel:       c.flags.UpgradeChannel,
 	})
 
 	return err //nolint:wrapcheck

--- a/templates/commands/render/render_test.go
+++ b/templates/commands/render/render_test.go
@@ -55,6 +55,7 @@ func TestRenderFlags_Parse(t *testing.T) {
 				"--manifest-only",
 				"--manifest",
 				"--skip-input-validation",
+				"--upgrade-channel", "main",
 				"helloworld@v1",
 			},
 			want: RenderFlags{
@@ -71,6 +72,7 @@ func TestRenderFlags_Parse(t *testing.T) {
 				ManifestOnly:         true,
 				SkipInputValidation:  true,
 				Source:               "helloworld@v1",
+				UpgradeChannel:       "main",
 			},
 		},
 		{

--- a/templates/common/render/manifest.go
+++ b/templates/common/render/manifest.go
@@ -74,6 +74,9 @@ type writeManifestParams struct {
 
 	// The temp directory where the template was downloaded.
 	templateDir string
+
+	// The value of the --upgrade-channel flag.
+	upgradeChannel string
 }
 
 // writeManifest creates a manifest struct, marshals it as YAML, and writes it
@@ -198,6 +201,13 @@ func buildManifest(p *writeManifestParams) (*manifest.WithHeader, error) {
 		locType = "" // we only save the location type in the manifest if the location is canonical
 	}
 
+	upgradeChannel := p.dlMeta.UpgradeChannel
+	if p.upgradeChannel != "" {
+		// The user specified --upgrade-channel to override the autodetected
+		// upgrade channel.
+		upgradeChannel = p.upgradeChannel
+	}
+
 	return &manifest.WithHeader{
 		Header: &header.Fields{
 			NewStyleAPIVersion: model.String{Val: apiVersion},
@@ -208,7 +218,7 @@ func buildManifest(p *writeManifestParams) (*manifest.WithHeader, error) {
 			LocationType:     model.String{Val: locType},                  // may be empty string if location isn't canonical
 			TemplateDirhash:  model.String{Val: templateDirhash},
 			TemplateVersion:  model.String{Val: p.dlMeta.Version},
-			UpgradeChannel:   model.String{Val: p.dlMeta.UpgradeChannel},
+			UpgradeChannel:   model.String{Val: upgradeChannel},
 			CreationTime:     now,
 			ModificationTime: now,
 			Inputs:           inputList,

--- a/templates/common/render/render.go
+++ b/templates/common/render/render.go
@@ -149,6 +149,10 @@ type Params struct {
 	// The directory under which to create temp directories. Normally empty,
 	// except in testing.
 	TempDirBase string
+
+	// The value of the --upgrade-channel flag. Leave blank to use the
+	// autodetected upgrade channel (most common).
+	UpgradeChannel string
 }
 
 // Result gives some metadata about the outcome of the render operation.
@@ -621,6 +625,7 @@ func commitTentatively(ctx context.Context, p *Params, cp *commitParams) (manife
 				inputs:                 cp.inputs,
 				outputHashes:           outputHashes,
 				templateDir:            cp.templateDir,
+				upgradeChannel:         p.UpgradeChannel,
 			}); err != nil {
 				return "", err
 			}

--- a/templates/common/render/render_test.go
+++ b/templates/common/render/render_test.go
@@ -101,6 +101,7 @@ steps:
 		flagSkipInputValidation bool
 		flagManifest            bool
 		flagManifestOnly        bool
+		flagUpgradeChannel      string
 		flagDebugStepDiffs      bool
 		overrideBuiltinVars     map[string]string
 		removeAllErr            error
@@ -183,6 +184,63 @@ steps:
 				CreationTime:     clk.Now(),
 				ModificationTime: clk.Now(),
 				TemplateDirhash:  mdl.S("h1:Gym1rh37Q4e6h72ELjloc4lfVPR6B6tuRaLnFmakAYo="),
+				Inputs: []*manifest.Input{
+					{
+						Name:  mdl.S("emoji_suffix"),
+						Value: mdl.S("\U0001F408"),
+					},
+					{
+						Name:  mdl.S("ending_punctuation"),
+						Value: mdl.S("!"),
+					},
+					{
+						Name:  mdl.S("name_to_greet"),
+						Value: mdl.S("Bob"),
+					},
+				},
+				OutputFiles: []*manifest.OutputFile{
+					{
+						File: mdl.S("dir1/file_in_dir.txt"),
+						Hash: mdl.S("h1:IeeGbHh8lPKI7ISJDiQTcNzKT/kATZ6IBgL4PbzOE4M="),
+					},
+					{
+						File: mdl.S("dir2/file2.txt"),
+						Hash: mdl.S("h1:AUDAxmpkSrLdJ6xVNvIMw3PW/RiW+YOOy0WVZ13aAfo="),
+					},
+					{
+						File: mdl.S("file1.txt"),
+						Hash: mdl.S("h1:UQ18krF3vW1ggpVvzlSWqmU0l4Fsuskdq7PaT9KHZ/4="),
+					},
+				},
+			},
+		},
+		{
+			name: "simple_success_with_manifest_and_upgrade_channel_flag",
+			flagInputs: map[string]string{
+				"name_to_greet":      "Bob",
+				"emoji_suffix":       "🐈",
+				"ending_punctuation": "!",
+			},
+			templateContents: map[string]string{
+				"myfile.txt":           "Some random stuff",
+				"spec.yaml":            specContents,
+				"file1.txt":            "my favorite color is blue",
+				"dir1/file_in_dir.txt": "file_in_dir contents",
+				"dir2/file2.txt":       "file2 contents",
+			},
+			flagManifest:       true,
+			flagUpgradeChannel: "main",
+			wantStdout:         "Hello, Bob🐈!\n",
+			wantDestContents: map[string]string{
+				"file1.txt":            "my favorite color is red",
+				"dir1/file_in_dir.txt": "file_in_dir contents",
+				"dir2/file2.txt":       "file2 contents",
+			},
+			wantManifest: &manifest.Manifest{
+				CreationTime:     clk.Now(),
+				ModificationTime: clk.Now(),
+				TemplateDirhash:  mdl.S("h1:Gym1rh37Q4e6h72ELjloc4lfVPR6B6tuRaLnFmakAYo="),
+				UpgradeChannel:   mdl.S("main"),
 				Inputs: []*manifest.Input{
 					{
 						Name:  mdl.S("emoji_suffix"),
@@ -1483,6 +1541,7 @@ steps:
 				SourceForMessages:   sourceDir,
 				Stdout:              stdoutBuf,
 				TempDirBase:         tempDir,
+				UpgradeChannel:      tc.flagUpgradeChannel,
 			}
 
 			ctx := logging.WithLogger(context.Background(), logging.TestLogger(t))

--- a/templates/common/templatesource/download.go
+++ b/templates/common/templatesource/download.go
@@ -68,6 +68,9 @@ type DownloadMetadata struct {
 
 	// Depending on where the template was taken from, there might be a version
 	// string associated with it (e.g. a git tag or a git SHA). May be empty.
+	// This field does not use the magic string "latest" which is used
+	// elsewhere; by the time this field is set, the "latest" version has been
+	// resolved to a specific concrete version.
 	Version string
 
 	// Either the special string "latest", or the name of a branch to use to


### PR DESCRIPTION
This lets the user specify what branch they want to track for upgrades. The default is still the old behavior, which is to make an educated guess (if the user installed from `mybranch` then track that, otherwise upgrade from the latest semver release).