### PR TITLE
fix: --input flags to upgrade were being ignored

### DIFF
--- a/templates/commands/goldentest/test_funcs.go
+++ b/templates/commands/goldentest/test_funcs.go
@@ -201,7 +201,7 @@ func renderTestCase(ctx context.Context, templateDir, outputDir string, tc *Test
 		OutDir:              testDir,
 		Downloader:          &templatesource.LocalDownloader{SrcPath: templateDir},
 		FS:                  &common.RealFS{},
-		Inputs:              varValuesToMap(tc.TestConfig.Inputs),
+		InputsFromFlags:     varValuesToMap(tc.TestConfig.Inputs),
 		OverrideBuiltinVars: varValuesToMap(tc.TestConfig.BuiltinVars),
 		SourceForMessages:   templateDir,
 		Stdout:              stdoutBuf,

--- a/templates/commands/render/render.go
+++ b/templates/commands/render/render.go
@@ -121,7 +121,7 @@ func (c *Command) Run(ctx context.Context, args []string) error {
 		FS:                   fs,
 		GitProtocol:          c.flags.GitProtocol,
 		IgnoreUnknownInputs:  c.flags.IgnoreUnknownInputs,
-		Inputs:               c.flags.Inputs,
+		InputsFromFlags:      c.flags.Inputs,
 		InputFiles:           c.flags.InputFiles,
 		KeepTempDirs:         c.flags.KeepTempDirs,
 		Manifest:             c.flags.Manifest,

--- a/templates/commands/upgrade/upgrade.go
+++ b/templates/commands/upgrade/upgrade.go
@@ -141,7 +141,7 @@ func (c *Command) Run(ctx context.Context, args []string) error {
 		FS:                   &common.RealFS{},
 		GitProtocol:          c.flags.GitProtocol,
 		InputFiles:           c.flags.InputFiles,
-		Inputs:               c.flags.Inputs,
+		InputsFromFlags:      c.flags.Inputs,
 		KeepTempDirs:         c.flags.KeepTempDirs,
 		Location:             absLocation,
 		Prompt:               c.flags.Prompt,

--- a/templates/commands/upgrade/upgrade_test.go
+++ b/templates/commands/upgrade/upgrade_test.go
@@ -88,7 +88,7 @@ steps:
 			},
 			localEdits: func(tb testing.TB, installedDir string) {
 				tb.Helper()
-				abctestutil.Overwrite(tb, installedDir, "greet.txt", "goodbye\n")
+				abctestutil.OverwriteJoin(tb, installedDir, "greet.txt", "goodbye\n")
 			},
 			upgradedTemplate: map[string]string{
 				"spec.yaml": includeDotSpec,
@@ -109,8 +109,8 @@ steps:
 			},
 			localEdits: func(tb testing.TB, installedDir string) {
 				tb.Helper()
-				abctestutil.Overwrite(tb, installedDir, "greet.txt", "hello, mars\n")
-				abctestutil.Overwrite(tb, installedDir, "color.txt", "red\n")
+				abctestutil.OverwriteJoin(tb, installedDir, "greet.txt", "hello, mars\n")
+				abctestutil.OverwriteJoin(tb, installedDir, "color.txt", "red\n")
 			},
 			wantExitCode: 1,
 			wantErr:      []string{"exit code 1"},
@@ -159,7 +159,7 @@ steps:
 			},
 			localEdits: func(tb testing.TB, installedDir string) {
 				tb.Helper()
-				abctestutil.Overwrite(tb, installedDir, "hello.txt", "a\nY\nc\n")
+				abctestutil.OverwriteJoin(tb, installedDir, "hello.txt", "a\nY\nc\n")
 			},
 			upgradedTemplate: map[string]string{
 				"spec.yaml": `

--- a/templates/common/fs_test.go
+++ b/templates/common/fs_test.go
@@ -530,7 +530,7 @@ func TestCopyRecursive_ForbidSymlinks(t *testing.T) {
 			sourceTempDir := t.TempDir()
 
 			for _, r := range tc.regularFiles {
-				abctestutil.Overwrite(t, sourceTempDir, r, "contents")
+				abctestutil.OverwriteJoin(t, sourceTempDir, r, "contents")
 			}
 			for _, s := range tc.symlinks {
 				path := filepath.Join(sourceTempDir, s)

--- a/templates/common/git/git_test.go
+++ b/templates/common/git/git_test.go
@@ -61,7 +61,7 @@ func TestLocalTags(t *testing.T) {
 		t.Fatalf("got %d tags, but expected 0 tags in an empty repo", len(got))
 	}
 
-	abctestutil.Overwrite(t, tempDir, "myfile1.txt", "some contents")
+	abctestutil.OverwriteJoin(t, tempDir, "myfile1.txt", "some contents")
 
 	// If we don't do this, there will be an error on commit
 	mustRun(ctx, t, "git", "config", "-f", tempDir+"/.git/config", "user.email", "fake@example.com")
@@ -80,7 +80,7 @@ func TestLocalTags(t *testing.T) {
 		t.Fatalf("got tags %v, want %v", got, want)
 	}
 
-	abctestutil.Overwrite(t, tempDir, "myfile2.txt", "some contents")
+	abctestutil.OverwriteJoin(t, tempDir, "myfile2.txt", "some contents")
 	mustRun(ctx, t, "git", "-C", tempDir, "add", "-A")
 	mustRun(ctx, t, "git", "-C", tempDir, "commit", "--no-gpg-sign", "--author", "nobody <nobody>", "-m", "my second commit")
 	mustRun(ctx, t, "git", "-C", tempDir, "tag", "mytag2")
@@ -276,10 +276,10 @@ func TestCheckout(t *testing.T) {
 
 			ctx := context.Background()
 			if len(tc.branch) > 0 {
-				abctestutil.Overwrite(t, tempDir, ".git/refs/heads/"+tc.branch, abctestutil.MinimalGitHeadSHA)
+				abctestutil.OverwriteJoin(t, tempDir, ".git/refs/heads/"+tc.branch, abctestutil.MinimalGitHeadSHA)
 			}
 			if len(tc.tag) > 0 {
-				abctestutil.Overwrite(t, tempDir, ".git/refs/tags/"+tc.tag, abctestutil.MinimalGitHeadSHA)
+				abctestutil.OverwriteJoin(t, tempDir, ".git/refs/tags/"+tc.tag, abctestutil.MinimalGitHeadSHA)
 			}
 			err := Checkout(ctx, tc.version, tempDir)
 			if diff := testutil.DiffErrString(err, tc.wantErr); diff != "" {

--- a/templates/common/render/render.go
+++ b/templates/common/render/render.go
@@ -110,7 +110,13 @@ type Params struct {
 
 	// The value of --input, or another source of input values (e.g. the golden
 	// test test.yaml).
-	Inputs map[string]string
+	InputsFromFlags map[string]string
+
+	// This is only set in the case where this template is being rendered as
+	// part of an upgrade operation, and contains the set of inputs that were
+	// saved in the manifest from the previous render operation. They're
+	// separate from the other inputs so they can be given lowest precedence.
+	InputsFromManifest map[string]string
 
 	// The value of --keep-temp-dirs.
 	KeepTempDirs bool
@@ -230,7 +236,8 @@ func RenderAlreadyDownloaded(ctx context.Context, dlMeta *templatesource.Downloa
 		FS:                  p.FS,
 		IgnoreUnknownInputs: p.IgnoreUnknownInputs,
 		InputFiles:          p.InputFiles,
-		Inputs:              p.Inputs,
+		Inputs:              p.InputsFromFlags,
+		InputsFromManifest:  p.InputsFromManifest,
 		Prompt:              p.Prompt,
 		Prompter:            p.Prompter,
 		SkipInputValidation: p.SkipInputValidation,

--- a/templates/common/render/render_test.go
+++ b/templates/common/render/render_test.go
@@ -1544,7 +1544,7 @@ steps:
 				},
 				IgnoreUnknownInputs: tc.flagIgnoreUnknownInputs,
 				InputFiles:          inputFilePaths,
-				Inputs:              tc.flagInputs,
+				InputsFromFlags:     tc.flagInputs,
 				KeepTempDirs:        tc.flagKeepTempDirs,
 				Manifest:            tc.flagManifest,
 				ManifestOnly:        tc.flagManifestOnly,

--- a/templates/common/upgrade/upgrade.go
+++ b/templates/common/upgrade/upgrade.go
@@ -410,7 +410,7 @@ func upgrade(ctx context.Context, p *Params, absManifestPath string) (_ *Manifes
 		IgnoreUnknownInputs:     true, // The old manifest may have inputs that were removed in the latest template version
 		InputFiles:              p.InputFiles,
 		IncludeFromDestExtraDir: reversedDir,
-		Inputs:                  inputsToMap(oldManifest.Inputs),
+		Inputs:                  sets.UnionMapKeys(p.Inputs, inputsToMap(oldManifest.Inputs)),
 		KeepTempDirs:            p.KeepTempDirs,
 		Manifest:                true,
 		OutDir:                  mergeDir,

--- a/templates/common/upgrade/upgrade.go
+++ b/templates/common/upgrade/upgrade.go
@@ -94,8 +94,8 @@ type Params struct {
 	// The value of --input-file.
 	InputFiles []string
 
-	// The value of --input.
-	Inputs map[string]string
+	// The values from --input.
+	InputsFromFlags map[string]string
 
 	// The value of --keep-temp-dirs.
 	KeepTempDirs bool
@@ -407,10 +407,10 @@ func upgrade(ctx context.Context, p *Params, absManifestPath string) (_ *Manifes
 		Downloader:              downloader,
 		FS:                      p.FS,
 		GitProtocol:             p.GitProtocol,
-		IgnoreUnknownInputs:     true, // The old manifest may have inputs that were removed in the latest template version
 		InputFiles:              p.InputFiles,
+		InputsFromManifest:      inputsToMap(oldManifest.Inputs),
 		IncludeFromDestExtraDir: reversedDir,
-		Inputs:                  sets.UnionMapKeys(p.Inputs, inputsToMap(oldManifest.Inputs)),
+		InputsFromFlags:         p.InputsFromFlags,
 		KeepTempDirs:            p.KeepTempDirs,
 		Manifest:                true,
 		OutDir:                  mergeDir,

--- a/templates/common/upgrade/upgrade_test.go
+++ b/templates/common/upgrade/upgrade_test.go
@@ -235,6 +235,7 @@ steps:
 			upgradeInputs: map[string]string{
 				"rename_to": "filename_from_flag.txt",
 			},
+			upgradeInputFileContents: `rename_to: value_from_file.txt`, // should be ignored in favor of upgradeInputs
 			templateUnionForUpgrade: map[string]string{
 				"spec.yaml": `api_version: 'cli.abcxyz.dev/v1beta6'
 kind: 'Template'
@@ -1462,7 +1463,7 @@ yellow is my favorite color
 				Clock:             clk,
 				CWD:               destDir,
 				FS:                &common.RealFS{},
-				Inputs:            tc.upgradeInputs,
+				InputsFromFlags:   tc.upgradeInputs,
 				InputFiles:        inputFiles,
 				Location:          manifestFullPath,
 				Prompt:            tc.prompt,

--- a/templates/testutil/fs.go
+++ b/templates/testutil/fs.go
@@ -255,8 +255,8 @@ func OverwriteJoin(tb testing.TB, dir, name, contents string) {
 	Overwrite(tb, filepath.Join(dir, name), contents)
 }
 
-// OverwriteJoin writes the given contents to the given path, failing the test
-// on error. If the enclosing directory doesn't exist, it will be created.
+// Overwrite writes the given contents to the given path, failing the test on
+// error. If the enclosing directory doesn't exist, it will be created.
 func Overwrite(tb testing.TB, path, contents string) {
 	tb.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {

--- a/templates/testutil/fs.go
+++ b/templates/testutil/fs.go
@@ -247,16 +247,22 @@ func TestMustGlob(tb testing.TB, glob string) (string, bool) {
 	panic("unreachable") // silence compiler warning for "missing return"
 }
 
-// Overwrite writes the given contents to the path created by filepath.Join(dir,
-// name), failing the test on error. If the enclosing directory doesn't exist,
-// it will be created.
-func Overwrite(tb testing.TB, dir, name, contents string) {
+// OverwriteJoin writes the given contents to the path created by
+// filepath.Join(dir, name), failing the test on error. If the enclosing
+// directory doesn't exist, it will be created.
+func OverwriteJoin(tb testing.TB, dir, name, contents string) {
 	tb.Helper()
-	filename := filepath.Join(dir, name)
-	if err := os.MkdirAll(filepath.Dir(filename), 0o700); err != nil {
+	Overwrite(tb, filepath.Join(dir, name), contents)
+}
+
+// OverwriteJoin writes the given contents to the given path, failing the test
+// on error. If the enclosing directory doesn't exist, it will be created.
+func Overwrite(tb testing.TB, path, contents string) {
+	tb.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		tb.Fatal(err)
 	}
-	if err := os.WriteFile(filename, []byte(contents), 0o600); err != nil {
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
 		tb.Fatal(err)
 	}
 }
@@ -271,7 +277,7 @@ func Prepend(tb testing.TB, dir, baseName, contents string) {
 	if err != nil {
 		tb.Fatal(err)
 	}
-	Overwrite(tb, dir, baseName, contents+string(buf))
+	OverwriteJoin(tb, dir, baseName, contents+string(buf))
 }
 
 func Remove(tb testing.TB, dir, baseName string) {


### PR DESCRIPTION
If the user wanted to override any input values during an upgrade, or provide a value for a newly-introduced template flag, their `--input=foo=bar` CLI flag was simply ignored. :upside-down-face:

We also add a test for the case where upgrade override flags come from a YAML file.