### PR TITLE
Allow empty string as a manifest input value

### DIFF
--- a/templates/model/manifest/v1alpha1/manifest.go
+++ b/templates/model/manifest/v1alpha1/manifest.go
@@ -118,7 +118,6 @@ func (i *Input) UnmarshalYAML(n *yaml.Node) error {
 func (i *Input) Validate() error {
 	return errors.Join(
 		model.NotZeroModel(&i.Pos, i.Name, "name"),
-		model.NotZeroModel(&i.Pos, i.Value, "value"),
 	)
 }
 

--- a/templates/model/manifest/v1alpha1/manifest_test.go
+++ b/templates/model/manifest/v1alpha1/manifest_test.go
@@ -114,19 +114,6 @@ output_files:
 			wantValidateErr: []string{`at line 6 column 5: field "name" is required`},
 		},
 		{
-			name: "input_missing_value",
-			in: `
-api_version: 'cli.abcxyz.dev/v1alpha1'
-template_location: 'github.com/abcxyz/abc/t/rest_server@latest'
-template_dirhash: 'h1:5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03'
-inputs:
-  - name: 'my_input_1'
-output_files:
-  - file: 'a/b/c.txt'
-    hash: 'h1:b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c'`,
-			wantValidateErr: []string{`at line 6 column 5: field "value" is required`},
-		},
-		{
 			name: "missing_file",
 			in: `
 api_version: 'cli.abcxyz.dev/v1alpha1'
@@ -266,13 +253,6 @@ func TestValidate(t *testing.T) {
 				in.Inputs[0].Name.Val = ""
 			},
 			wantErr: `"name" is required`,
-		},
-		{
-			name: "missing_input_value",
-			mutate: func(in *Manifest) {
-				in.Inputs[0].Value.Val = ""
-			},
-			wantErr: `"value" is required`,
 		},
 		{
 			name: "missing_file_hash",


### PR DESCRIPTION
This should never have been enforced. It's perfectly legal for a template input value to be empty string.