### PR TITLE
Unhide the `upgrade` subcommand

### DIFF
--- a/templates/commands/upgrade/upgrade.go
+++ b/templates/commands/upgrade/upgrade.go
@@ -56,12 +56,6 @@ template was originally rendered, usually found in the .abc subdirectory.
 `
 }
 
-// Hidden implements cli.Command.
-func (c *Command) Hidden() bool {
-	// TODO(upgrade): unhide the upgrade command when it's ready.
-	return true
-}
-
 func (c *Command) Flags() *cli.FlagSet {
 	set := c.NewFlagSet()
 	c.flags.Register(set)


### PR DESCRIPTION
This will be released soon, and in the meantime the lack of tab-completion is annoying.