### PR TITLE
Add --upgrade-channel flag to upgrade command

### DIFF
--- a/templates/commands/render/flags.go
+++ b/templates/commands/render/flags.go
@@ -94,6 +94,7 @@ func (r *RenderFlags) Register(set *cli.FlagSet) {
 	f.StringSliceVar(flags.InputFiles(&r.InputFiles))
 	f.BoolVar(flags.KeepTempDirs(&r.KeepTempDirs))
 	f.BoolVar(flags.SkipInputValidation(&r.SkipInputValidation))
+	f.StringVar(flags.UpgradeChannel(&r.UpgradeChannel))
 
 	f.StringVar(&cli.StringVar{
 		Name:    "dest",
@@ -129,14 +130,6 @@ func (r *RenderFlags) Register(set *cli.FlagSet) {
 		EnvVar:  "ABC_MANIFEST",
 		// TODO(upgrade): remove "(experimental)"
 		Usage: "(experimental) write a manifest file containing metadata that will allow future template upgrades.",
-	})
-
-	f.StringVar(&cli.StringVar{
-		Name:    "upgrade-channel",
-		Target:  &r.UpgradeChannel,
-		Default: "",
-		EnvVar:  "ABC_UPGRADE_CHANNEL",
-		Usage:   `overrides the "upgrade_channel" field in the output manifest, which controls where upgraded template versions will be pulled from in the future by "abc uprade". Can be either a branch name or the special string "latest". The default is to upgrade from the branch that the template was originally rendered from if rendered from a branch, or in any other case to use the value "latest" to upgrade to the latest release tag by semver order.`,
 	})
 
 	f.BoolVar(&cli.BoolVar{

--- a/templates/commands/upgrade/flags.go
+++ b/templates/commands/upgrade/flags.go
@@ -84,6 +84,9 @@ type Flags struct {
 	// template location stored in the manifest (which is the default).
 	TemplateLocation string
 
+	// See common/flags.UpgradeChannel().
+	UpgradeChannel string
+
 	Verbose bool
 
 	// The template version to upgrade to. If not specified, the underlying
@@ -123,6 +126,7 @@ func (f *Flags) Register(set *cli.FlagSet) {
 	r.BoolVar(flags.KeepTempDirs(&f.KeepTempDirs))
 	r.BoolVar(flags.Prompt(&f.Prompt))
 	r.BoolVar(flags.AcceptDefaults(&f.AcceptDefaults))
+	r.StringVar(flags.UpgradeChannel(&f.UpgradeChannel))
 
 	r.StringVar(&cli.StringVar{
 		Name:    "version",

--- a/templates/commands/upgrade/upgrade.go
+++ b/templates/commands/upgrade/upgrade.go
@@ -151,6 +151,7 @@ func (c *Command) Run(ctx context.Context, args []string) error {
 		SkipPromptTTYCheck:   c.skipPromptTTYCheck,
 		Stdout:               c.Stdout(),
 		TemplateLocation:     c.flags.TemplateLocation,
+		UpgradeChannel:       c.flags.UpgradeChannel,
 		Version:              c.flags.Version,
 	})
 	if result.Err != nil {

--- a/templates/common/flags/flags.go
+++ b/templates/common/flags/flags.go
@@ -152,3 +152,13 @@ func AcceptDefaults(a *bool) *cli.BoolVar {
 		Usage:   "when a template input has a default value, and the user didn't provide a value for that input, and prompting is disabled, this will cause the default value to be silently used.",
 	}
 }
+
+func UpgradeChannel(u *string) *cli.StringVar {
+	return &cli.StringVar{
+		Name:    "upgrade-channel",
+		Target:  u,
+		Default: "",
+		EnvVar:  "ABC_UPGRADE_CHANNEL",
+		Usage:   `overrides the "upgrade_channel" field in the output manifest, which controls where upgraded template versions will be pulled from in the future by "abc uprade". Can be either a branch name or the special string "latest". The default is to upgrade from the branch that the template was originally rendered from if rendered from a branch, or in any other case to use the value "latest" to upgrade to the latest release tag by semver order.`,
+	}
+}

--- a/templates/common/upgrade/upgrade.go
+++ b/templates/common/upgrade/upgrade.go
@@ -136,6 +136,10 @@ type Params struct {
 	// template location stored in the manifest (which is the default).
 	TemplateLocation string
 
+	// The value of --upgrade-channel. The branch to pull upgrades from, or the
+	// special string "latest".
+	UpgradeChannel string
+
 	// An optional version to update to, overriding the upgrade_channel field in
 	// the manifest.
 	//
@@ -429,6 +433,7 @@ func upgrade(ctx context.Context, p *Params, absManifestPath string) (_ *Manifes
 		SourceForMessages:       oldManifest.TemplateLocation.Val,
 		Stdout:                  p.Stdout,
 		TempDirBase:             p.TempDirBase,
+		UpgradeChannel:          p.UpgradeChannel,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed rendering template: %w", err)


### PR DESCRIPTION
This flag already existed on the `render` command, I just moved it to `common` and referenced it from the `upgrade` command now. This flag controls the `upgrade_channel` field on the manifest field that is output during rendering/upgrading.