### PR TITLE
chore: remove workflow dispatch trigger

### DIFF
--- a/.github/workflows/notify-on-issue-and-release.yml
+++ b/.github/workflows/notify-on-issue-and-release.yml
@@ -21,7 +21,6 @@ on:
   release:
     types:
       - 'published'
-  workflow_dispatch:
 
 jobs:
   call_action:


### PR DESCRIPTION
I don't think we need this. It was here for debugging purposes (I assume).