### PR TITLE
Ignore the manifest Dirhash and Hash fields in test assertions

### DIFF
--- a/templates/common/render/render_test.go
+++ b/templates/common/render/render_test.go
@@ -185,7 +185,6 @@ steps:
 			wantManifest: &manifest.Manifest{
 				CreationTime:     clk.Now(),
 				ModificationTime: clk.Now(),
-				TemplateDirhash:  mdl.S("h1:Gym1rh37Q4e6h72ELjloc4lfVPR6B6tuRaLnFmakAYo="),
 				Inputs: []*manifest.Input{
 					{
 						Name:  mdl.S("emoji_suffix"),
@@ -203,15 +202,12 @@ steps:
 				OutputFiles: []*manifest.OutputFile{
 					{
 						File: mdl.S("dir1/file_in_dir.txt"),
-						Hash: mdl.S("h1:IeeGbHh8lPKI7ISJDiQTcNzKT/kATZ6IBgL4PbzOE4M="),
 					},
 					{
 						File: mdl.S("dir2/file2.txt"),
-						Hash: mdl.S("h1:AUDAxmpkSrLdJ6xVNvIMw3PW/RiW+YOOy0WVZ13aAfo="),
 					},
 					{
 						File: mdl.S("file1.txt"),
-						Hash: mdl.S("h1:UQ18krF3vW1ggpVvzlSWqmU0l4Fsuskdq7PaT9KHZ/4="),
 					},
 				},
 			},
@@ -241,7 +237,6 @@ steps:
 			wantManifest: &manifest.Manifest{
 				CreationTime:     clk.Now(),
 				ModificationTime: clk.Now(),
-				TemplateDirhash:  mdl.S("h1:Gym1rh37Q4e6h72ELjloc4lfVPR6B6tuRaLnFmakAYo="),
 				UpgradeChannel:   mdl.S("main"),
 				Inputs: []*manifest.Input{
 					{
@@ -260,15 +255,12 @@ steps:
 				OutputFiles: []*manifest.OutputFile{
 					{
 						File: mdl.S("dir1/file_in_dir.txt"),
-						Hash: mdl.S("h1:IeeGbHh8lPKI7ISJDiQTcNzKT/kATZ6IBgL4PbzOE4M="),
 					},
 					{
 						File: mdl.S("dir2/file2.txt"),
-						Hash: mdl.S("h1:AUDAxmpkSrLdJ6xVNvIMw3PW/RiW+YOOy0WVZ13aAfo="),
 					},
 					{
 						File: mdl.S("file1.txt"),
-						Hash: mdl.S("h1:UQ18krF3vW1ggpVvzlSWqmU0l4Fsuskdq7PaT9KHZ/4="),
 					},
 				},
 			},
@@ -293,7 +285,6 @@ steps:
 			wantManifest: &manifest.Manifest{
 				CreationTime:     clk.Now(),
 				ModificationTime: clk.Now(),
-				TemplateDirhash:  mdl.S("h1:Gym1rh37Q4e6h72ELjloc4lfVPR6B6tuRaLnFmakAYo="),
 				Inputs: []*manifest.Input{
 					{
 						Name:  mdl.S("emoji_suffix"),
@@ -311,15 +302,12 @@ steps:
 				OutputFiles: []*manifest.OutputFile{
 					{
 						File: mdl.S("dir1/file_in_dir.txt"),
-						Hash: mdl.S("h1:IeeGbHh8lPKI7ISJDiQTcNzKT/kATZ6IBgL4PbzOE4M="),
 					},
 					{
 						File: mdl.S("dir2/file2.txt"),
-						Hash: mdl.S("h1:AUDAxmpkSrLdJ6xVNvIMw3PW/RiW+YOOy0WVZ13aAfo="),
 					},
 					{
 						File: mdl.S("file1.txt"),
-						Hash: mdl.S("h1:UQ18krF3vW1ggpVvzlSWqmU0l4Fsuskdq7PaT9KHZ/4="),
 					},
 				},
 			},
@@ -349,7 +337,6 @@ steps:
 			wantManifest: &manifest.Manifest{
 				CreationTime:     clk.Now(),
 				ModificationTime: clk.Now(),
-				TemplateDirhash:  mdl.S("h1:Gym1rh37Q4e6h72ELjloc4lfVPR6B6tuRaLnFmakAYo="),
 				Inputs: []*manifest.Input{
 					{
 						Name:  mdl.S("emoji_suffix"),
@@ -662,11 +649,9 @@ steps:
 				// time we add a new api version
 				CreationTime:     clk.Now(),
 				ModificationTime: clk.Now(),
-				TemplateDirhash:  mdl.S("h1:aJN049UDpyv0f6rr9IApCi4PV3Z3llWM2OOSH+KCUzc="),
 				OutputFiles: []*manifest.OutputFile{
 					{
 						File: mdl.S("myfile.txt"),
-						Hash: mdl.S("h1:84uJzemmEjGfgzar/DclZc/GatFVOXD39/ewmvykVLs="),
 						Patch: mdl.SP(`--- a/myfile.txt
 +++ b/myfile.txt
 @@ -1 +1 @@
@@ -678,7 +663,6 @@ steps:
 					},
 					{
 						File: mdl.S("subdir_a/file_a.txt"),
-						Hash: mdl.S("h1:84uJzemmEjGfgzar/DclZc/GatFVOXD39/ewmvykVLs="),
 						Patch: mdl.SP(`--- a/subdir_a/file_a.txt
 +++ b/subdir_a/file_a.txt
 @@ -1 +1 @@
@@ -690,7 +674,6 @@ steps:
 					},
 					{
 						File: mdl.S("subdir_b/file_b.txt"),
-						Hash: mdl.S("h1:84uJzemmEjGfgzar/DclZc/GatFVOXD39/ewmvykVLs="),
 						Patch: mdl.SP(`--- a/subdir_b/file_b.txt
 +++ b/subdir_b/file_b.txt
 @@ -1 +1 @@
@@ -1476,7 +1459,6 @@ steps:
 			wantManifest: &manifest.Manifest{
 				CreationTime:     clk.Now(),
 				ModificationTime: clk.Now(),
-				TemplateDirhash:  mdl.S("h1:Gym1rh37Q4e6h72ELjloc4lfVPR6B6tuRaLnFmakAYo="),
 				Inputs: []*manifest.Input{
 					{
 						Name:  mdl.S("emoji_suffix"),
@@ -1494,15 +1476,12 @@ steps:
 				OutputFiles: []*manifest.OutputFile{
 					{
 						File: mdl.S("dir1/file_in_dir.txt"),
-						Hash: mdl.S("h1:IeeGbHh8lPKI7ISJDiQTcNzKT/kATZ6IBgL4PbzOE4M="),
 					},
 					{
 						File: mdl.S("dir2/file2.txt"),
-						Hash: mdl.S("h1:AUDAxmpkSrLdJ6xVNvIMw3PW/RiW+YOOy0WVZ13aAfo="),
 					},
 					{
 						File: mdl.S("file1.txt"),
-						Hash: mdl.S("h1:UQ18krF3vW1ggpVvzlSWqmU0l4Fsuskdq7PaT9KHZ/4="),
 					},
 				},
 			},
@@ -1639,6 +1618,8 @@ func verifyManifest(ctx context.Context, tb testing.TB, gotManifest bool, manife
 	opts := []cmp.Option{
 		// Don't force test authors to assert the line and column numbers
 		cmpopts.IgnoreTypes(&model.ConfigPos{}, model.ConfigPos{}),
+		cmpopts.IgnoreFields(manifest.Manifest{}, "TemplateDirhash"),
+		cmpopts.IgnoreFields(manifest.OutputFile{}, "Hash"),
 		cmpopts.EquateEmpty(),
 	}
 


### PR DESCRIPTION
Since these hashes change when we modify a test, we'll just ignore them so test authors don't have to provide a valid hash in the "want" manifest. This is better than updating these hashes whenever we modify or create a test case.