### PR TITLE
Test prompting during upgrade when a new input is added with a default

### DIFF
--- a/templates/commands/goldentest/new_test_cli_test.go
+++ b/templates/commands/goldentest/new_test_cli_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	abctestutil "github.com/abcxyz/abc/templates/testutil"
+	"github.com/abcxyz/abc/templates/testutil/prompt"
 	"github.com/abcxyz/pkg/cli"
 	"github.com/abcxyz/pkg/logging"
 	"github.com/abcxyz/pkg/testutil"
@@ -330,7 +331,7 @@ func TestNewTestPrompt(t *testing.T) {
 		newTestName      string
 		flagBuiltinVars  map[string]string
 		flagPrompt       bool
-		dialog           []abctestutil.DialogStep
+		dialog           []prompt.DialogStep
 		templateContents map[string]string
 		expectedContents map[string]string
 		wantErr          string
@@ -358,7 +359,7 @@ steps:
     params:
       message: 'Hello, {{.name}}!'`,
 			},
-			dialog: []abctestutil.DialogStep{
+			dialog: []prompt.DialogStep{
 				{
 					WaitForPrompt: `
 Input name:   name
@@ -407,7 +408,7 @@ builtin_vars:
 			r := &NewTestCommand{}
 			r.skipPromptTTYCheck = true
 
-			err := abctestutil.DialogTest(ctx, t, tc.dialog, r, args)
+			err := prompt.DialogTest(ctx, t, tc.dialog, r, args)
 			if diff := testutil.DiffErrString(err, tc.wantErr); diff != "" {
 				t.Fatal(diff)
 			}

--- a/templates/commands/render/render_test.go
+++ b/templates/commands/render/render_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/abcxyz/abc/templates/common"
 	abctestutil "github.com/abcxyz/abc/templates/testutil"
+	"github.com/abcxyz/abc/templates/testutil/prompt"
 	"github.com/abcxyz/pkg/cli"
 	"github.com/abcxyz/pkg/logging"
 	"github.com/abcxyz/pkg/testutil"
@@ -193,7 +194,7 @@ steps:
 		name             string
 		templateContents map[string]string
 		flagPrompt       bool
-		dialog           []abctestutil.DialogStep
+		dialog           []prompt.DialogStep
 		wantDestContents map[string]string
 		wantErr          string
 	}{
@@ -207,7 +208,7 @@ steps:
 				"dir2/file2.txt":       "file2 contents",
 			},
 			flagPrompt: true,
-			dialog: []abctestutil.DialogStep{
+			dialog: []prompt.DialogStep{
 				{
 					WaitForPrompt: `
 Input name:   name_of_favourite_person
@@ -247,7 +248,7 @@ Enter value: `,
 
 			r := &Command{skipPromptTTYCheck: true}
 
-			err := abctestutil.DialogTest(ctx, t, tc.dialog, r, args)
+			err := prompt.DialogTest(ctx, t, tc.dialog, r, args)
 			if diff := testutil.DiffErrString(err, tc.wantErr); diff != "" {
 				t.Fatal(diff)
 			}

--- a/templates/commands/upgrade/upgrade_test.go
+++ b/templates/commands/upgrade/upgrade_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/abcxyz/abc/templates/common/templatesource"
 	"github.com/abcxyz/abc/templates/common/upgrade"
 	abctestutil "github.com/abcxyz/abc/templates/testutil"
+	"github.com/abcxyz/abc/templates/testutil/prompt"
 	"github.com/abcxyz/pkg/logging"
 	"github.com/abcxyz/pkg/testutil"
 )
@@ -334,7 +335,7 @@ steps:
 
 	cases := []struct {
 		name              string
-		dialog            []abctestutil.DialogStep
+		dialog            []prompt.DialogStep
 		prompt            bool
 		inputFileContents string
 		origTemplate      map[string]string
@@ -355,7 +356,7 @@ steps:
 				"out.txt":   "",
 				"spec.yaml": specOneInput,
 			},
-			dialog: []abctestutil.DialogStep{
+			dialog: []prompt.DialogStep{
 				{
 					WaitForPrompt: "Input name:   animal\nDescription:  An animal name\n\nEnter value: ",
 					ThenRespond:   "alligator\n",
@@ -415,7 +416,7 @@ steps:
 `,
 			},
 			inputFileContents: `color: 'orange'`,
-			dialog: []abctestutil.DialogStep{
+			dialog: []prompt.DialogStep{
 				{
 					WaitForPrompt: "Input name:   animal\nDescription:  An animal name\n\nEnter value: ",
 					ThenRespond:   "alligator\n",
@@ -490,7 +491,7 @@ steps:
 			}
 			args = append(args, manifestFullPath)
 
-			err = abctestutil.DialogTest(ctx, t, tc.dialog, cmd, args)
+			err = prompt.DialogTest(ctx, t, tc.dialog, cmd, args)
 			wantErr := strings.ReplaceAll(tc.wantErr, "TEMPDIR", tempBase)
 			if diff := testutil.DiffErrString(err, wantErr); diff != "" {
 				t.Fatal(diff)

--- a/templates/common/input/input.go
+++ b/templates/common/input/input.go
@@ -135,7 +135,7 @@ func Resolve(ctx context.Context, rp *ResolveParams) (map[string]string, error) 
 
 // This interface is satisfied by *prompt.FakePrompter.
 type fakePrompter interface {
-	PretendStdinIsTTY()
+	IsTestFake()
 }
 
 func validateInputs(ctx context.Context, specInputs []*spec.Input, inputVals map[string]string) error {

--- a/templates/common/render/render_test.go
+++ b/templates/common/render/render_test.go
@@ -39,6 +39,7 @@ import (
 	spec "github.com/abcxyz/abc/templates/model/spec/v1beta6"
 	abctestutil "github.com/abcxyz/abc/templates/testutil"
 	mdl "github.com/abcxyz/abc/templates/testutil/model"
+	"github.com/abcxyz/abc/templates/testutil/prompt"
 	"github.com/abcxyz/pkg/cli"
 	"github.com/abcxyz/pkg/logging"
 	"github.com/abcxyz/pkg/testutil"
@@ -1641,7 +1642,7 @@ func TestPromptDialog(t *testing.T) {
 		name          string
 		inputs        []*spec.Input
 		flagInputVals map[string]string // Simulates some inputs having already been provided by flags, like --input=foo=bar means we shouldn't prompt for "foo"
-		dialog        []abctestutil.DialogStep
+		dialog        []prompt.DialogStep
 		want          map[string]string
 		wantErr       string
 	}{
@@ -1653,7 +1654,7 @@ func TestPromptDialog(t *testing.T) {
 					Desc: mdl.S("your favorite animal"),
 				},
 			},
-			dialog: []abctestutil.DialogStep{
+			dialog: []prompt.DialogStep{
 				{
 					WaitForPrompt: `
 Input name:   animal
@@ -1681,7 +1682,7 @@ Enter value: `,
 					},
 				},
 			},
-			dialog: []abctestutil.DialogStep{
+			dialog: []prompt.DialogStep{
 				{
 					WaitForPrompt: `
 Input name:   animal
@@ -1715,7 +1716,7 @@ Enter value: `,
 					},
 				},
 			},
-			dialog: []abctestutil.DialogStep{
+			dialog: []prompt.DialogStep{
 				{
 					WaitForPrompt: `
 Input name:   animal
@@ -1745,7 +1746,7 @@ Enter value: `,
 					Desc: mdl.S("your favorite car"),
 				},
 			},
-			dialog: []abctestutil.DialogStep{
+			dialog: []prompt.DialogStep{
 				{
 					WaitForPrompt: `
 Input name:   animal
@@ -1799,7 +1800,7 @@ Enter value: `,
 			flagInputVals: map[string]string{
 				"animal": "duck",
 			},
-			dialog: []abctestutil.DialogStep{
+			dialog: []prompt.DialogStep{
 				{
 					WaitForPrompt: `
 Input name:   car
@@ -1827,7 +1828,7 @@ Enter value: `,
 					Default: mdl.SP("shark"),
 				},
 			},
-			dialog: []abctestutil.DialogStep{
+			dialog: []prompt.DialogStep{
 				{
 					WaitForPrompt: `
 Input name:   animal
@@ -1851,7 +1852,7 @@ Enter value, or leave empty to accept default: `,
 					Default: mdl.SP("shark"),
 				},
 			},
-			dialog: []abctestutil.DialogStep{
+			dialog: []prompt.DialogStep{
 				{
 					WaitForPrompt: `
 Input name:   animal
@@ -1875,7 +1876,7 @@ Enter value, or leave empty to accept default: `,
 					Default: mdl.SP(""),
 				},
 			},
-			dialog: []abctestutil.DialogStep{
+			dialog: []prompt.DialogStep{
 				{
 					WaitForPrompt: `
 Input name:   animal
@@ -1896,6 +1897,8 @@ Enter value, or leave empty to accept default: `,
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
+
+			// TODO rewrite to use framework
 
 			cmd := &cli.BaseCommand{}
 
@@ -1927,8 +1930,8 @@ Enter value, or leave empty to accept default: `,
 			}()
 
 			for _, ds := range tc.dialog {
-				abctestutil.ReadWithTimeout(t, stdoutReader, ds.WaitForPrompt)
-				abctestutil.WriteWithTimeout(t, stdinWriter, ds.ThenRespond)
+				prompt.ReadWithTimeout(t, stdoutReader, ds.WaitForPrompt)
+				prompt.WriteWithTimeout(t, stdinWriter, ds.ThenRespond)
 			}
 
 			select {

--- a/templates/common/templatesource/remote_git.go
+++ b/templates/common/templatesource/remote_git.go
@@ -346,11 +346,11 @@ func resolveLatest(ctx context.Context, tmpDir string) (string, error) {
 		return "", fmt.Errorf(`the template source requested the "latest" release, but there were no semver-formatted tags beginning with "v". Available tags were: %v`, tags)
 	}
 
-	max := slices.MaxFunc(versions, func(l, r *semver.Version) int {
+	maxVer := slices.MaxFunc(versions, func(l, r *semver.Version) int {
 		return l.Compare(r)
 	})
 
-	return "v" + max.Original(), nil
+	return "v" + maxVer.Original(), nil
 }
 
 // A fakeable interface around the lower-level git Clone function, for testing.

--- a/templates/common/upgrade/upgrade_test.go
+++ b/templates/common/upgrade/upgrade_test.go
@@ -1346,7 +1346,7 @@ yellow is my favorite color
 			}
 
 			var upgradeResult *Result
-			prompt.DialogTestNoCmd(ctx, t, tc.dialogSteps, func(prompter input.Prompter) {
+			prompt.DialogTestFunc(ctx, t, tc.dialogSteps, func(prompter input.Prompter) {
 				params.Prompter = prompter
 				upgradeResult = UpgradeAll(ctx, params)
 			})

--- a/templates/testutil/cmp.go
+++ b/templates/testutil/cmp.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package testutil contains util functions to facilitate tests.
 package testutil
 
 import (

--- a/templates/testutil/prompt/prompt.go
+++ b/templates/testutil/prompt/prompt.go
@@ -27,9 +27,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+
 	"github.com/abcxyz/abc/templates/common/input"
 	"github.com/abcxyz/pkg/cli"
-	"github.com/google/go-cmp/cmp"
 )
 
 const (
@@ -170,9 +171,13 @@ func (f *FakePrompter) Stdin() io.Reader {
 
 // This function doesn't do anything and is never called. It just satisfies an
 // interface so a type assertion can check for a fake prompter.
-func (f *FakePrompter) PretendStdinIsTTY() {}
+func (f *FakePrompter) IsTestFake() {
+	panic("this function is never called, it just satisfies an interface")
+}
 
 func DialogTestNoCmd(ctx context.Context, tb testing.TB, steps []DialogStep, f func(input.Prompter)) {
+	tb.Helper()
+
 	done := make(chan struct{})
 	go func() {
 		defer close(done)

--- a/templates/testutil/prompt/prompt.go
+++ b/templates/testutil/prompt/prompt.go
@@ -175,7 +175,12 @@ func (f *FakePrompter) IsTestFake() {
 	panic("this function is never called, it just satisfies an interface")
 }
 
-func DialogTestNoCmd(ctx context.Context, tb testing.TB, steps []DialogStep, f func(input.Prompter)) {
+// DialogTestFunc is like DialogTest except it doesn't depend on having a
+// cli.Command. A background goroutine is started that will execute the
+// back-and-forth conversation defined in the given steps, simulating the user.
+// Your provided callback should prompt the user for some input using the
+// provided Prompter.
+func DialogTestFunc(ctx context.Context, tb testing.TB, steps []DialogStep, f func(input.Prompter)) {
 	tb.Helper()
 
 	done := make(chan struct{})


### PR DESCRIPTION
This tests an edge case where:

 1. A template is installed that has no inputs.
 2. The template is updated to add an input that has a default value
 3. We run an upgrade
 4. The user should be prompted for a value for the new input; the default value should not silently be used.

I thought I saw this last week in my manual testing, but the test passes without changing the logic, so I may have been mistaken.

This change involves some refactoring and test util updates because this is the first time that we've tested prompting logic at the library layer (`common/*`), rather than the Command layer (`commands/*`) which wraps the library.