### PR TITLE
Add the --even-if-up-to-date flag to `upgrade`

### DIFF
--- a/templates/commands/upgrade/flags.go
+++ b/templates/commands/upgrade/flags.go
@@ -51,6 +51,12 @@ type Flags struct {
 	// See common/flags.DebugStepDiffs().
 	DebugStepDiffs bool
 
+	// Continue upgrading even if the dirhash matches between the
+	// already-installed template version and the to-be-installed template
+	// version. This is useful to for the manifest to be rewritten with a new
+	// template_location field when running with --template-location=foo.
+	EvenIfUpToDate bool
+
 	// See common/flags.GitProtocol().
 	GitProtocol string
 
@@ -100,6 +106,11 @@ func (f *Flags) Register(set *cli.FlagSet) {
 		Predict: predict.Files("*.yaml"),
 		Target:  &f.ResumeFrom,
 		Usage:   "begin or resume the upgrade starting at this manifest file",
+	})
+	u.BoolVar(&cli.BoolVar{
+		Name:   "even-if-up-to-date",
+		Target: &f.EvenIfUpToDate,
+		Usage:  "continue even if the template dirhash shows that the latest version of the template has already been installed; this is useful to force the manifest to be rewritten when used with --template-location",
 	})
 	u.BoolVar(flags.Verbose(&f.Verbose))
 

--- a/templates/commands/upgrade/flags.go
+++ b/templates/commands/upgrade/flags.go
@@ -55,7 +55,7 @@ type Flags struct {
 	// already-installed template version and the to-be-installed template
 	// version. This is useful to for the manifest to be rewritten with a new
 	// template_location field when running with --template-location=foo.
-	EvenIfUpToDate bool
+	ContinueIfCurrent bool
 
 	// See common/flags.GitProtocol().
 	GitProtocol string
@@ -108,8 +108,8 @@ func (f *Flags) Register(set *cli.FlagSet) {
 		Usage:   "begin or resume the upgrade starting at this manifest file",
 	})
 	u.BoolVar(&cli.BoolVar{
-		Name:   "even-if-up-to-date",
-		Target: &f.EvenIfUpToDate,
+		Name:   "continue-if-current",
+		Target: &f.ContinueIfCurrent,
 		Usage:  "continue even if the template dirhash shows that the latest version of the template has already been installed; this is useful to force the manifest to be rewritten when used with --template-location",
 	})
 	u.BoolVar(flags.Verbose(&f.Verbose))

--- a/templates/commands/upgrade/upgrade.go
+++ b/templates/commands/upgrade/upgrade.go
@@ -138,6 +138,7 @@ func (c *Command) Run(ctx context.Context, args []string) error {
 		Clock:                clock.New(),
 		DebugStepDiffs:       c.flags.DebugStepDiffs,
 		DebugScratchContents: c.flags.DebugScratchContents,
+		EvenIfUpToDate:       c.flags.EvenIfUpToDate,
 		FS:                   &common.RealFS{},
 		GitProtocol:          c.flags.GitProtocol,
 		InputFiles:           c.flags.InputFiles,

--- a/templates/commands/upgrade/upgrade.go
+++ b/templates/commands/upgrade/upgrade.go
@@ -138,7 +138,7 @@ func (c *Command) Run(ctx context.Context, args []string) error {
 		Clock:                clock.New(),
 		DebugStepDiffs:       c.flags.DebugStepDiffs,
 		DebugScratchContents: c.flags.DebugScratchContents,
-		EvenIfUpToDate:       c.flags.EvenIfUpToDate,
+		ContinueIfCurrent:    c.flags.ContinueIfCurrent,
 		FS:                   &common.RealFS{},
 		GitProtocol:          c.flags.GitProtocol,
 		InputFiles:           c.flags.InputFiles,

--- a/templates/common/render/render.go
+++ b/templates/common/render/render.go
@@ -613,6 +613,7 @@ func commitTentatively(ctx context.Context, p *Params, cp *commitParams) (manife
 		if err != nil {
 			return "", err //nolint:wrapcheck
 		}
+		fmt.Printf(" *** Diff is: \n%s\n", diff)
 		if diff != "" {
 			includeFromDestPatches[relPath] = diff
 		}

--- a/templates/common/render/render.go
+++ b/templates/common/render/render.go
@@ -613,7 +613,6 @@ func commitTentatively(ctx context.Context, p *Params, cp *commitParams) (manife
 		if err != nil {
 			return "", err //nolint:wrapcheck
 		}
-		fmt.Printf(" *** Diff is: \n%s\n", diff)
 		if diff != "" {
 			includeFromDestPatches[relPath] = diff
 		}

--- a/templates/common/upgrade/upgrade.go
+++ b/templates/common/upgrade/upgrade.go
@@ -89,7 +89,7 @@ type Params struct {
 	// already-installed template version and the to-be-installed template
 	// version. This is useful to for the manifest to be rewritten with a new
 	// template_location field when running with --template-location=foo.
-	EvenIfUpToDate bool
+	ContinueIfCurrent bool
 
 	// FS abstracts filesystem operations for error injection testing.
 	FS common.FS
@@ -359,7 +359,7 @@ func upgrade(ctx context.Context, p *Params, absManifestPath string) (_ *Manifes
 		return nil, fmt.Errorf("failed downloading template: %w", err)
 	}
 
-	if !p.EvenIfUpToDate {
+	if !p.ContinueIfCurrent {
 		hashMatch, err := dirhash.Verify(oldManifest.TemplateDirhash.Val, templateDir)
 		if err != nil {
 			return nil, err //nolint:wrapcheck

--- a/templates/common/upgrade/upgrade.go
+++ b/templates/common/upgrade/upgrade.go
@@ -85,6 +85,12 @@ type Params struct {
 	// The value of --debug-step-diffs.
 	DebugStepDiffs bool
 
+	// Continue upgrading even if the dirhash matches between the
+	// already-installed template version and the to-be-installed template
+	// version. This is useful to for the manifest to be rewritten with a new
+	// template_location field when running with --template-location=foo.
+	EvenIfUpToDate bool
+
 	// FS abstracts filesystem operations for error injection testing.
 	FS common.FS
 
@@ -353,18 +359,20 @@ func upgrade(ctx context.Context, p *Params, absManifestPath string) (_ *Manifes
 		return nil, fmt.Errorf("failed downloading template: %w", err)
 	}
 
-	hashMatch, err := dirhash.Verify(oldManifest.TemplateDirhash.Val, templateDir)
-	if err != nil {
-		return nil, err //nolint:wrapcheck
-	}
-	if hashMatch {
-		// No need to upgrade. We already have the latest template version.
-		logger.InfoContext(ctx, "template installation is already up to date",
-			"manifest_path", absManifestPath)
-		return &ManifestResult{
-			Type:   AlreadyUpToDate,
-			DLMeta: dlMeta,
-		}, nil
+	if !p.EvenIfUpToDate {
+		hashMatch, err := dirhash.Verify(oldManifest.TemplateDirhash.Val, templateDir)
+		if err != nil {
+			return nil, err //nolint:wrapcheck
+		}
+		if hashMatch {
+			// No need to upgrade. We already have the latest template version.
+			logger.InfoContext(ctx, "template installation is already up to date",
+				"manifest_path", absManifestPath)
+			return &ManifestResult{
+				Type:   AlreadyUpToDate,
+				DLMeta: dlMeta,
+			}, nil
+		}
 	}
 
 	// The "merge directory" is yet another temp directory in addition to

--- a/templates/common/upgrade/upgrade_test.go
+++ b/templates/common/upgrade/upgrade_test.go
@@ -118,7 +118,8 @@ func TestUpgradeAll(t *testing.T) {
 
 		localEdits                   func(tb testing.TB, installedDir string)
 		dialogSteps                  []prompt.DialogStep
-		prompt                       bool
+		flagPrompt                   bool
+		flagEvenIfUpToDate           bool
 		upgradeInputs                map[string]string
 		upgradeInputFileContents     string
 		wantDestContentsAfterUpgrade map[string]string // excludes manifest contents
@@ -165,7 +166,7 @@ Enter value, or leave empty to accept default: `,
 					ThenRespond: "manual_filename.txt",
 				},
 			},
-			prompt: true,
+			flagPrompt: true,
 			templateUnionForUpgrade: map[string]string{
 				"spec.yaml": `api_version: 'cli.abcxyz.dev/v1beta6'
 kind: 'Template'
@@ -414,6 +415,38 @@ steps:
 				"out.txt": "hello\n",
 			},
 			wantManifestAfterUpgrade: outTxtOnlyManifest,
+		},
+		{
+			name:               "dont_short_circuit_if_already_latest_version_but_flag_overrides",
+			flagEvenIfUpToDate: true,
+			want: &Result{
+				Overall: Success,
+				Results: []*ManifestResult{
+					{
+						ManifestPath: ".",
+						Type:         Success,
+						DLMeta:       wantDLMeta,
+						NonConflicts: []ActionTaken{
+							{
+								Action: Noop,
+								Path:   "out.txt",
+							},
+						},
+					},
+				},
+			},
+			origTemplateDirContents: map[string]string{
+				"out.txt":   "hello\n",
+				"spec.yaml": includeDotSpec,
+			},
+			templateUnionForUpgrade:   map[string]string{},
+			wantManifestBeforeUpgrade: outTxtOnlyManifest,
+			wantDestContentsAfterUpgrade: map[string]string{
+				"out.txt": "hello\n",
+			},
+			wantManifestAfterUpgrade: manifestWith(outTxtOnlyManifest, func(m *manifest.Manifest) {
+				m.ModificationTime = afterUpgradeTime
+			}),
 		},
 		{
 			name: "new_template_has_file_not_in_old_template",
@@ -1511,11 +1544,12 @@ yellow is my favorite color
 			params := &Params{
 				Clock:             clk,
 				CWD:               destDir,
+				EvenIfUpToDate:    tc.flagEvenIfUpToDate,
 				FS:                &common.RealFS{},
 				InputsFromFlags:   tc.upgradeInputs,
 				InputFiles:        inputFiles,
 				Location:          manifestFullPath,
-				Prompt:            tc.prompt,
+				Prompt:            tc.flagPrompt,
 				Stdout:            os.Stdout,
 				downloaderFactory: dlFactory,
 			}
@@ -2353,7 +2387,7 @@ func assertManifest(ctx context.Context, tb testing.TB, whereAreWe string, want 
 		// Don't force test authors to assert the line and column numbers
 		cmpopts.IgnoreTypes(&model.ConfigPos{}, model.ConfigPos{}),
 
-		// Don't force test author to compute hashes when writing test/updating test cases.
+		// Don't force test author to compute hashes when writing/updating test cases.
 		cmpopts.IgnoreFields(manifest.Manifest{}, "TemplateDirhash"),
 		cmpopts.IgnoreFields(manifest.OutputFile{}, "Hash"),
 	}

--- a/templates/common/upgrade/upgrade_test.go
+++ b/templates/common/upgrade/upgrade_test.go
@@ -119,7 +119,7 @@ func TestUpgradeAll(t *testing.T) {
 		localEdits                   func(tb testing.TB, installedDir string)
 		dialogSteps                  []prompt.DialogStep
 		flagPrompt                   bool
-		flagContinueIfCurrent           bool
+		flagContinueIfCurrent        bool
 		upgradeInputs                map[string]string
 		upgradeInputFileContents     string
 		wantDestContentsAfterUpgrade map[string]string // excludes manifest contents
@@ -417,7 +417,7 @@ steps:
 			wantManifestAfterUpgrade: outTxtOnlyManifest,
 		},
 		{
-			name:               "dont_short_circuit_if_already_latest_version_but_flag_overrides",
+			name:                  "dont_short_circuit_if_already_latest_version_but_flag_overrides",
 			flagContinueIfCurrent: true,
 			want: &Result{
 				Overall: Success,

--- a/templates/common/upgrade/upgrade_test.go
+++ b/templates/common/upgrade/upgrade_test.go
@@ -439,13 +439,14 @@ steps:
 				"out.txt":   "hello\n",
 				"spec.yaml": includeDotSpec,
 			},
+
 			templateUnionForUpgrade:   map[string]string{},
 			wantManifestBeforeUpgrade: outTxtOnlyManifest,
 			wantDestContentsAfterUpgrade: map[string]string{
 				"out.txt": "hello\n",
 			},
 			wantManifestAfterUpgrade: manifestWith(outTxtOnlyManifest, func(m *manifest.Manifest) {
-				m.ModificationTime = afterUpgradeTime
+				m.ModificationTime = afterUpgradeTime // timestamp gets updated, because upgrade actually runs.
 			}),
 		},
 		{

--- a/templates/common/upgrade/upgrade_test.go
+++ b/templates/common/upgrade/upgrade_test.go
@@ -119,7 +119,7 @@ func TestUpgradeAll(t *testing.T) {
 		localEdits                   func(tb testing.TB, installedDir string)
 		dialogSteps                  []prompt.DialogStep
 		flagPrompt                   bool
-		flagEvenIfUpToDate           bool
+		flagContinueIfCurrent           bool
 		upgradeInputs                map[string]string
 		upgradeInputFileContents     string
 		wantDestContentsAfterUpgrade map[string]string // excludes manifest contents
@@ -418,7 +418,7 @@ steps:
 		},
 		{
 			name:               "dont_short_circuit_if_already_latest_version_but_flag_overrides",
-			flagEvenIfUpToDate: true,
+			flagContinueIfCurrent: true,
 			want: &Result{
 				Overall: Success,
 				Results: []*ManifestResult{
@@ -1545,7 +1545,7 @@ yellow is my favorite color
 			params := &Params{
 				Clock:             clk,
 				CWD:               destDir,
-				EvenIfUpToDate:    tc.flagEvenIfUpToDate,
+				ContinueIfCurrent: tc.flagContinueIfCurrent,
 				FS:                &common.RealFS{},
 				InputsFromFlags:   tc.upgradeInputs,
 				InputFiles:        inputFiles,


### PR DESCRIPTION
This flag forces the upgrade command to proceed even if the the installed template version is already the latest version. This is useful for:

 - Forcing the manifest to be rewritten, perhaps to change the --template-location or --upgrade-channel values
 - Re-rendering a template with different inputs using `--input=foo=bar`