### PR TITLE
Add --accept-defaults flag, and error when user intent is unclear

### DIFF
--- a/templates/commands/goldentest/new_test_cli.go
+++ b/templates/commands/goldentest/new_test_cli.go
@@ -85,6 +85,7 @@ func (c *NewTestCommand) Run(ctx context.Context, args []string) (rErr error) {
 	logger.DebugContext(ctx, "resolving inputs")
 
 	resolvedInputs, err := input.Resolve(ctx, &input.ResolveParams{
+		AcceptDefaults:     c.flags.AcceptDefaults,
 		FS:                 fs,
 		Inputs:             c.flags.Inputs,
 		Prompt:             c.flags.Prompt,

--- a/templates/commands/goldentest/new_test_flags.go
+++ b/templates/commands/goldentest/new_test_flags.go
@@ -46,6 +46,9 @@ type NewTestFlags struct {
 
 	// ForceOverwrite lets existing test config file be overwritten.
 	ForceOverwrite bool
+
+	// See common/flags.AcceptDefaults().
+	AcceptDefaults bool
 }
 
 func (r *NewTestFlags) Register(set *cli.FlagSet) {
@@ -54,6 +57,7 @@ func (r *NewTestFlags) Register(set *cli.FlagSet) {
 	f.StringMapVar(flags.Inputs(&r.Inputs))
 
 	f.BoolVar(flags.Prompt(&r.Prompt))
+	f.BoolVar(flags.AcceptDefaults(&r.AcceptDefaults))
 
 	f.BoolVar(&cli.BoolVar{
 		Name:    "force-overwrite",

--- a/templates/commands/goldentest/test_funcs.go
+++ b/templates/commands/goldentest/test_funcs.go
@@ -195,6 +195,7 @@ func renderTestCase(ctx context.Context, templateDir, outputDir string, tc *Test
 	stdoutBuf := &strings.Builder{}
 
 	_, err = render.Render(ctx, &render.Params{
+		AcceptDefaults:      true,
 		Clock:               clock.New(),
 		Cwd:                 cwd,
 		OutDir:              testDir,

--- a/templates/commands/render/flags.go
+++ b/templates/commands/render/flags.go
@@ -26,6 +26,9 @@ import (
 
 // RenderFlags describes what template to render and how.
 type RenderFlags struct {
+	// See common/flags.AcceptDefaults().
+	AcceptDefaults bool
+
 	// Positional arguments:
 
 	// Source is the location of the input template to be rendered.
@@ -117,6 +120,7 @@ func (r *RenderFlags) Register(set *cli.FlagSet) {
 	})
 
 	f.BoolVar(flags.Prompt(&r.Prompt))
+	f.BoolVar(flags.AcceptDefaults(&r.AcceptDefaults))
 
 	f.BoolVar(&cli.BoolVar{
 		Name:    "manifest",

--- a/templates/commands/render/render.go
+++ b/templates/commands/render/render.go
@@ -108,6 +108,7 @@ func (c *Command) Run(ctx context.Context, args []string) error {
 	}
 
 	_, err = render.Render(ctx, &render.Params{
+		AcceptDefaults:       c.flags.AcceptDefaults,
 		BackupDir:            backupDir,
 		Backups:              true,
 		Clock:                clock.New(),

--- a/templates/commands/render/render_test.go
+++ b/templates/commands/render/render_test.go
@@ -44,6 +44,7 @@ func TestRenderFlags_Parse(t *testing.T) {
 		{
 			name: "all_flags_present",
 			args: []string{
+				"--accept-defaults",
 				"--debug-scratch-contents",
 				"--debug-step-diffs",
 				"--dest", "my_dir",
@@ -60,6 +61,7 @@ func TestRenderFlags_Parse(t *testing.T) {
 				"helloworld@v1",
 			},
 			want: RenderFlags{
+				AcceptDefaults:       true,
 				DebugScratchContents: true,
 				DebugStepDiffs:       true,
 				Dest:                 "my_dir",

--- a/templates/commands/upgrade/flags.go
+++ b/templates/commands/upgrade/flags.go
@@ -26,6 +26,9 @@ import (
 type Flags struct {
 	Location string
 
+	// See common/flags.AcceptDefaults().
+	AcceptDefaults bool
+
 	// A list of files that were...
 	//   - changed in place by a previous render operation...
 	//   - then an upgrade operation was attempted, which attempted to undo the
@@ -108,6 +111,8 @@ func (f *Flags) Register(set *cli.FlagSet) {
 	r.BoolVar(flags.DebugStepDiffs(&f.DebugStepDiffs))
 	r.BoolVar(flags.KeepTempDirs(&f.KeepTempDirs))
 	r.BoolVar(flags.Prompt(&f.Prompt))
+	r.BoolVar(flags.AcceptDefaults(&f.AcceptDefaults))
+
 	r.StringVar(&cli.StringVar{
 		Name:    "version",
 		Usage:   "for remote templates, the version to upgrade to; may be a git tag, branch, or SHA",

--- a/templates/commands/upgrade/upgrade.go
+++ b/templates/commands/upgrade/upgrade.go
@@ -133,6 +133,7 @@ func (c *Command) Run(ctx context.Context, args []string) error {
 	}
 
 	result := upgrade.UpgradeAll(ctx, &upgrade.Params{
+		AcceptDefaults:       c.flags.AcceptDefaults,
 		AlreadyResolved:      c.flags.AlreadyResolved,
 		Clock:                clock.New(),
 		DebugStepDiffs:       c.flags.DebugStepDiffs,

--- a/templates/common/flags/flags.go
+++ b/templates/common/flags/flags.go
@@ -140,3 +140,15 @@ func Verbose(v *bool) *cli.BoolVar {
 		Usage:   "include more output; intended for power users",
 	}
 }
+
+// AcceptDefaults causes template defaults to be accepted automatically when
+// prompting is disabled.
+func AcceptDefaults(a *bool) *cli.BoolVar {
+	return &cli.BoolVar{
+		Name:    "accept-defaults",
+		Target:  a,
+		Default: false,
+		EnvVar:  "ABC_ACCEPT_DEFAULTS",
+		Usage:   "when a template input has a default value, and the user didn't provide a value for that input, and prompting is disabled, this will cause the default value to be silently used.",
+	}
+}

--- a/templates/common/input/input.go
+++ b/templates/common/input/input.go
@@ -315,20 +315,6 @@ func insertDefaultInputs(spec *spec.Spec, userInputs map[string]string) []string
 		defaulted = append(defaulted, specInput.Name.Val)
 	}
 
-	// if len(inputsForError) > 0 {
-	// 	// This avoids a specific poor user experience. Suppose the user runs
-	// 	// `abc upgrade` (without --prompt), which is a very reasonable thing to
-	// 	// do. Suppose the upgraded version of the template has a new input with
-	// 	// a default value for that input. It would be bad for abc to just
-	// 	// silently use the default value for that new input; technically you
-	// 	// could argue that the user should have used the --prompt flag if they
-	// 	// wanted a chance to override the default, but that would be a footgun
-	// 	// and we can't expect users to be that diligent. So we'll reject the
-	// 	// current operation and ask the user to clarify their intent with
-	// 	// either --prompt or --accept-defaults.
-	// 	return fmt.Errorf("there are some inputs for which a value was not provided but a default is available; please use either --prompt or --accept-defaults: %v", inputsForError)
-	// }
-
 	return defaulted
 }
 

--- a/templates/common/input/input.go
+++ b/templates/common/input/input.go
@@ -297,10 +297,12 @@ func loadInputFiles(fs common.FS, paths []string) (map[string]string, error) {
 	return out, nil
 }
 
-// insertDefaultInputs defaults any missing inputs for which a default
-// exists. The input map will be mutated by adding new keys.
+// insertDefaultInputs defaults any missing inputs for which a default exists.
+// The input map will be mutated by adding new keys. The return value is the
+// list of input names that had default values set because they were not already
+// set.
 func insertDefaultInputs(spec *spec.Spec, userInputs map[string]string) []string {
-	var defaulted []string
+	var defaulted []string //nolint:prealloc
 
 	for _, specInput := range spec.Inputs {
 		_, userGaveInput := userInputs[specInput.Name.Val]

--- a/templates/common/input/input.go
+++ b/templates/common/input/input.go
@@ -38,8 +38,9 @@ import (
 type ResolveParams struct {
 	FS common.FS
 
-	// The template spec.yaml model.
-	Spec *spec.Spec
+	// Whether to silently accept default values for template inputs in the case
+	// where prompting is disabled.
+	AcceptDefaults bool
 
 	// Ignore any values in the Inputs map that aren't valid template inputs,
 	// rather than returning error.
@@ -63,6 +64,9 @@ type ResolveParams struct {
 	// can be set to true to bypass the check and allow stdin to be something
 	// other than a TTY, like an os.Pipe.
 	SkipPromptTTYCheck bool
+
+	// The template spec.yaml model.
+	Spec *spec.Spec
 }
 
 // Prompter prints messages to the user asking them to enter a value. This is
@@ -116,9 +120,23 @@ func Resolve(ctx context.Context, rp *ResolveParams) (map[string]string, error) 
 			return nil, err
 		}
 	} else {
-		insertDefaultInputs(rp.Spec, inputs)
+		defaulted := insertDefaultInputs(rp.Spec, inputs)
 		if missing := checkInputsMissing(rp.Spec, inputs); len(missing) > 0 {
 			return nil, fmt.Errorf("missing input(s): %s, you may want to use one of the flags --prompt, --input, or --input-file", strings.Join(missing, ", "))
+		}
+		if len(defaulted) > 0 && !rp.AcceptDefaults {
+			// This avoids a specific poor user experience. Suppose the user
+			// runs `abc upgrade` (without --prompt), which is a very reasonable
+			// thing to do. Suppose the upgraded version of the template has a
+			// new input with a default value for that input. It would be bad
+			// for abc to just silently use the default value for that new
+			// input; technically you could argue that the user should have used
+			// the --prompt flag if they wanted a chance to override the
+			// default, but that would be a footgun and we can't expect users to
+			// be that diligent. So we'll reject the current operation and ask
+			// the user to clarify their intent with either --prompt or
+			// --accept-defaults.
+			return nil, fmt.Errorf("there are some inputs for which a value was not provided but a default is available; please use either --prompt or --accept-defaults: %v", defaulted)
 		}
 	}
 
@@ -281,12 +299,35 @@ func loadInputFiles(fs common.FS, paths []string) (map[string]string, error) {
 
 // insertDefaultInputs defaults any missing inputs for which a default
 // exists. The input map will be mutated by adding new keys.
-func insertDefaultInputs(spec *spec.Spec, inputs map[string]string) {
+func insertDefaultInputs(spec *spec.Spec, userInputs map[string]string) []string {
+	var defaulted []string
+
 	for _, specInput := range spec.Inputs {
-		if _, ok := inputs[specInput.Name.Val]; !ok && specInput.Default != nil {
-			inputs[specInput.Name.Val] = specInput.Default.Val
+		_, userGaveInput := userInputs[specInput.Name.Val]
+		defaultExists := specInput.Default != nil
+		if userGaveInput || !defaultExists {
+			continue
 		}
+
+		userInputs[specInput.Name.Val] = specInput.Default.Val
+		defaulted = append(defaulted, specInput.Name.Val)
 	}
+
+	// if len(inputsForError) > 0 {
+	// 	// This avoids a specific poor user experience. Suppose the user runs
+	// 	// `abc upgrade` (without --prompt), which is a very reasonable thing to
+	// 	// do. Suppose the upgraded version of the template has a new input with
+	// 	// a default value for that input. It would be bad for abc to just
+	// 	// silently use the default value for that new input; technically you
+	// 	// could argue that the user should have used the --prompt flag if they
+	// 	// wanted a chance to override the default, but that would be a footgun
+	// 	// and we can't expect users to be that diligent. So we'll reject the
+	// 	// current operation and ask the user to clarify their intent with
+	// 	// either --prompt or --accept-defaults.
+	// 	return fmt.Errorf("there are some inputs for which a value was not provided but a default is available; please use either --prompt or --accept-defaults: %v", inputsForError)
+	// }
+
+	return defaulted
 }
 
 // checkInputsMissing checks for missing inputs and returns them as a slice.

--- a/templates/common/render/render.go
+++ b/templates/common/render/render.go
@@ -45,6 +45,9 @@ import (
 
 // Params contains the arguments to Render().
 type Params struct {
+	// The value of --accept-defaults.
+	AcceptDefaults bool
+
 	// BackupDir is the directory where overwritten files will be backed up.
 	// BackupDir is ignored if Backups is false.
 	BackupDir string
@@ -223,6 +226,7 @@ func RenderAlreadyDownloaded(ctx context.Context, dlMeta *templatesource.Downloa
 
 	logger.DebugContext(ctx, "resolving inputs")
 	resolvedInputs, err := input.Resolve(ctx, &input.ResolveParams{
+		AcceptDefaults:      p.AcceptDefaults,
 		FS:                  p.FS,
 		IgnoreUnknownInputs: p.IgnoreUnknownInputs,
 		InputFiles:          p.InputFiles,

--- a/templates/common/render/render_test.go
+++ b/templates/common/render/render_test.go
@@ -96,6 +96,7 @@ steps:
 		flagInputs              map[string]string
 		inputFileNames          []string
 		inputFileContents       map[string]string
+		flagAcceptDefaults      bool
 		flagKeepTempDirs        bool
 		flagForceOverwrite      bool
 		flagIgnoreUnknownInputs bool
@@ -385,7 +386,8 @@ steps:
 			inputFileContents: map[string]string{
 				"inputs.yaml": `
 name_to_greet: 'Bob'
-emoji_suffix: '🐈'`,
+emoji_suffix: '🐈'
+ending_punctuation: '.'`,
 			},
 			templateContents: map[string]string{
 				"myfile.txt":           "Some random stuff",
@@ -417,7 +419,8 @@ emoji_suffix: '🐈'`,
 				"dir1/file_in_dir.txt": "file_in_dir contents",
 				"dir2/file2.txt":       "file2 contents",
 			},
-			wantStdout: "Hello, Robert🐈.\n",
+			flagAcceptDefaults: true,
+			wantStdout:         "Hello, Robert🐈.\n",
 			wantDestContents: map[string]string{
 				"file1.txt":            "my favorite color is red",
 				"dir1/file_in_dir.txt": "file_in_dir contents",
@@ -433,6 +436,7 @@ name_to_greet: 'Bob'`,
 				"other-inputs.yaml": `
 emoji_suffix: '🐈'`,
 			},
+			flagAcceptDefaults: true,
 			templateContents: map[string]string{
 				"myfile.txt":           "Some random stuff",
 				"spec.yaml":            specContents,
@@ -465,7 +469,8 @@ emoji_suffix: '🐈'`,
 				"name_to_greet": "Bob",
 				"emoji_suffix":  "🐈",
 			},
-			flagKeepTempDirs: true,
+			flagKeepTempDirs:   true,
+			flagAcceptDefaults: true,
 			templateContents: map[string]string{
 				"spec.yaml":            specContents,
 				"file1.txt":            "my favorite color is blue",
@@ -508,8 +513,9 @@ emoji_suffix: '🐈'`,
 		{
 			name: "existing_dest_file_with_overwrite_flag_should_succeed",
 			flagInputs: map[string]string{
-				"name_to_greet": "Bob",
-				"emoji_suffix":  "🐈",
+				"name_to_greet":      "Bob",
+				"emoji_suffix":       "🐈",
+				"ending_punctuation": ".",
 			},
 			flagForceOverwrite: true,
 			existingDestContents: map[string]string{
@@ -535,8 +541,9 @@ emoji_suffix: '🐈'`,
 		{
 			name: "existing_dest_file_without_overwrite_flag_should_fail",
 			flagInputs: map[string]string{
-				"name_to_greet": "Bob",
-				"emoji_suffix":  "🐈",
+				"name_to_greet":      "Bob",
+				"emoji_suffix":       "🐈",
+				"ending_punctuation": ".",
 			},
 			flagForceOverwrite: false,
 			existingDestContents: map[string]string{
@@ -567,6 +574,7 @@ emoji_suffix: '🐈'`,
 				"name_to_greet": "Bob",
 				"emoji_suffix":  "🐈",
 			},
+			flagAcceptDefaults: true,
 			templateContents: map[string]string{
 				"myfile.txt":           "Some random stuff",
 				"spec.yaml":            specContents,
@@ -601,6 +609,7 @@ emoji_suffix: '🐈'`,
 		{
 			name:       "handles_missing_required_inputs",
 			flagInputs: map[string]string{},
+			// flagAcceptDefaults: ,
 			templateContents: map[string]string{
 				"myfile.txt":           "Some random stuff",
 				"spec.yaml":            specContents,
@@ -947,8 +956,9 @@ steps:
     params:
       message: 'Goodbye'`,
 			},
-			wantStdout:       "Hello\n",
-			wantDestContents: map[string]string{},
+			flagAcceptDefaults: true,
+			wantStdout:         "Hello\n",
+			wantDestContents:   map[string]string{},
 		},
 		{
 			name: "step_with_if_needs_v1beta1",
@@ -983,7 +993,7 @@ steps:
 			wantErr: `"if" expression "bad_expression" failed at step index 0 action "print"`,
 		},
 		{
-			name:           "unknown_input_file_flags should be ignored",
+			name:           "unknown_input_file_flags_should_be_ignored",
 			flagInputs:     map[string]string{"name_to_greet": "Robert"},
 			inputFileNames: []string{"inputs.yaml"},
 			inputFileContents: map[string]string{
@@ -991,6 +1001,7 @@ steps:
 unknown_key: 'unknown value'
 emoji_suffix: '🐈'`,
 			},
+			flagAcceptDefaults: true,
 			templateContents: map[string]string{
 				"myfile.txt":           "Some random stuff",
 				"spec.yaml":            specContents,
@@ -1520,6 +1531,7 @@ steps:
 			rfs := &common.RealFS{}
 			stdoutBuf := &strings.Builder{}
 			p := &Params{
+				AcceptDefaults: tc.flagAcceptDefaults,
 				Backups:        true,
 				BackupDir:      backupDir,
 				Clock:          clk,

--- a/templates/common/upgrade/upgrade.go
+++ b/templates/common/upgrade/upgrade.go
@@ -64,6 +64,9 @@ const rejectedPatchSuffix = ".patch.rej"
 
 // Params contains all the arguments to Upgrade().
 type Params struct {
+	// The value of --accept-defaults.
+	AcceptDefaults bool
+
 	// Relative paths where patch reversal has already happened. This is a flag
 	// supplied by the user. This will be set if there were merge conflicts
 	// during patch reversal that were manually resolved by the user.
@@ -396,6 +399,7 @@ func upgrade(ctx context.Context, p *Params, absManifestPath string) (_ *Manifes
 	}
 
 	renderResult, err := render.RenderAlreadyDownloaded(ctx, dlMeta, templateDir, &render.Params{
+		AcceptDefaults:          p.AcceptDefaults,
 		Clock:                   p.Clock,
 		Cwd:                     p.CWD,
 		DebugStepDiffs:          p.DebugStepDiffs,


### PR DESCRIPTION
This avoids a specific poor user experience. Suppose the user runs `abc upgrade` (without --prompt), which is a very reasonable thing to do. Suppose the upgraded version of the template has a new input with a default value for that input. It would be bad for abc to just silently use the default value for that new input; technically you could argue that the user should have used the --prompt flag if they wanted a chance to override the default, but that would be a footgun and we can't expect users to be that diligent. So we'll reject the current operation and ask the user to clarify their intent with either --prompt or --accept-defaults.