### PR TITLE
Remove Manifest option in favor of SkipManifest

### DIFF
--- a/cmd/abc/abc_test.go
+++ b/cmd/abc/abc_test.go
@@ -36,12 +36,12 @@ func TestRootCmd(t *testing.T) {
 	}{
 		{
 			name:       "render_prints_to_stdout",
-			args:       []string{"render", "--manifest=false", "--input=person_name=Bob", "../../examples/templates/render/print"},
+			args:       []string{"render", "--skip-manifest", "--input=person_name=Bob", "../../examples/templates/render/print"},
 			wantStdout: "Hello, Bob!\n",
 		},
 		{
 			name:       "old_templates_subcommand_render_prints_to_stdout",
-			args:       []string{"templates", "render", "--manifest=false", "--input=person_name=Bob", "../../examples/templates/render/print"},
+			args:       []string{"templates", "render", "--skip-manifest", "--input=person_name=Bob", "../../examples/templates/render/print"},
 			wantStdout: "Hello, Bob!\n",
 		},
 		{

--- a/templates/commands/goldentest/test_funcs.go
+++ b/templates/commands/goldentest/test_funcs.go
@@ -198,6 +198,7 @@ func renderTestCase(ctx context.Context, templateDir, outputDir string, tc *Test
 		FS:                  &common.RealFS{},
 		InputsFromFlags:     varValuesToMap(tc.TestConfig.Inputs),
 		OverrideBuiltinVars: varValuesToMap(tc.TestConfig.BuiltinVars),
+		SkipManifest:        true,
 		SourceForMessages:   templateDir,
 		Stdout:              stdoutBuf,
 	})

--- a/templates/commands/goldentest/test_funcs_test.go
+++ b/templates/commands/goldentest/test_funcs_test.go
@@ -579,7 +579,9 @@ steps:
 				return
 			}
 
-			gotDestContents := abctestutil.LoadDir(t, filepath.Join(tempDir, "testdata/golden/test"))
+			gotDestContents := abctestutil.LoadDir(t, filepath.Join(tempDir, "testdata/golden/test"),
+				abctestutil.SkipGlob(".abc/manifest*"), // manifests are asserted separately
+			)
 			if diff := cmp.Diff(gotDestContents, tc.want); diff != "" {
 				t.Errorf("dest directory contents were not as expected (-got,+want): %s", diff)
 			}

--- a/templates/commands/render/flags.go
+++ b/templates/commands/render/flags.go
@@ -81,7 +81,7 @@ type RenderFlags struct {
 
 	// Manifest enables the writing of manifest files, which are an experimental
 	// feature related to template upgrades.
-	Manifest bool
+	SkipManifest bool
 
 	// Whether to *only* create a manifest file without outputting any other
 	// files from the template.
@@ -129,12 +129,12 @@ func (r *RenderFlags) Register(set *cli.FlagSet) {
 	f.BoolVar(flags.AcceptDefaults(&r.AcceptDefaults))
 
 	f.BoolVar(&cli.BoolVar{
-		Name:    "manifest",
-		Target:  &r.Manifest,
-		Default: true,
-		EnvVar:  "ABC_MANIFEST",
+		Name:    "skip-manifest",
+		Target:  &r.SkipManifest,
+		Default: false,
+		EnvVar:  "ABC_SKIP_MANIFEST",
 		// TODO(upgrade): remove "(experimental)"
-		Usage: "(experimental) write a manifest file containing metadata that will allow future template upgrades.",
+		Usage: "(experimental) skip writing a manifest file containing metadata that will allow future template upgrades.",
 	})
 
 	f.BoolVar(&cli.BoolVar{
@@ -143,7 +143,7 @@ func (r *RenderFlags) Register(set *cli.FlagSet) {
 		Default: false,
 		EnvVar:  "ABC_MANIFEST_ONLY",
 		// TODO(upgrade): remove "(experimental)"
-		Usage: "(experimental) write only a manifest file and no other files; implicitly sets --manifest=true; this is for the case where you have already rendered a template but there's no manifest, and you want to create just the manifest",
+		Usage: "(experimental) write only a manifest file and no other files; implicitly sets --skip-manifest=false; this is for the case where you have already rendered a template but there's no manifest, and you want to create just the manifest",
 	})
 
 	f.BoolVar(&cli.BoolVar{
@@ -167,11 +167,6 @@ func (r *RenderFlags) Register(set *cli.FlagSet) {
 		r.Source = strings.TrimSpace(set.Arg(0))
 		if r.Source == "" {
 			return fmt.Errorf("missing <source> file")
-		}
-
-		if r.BackfillManifestOnly {
-			// --backfill-manifest-only implies the user wants a manifest.
-			r.Manifest = true
 		}
 
 		return nil

--- a/templates/commands/render/render.go
+++ b/templates/commands/render/render.go
@@ -113,9 +113,12 @@ func (c *Command) Run(ctx context.Context, args []string) error {
 		return err //nolint:wrapcheck
 	}
 
+	skipManifest := c.flags.SkipManifest && !c.flags.BackfillManifestOnly
+
 	_, err = render.Render(ctx, &render.Params{
 		AcceptDefaults:         c.flags.AcceptDefaults,
 		ContinueWithoutPatches: c.flags.ContinueWithoutPatches,
+		BackfillManifestOnly:   c.flags.BackfillManifestOnly,
 		BackupDir:              backupDir,
 		Backups:                true,
 		Clock:                  clock.New(),
@@ -131,11 +134,10 @@ func (c *Command) Run(ctx context.Context, args []string) error {
 		InputsFromFlags:        c.flags.Inputs,
 		InputFiles:             c.flags.InputFiles,
 		KeepTempDirs:           c.flags.KeepTempDirs,
-		Manifest:               c.flags.Manifest,
-		BackfillManifestOnly:   c.flags.BackfillManifestOnly,
 		Prompt:                 c.flags.Prompt,
 		Prompter:               c,
 		SkipInputValidation:    c.flags.SkipInputValidation,
+		SkipManifest:           skipManifest,
 		SkipPromptTTYCheck:     c.skipPromptTTYCheck,
 		SourceForMessages:      c.flags.Source,
 		Stdout:                 c.Stdout(),

--- a/templates/commands/upgrade/upgrade_test.go
+++ b/templates/commands/upgrade/upgrade_test.go
@@ -235,7 +235,6 @@ these flags:
 				DestDir:     destDir,
 				Downloader:  downloader,
 				FS:          &common.RealFS{},
-				Manifest:    true,
 				OutDir:      destDir,
 				TempDirBase: tempBase,
 			})
@@ -468,7 +467,6 @@ steps:
 				DestDir:     destDir,
 				Downloader:  downloader,
 				FS:          &common.RealFS{},
-				Manifest:    true,
 				OutDir:      destDir,
 				TempDirBase: tempBase,
 			})

--- a/templates/common/render/render_test.go
+++ b/templates/common/render/render_test.go
@@ -102,7 +102,6 @@ steps:
 		flagForceOverwrite         bool
 		flagIgnoreUnknownInputs    bool
 		flagSkipInputValidation    bool
-		flagManifest               bool
 		flagBackfillManifestOnly   bool
 		flagUpgradeChannel         string
 		flagDebugStepDiffs         bool
@@ -140,6 +139,20 @@ steps:
 				"dir1/file_in_dir.txt": "file_in_dir contents",
 				"dir2/file2.txt":       "file2 contents",
 			},
+			wantManifest: &manifest.Manifest{
+				CreationTime:     clk.Now(),
+				ModificationTime: clk.Now(),
+				Inputs: []*manifest.Input{
+					{Name: mdl.S("emoji_suffix"), Value: mdl.S("🐈")},
+					{Name: mdl.S("ending_punctuation"), Value: mdl.S("!")},
+					{Name: mdl.S("name_to_greet"), Value: mdl.S("Bob")},
+				},
+				OutputFiles: []*manifest.OutputFile{
+					{File: mdl.S("dir1/file_in_dir.txt")},
+					{File: mdl.S("dir2/file2.txt")},
+					{File: mdl.S("file1.txt")},
+				},
+			},
 		},
 		{
 			name: "simple_success_with_debug_flag",
@@ -162,6 +175,35 @@ steps:
 				"dir1/file_in_dir.txt": "file_in_dir contents",
 				"dir2/file2.txt":       "file2 contents",
 			},
+			wantManifest: &manifest.Manifest{
+				CreationTime:     clk.Now(),
+				ModificationTime: clk.Now(),
+				Inputs: []*manifest.Input{
+					{
+						Name:  mdl.S("emoji_suffix"),
+						Value: mdl.S("\U0001F408"),
+					},
+					{
+						Name:  mdl.S("ending_punctuation"),
+						Value: mdl.S("!"),
+					},
+					{
+						Name:  mdl.S("name_to_greet"),
+						Value: mdl.S("Bob"),
+					},
+				},
+				OutputFiles: []*manifest.OutputFile{
+					{
+						File: mdl.S("dir1/file_in_dir.txt"),
+					},
+					{
+						File: mdl.S("dir2/file2.txt"),
+					},
+					{
+						File: mdl.S("file1.txt"),
+					},
+				},
+			},
 		},
 		{
 			name: "simple_success_with_manifest",
@@ -177,8 +219,7 @@ steps:
 				"dir1/file_in_dir.txt": "file_in_dir contents",
 				"dir2/file2.txt":       "file2 contents",
 			},
-			flagManifest: true,
-			wantStdout:   "Hello, Bob🐈!\n",
+			wantStdout: "Hello, Bob🐈!\n",
 			wantDestContents: map[string]string{
 				"file1.txt":            "my favorite color is red",
 				"dir1/file_in_dir.txt": "file_in_dir contents",
@@ -228,7 +269,6 @@ steps:
 				"dir1/file_in_dir.txt": "file_in_dir contents",
 				"dir2/file2.txt":       "file2 contents",
 			},
-			flagManifest:       true,
 			flagUpgradeChannel: "main",
 			wantStdout:         "Hello, Bob🐈!\n",
 			wantDestContents: map[string]string{
@@ -281,7 +321,6 @@ steps:
 				"dir1/file_in_dir.txt": "file_in_dir contents",
 				"dir2/file2.txt":       "file2 contents",
 			},
-			flagManifest:             true,
 			flagBackfillManifestOnly: true,
 			wantDestContents:         map[string]string{},
 			wantManifest: &manifest.Manifest{
@@ -328,7 +367,6 @@ steps:
 				"dir1/file_in_dir.txt": "file_in_dir contents",
 				"dir2/file2.txt":       "file2 contents",
 			},
-			flagManifest:             true,
 			flagBackfillManifestOnly: true,
 			existingDestContents: map[string]string{
 				"file1.txt": "existing contents",
@@ -388,7 +426,6 @@ steps:
           - to_replace: 'purple'
             with: 'red'`,
 			},
-			flagManifest:               true,
 			flagBackfillManifestOnly:   true,
 			flagContinueWithoutPatches: true,
 			existingDestContents: map[string]string{
@@ -430,6 +467,20 @@ ending_punctuation: '.'`,
 				"dir1/file_in_dir.txt": "file_in_dir contents",
 				"dir2/file2.txt":       "file2 contents",
 			},
+			wantManifest: &manifest.Manifest{
+				CreationTime:     clk.Now(),
+				ModificationTime: clk.Now(),
+				Inputs: []*manifest.Input{
+					{Name: mdl.S("emoji_suffix"), Value: mdl.S("🐈")},
+					{Name: mdl.S("ending_punctuation"), Value: mdl.S(".")},
+					{Name: mdl.S("name_to_greet"), Value: mdl.S("Bob")},
+				},
+				OutputFiles: []*manifest.OutputFile{
+					{File: mdl.S("dir1/file_in_dir.txt")},
+					{File: mdl.S("dir2/file2.txt")},
+					{File: mdl.S("file1.txt")},
+				},
+			},
 		},
 		{
 			name:           "simple_success_with_both_inputs_and_input_file_flags",
@@ -454,6 +505,35 @@ emoji_suffix: '🐈'`,
 				"dir1/file_in_dir.txt": "file_in_dir contents",
 				"dir2/file2.txt":       "file2 contents",
 			},
+			wantManifest: &manifest.Manifest{
+				CreationTime:     clk.Now(),
+				ModificationTime: clk.Now(),
+				Inputs: []*manifest.Input{
+					{
+						Name:  mdl.S("emoji_suffix"),
+						Value: mdl.S("\U0001F408"),
+					},
+					{
+						Name:  mdl.S("ending_punctuation"),
+						Value: mdl.S("."),
+					},
+					{
+						Name:  mdl.S("name_to_greet"),
+						Value: mdl.S("Robert"),
+					},
+				},
+				OutputFiles: []*manifest.OutputFile{
+					{
+						File: mdl.S("dir1/file_in_dir.txt"),
+					},
+					{
+						File: mdl.S("dir2/file2.txt"),
+					},
+					{
+						File: mdl.S("file1.txt"),
+					},
+				},
+			},
 		},
 		{
 			name:           "simple_success_with_two_input_file_flags",
@@ -477,6 +557,20 @@ emoji_suffix: '🐈'`,
 				"file1.txt":            "my favorite color is red",
 				"dir1/file_in_dir.txt": "file_in_dir contents",
 				"dir2/file2.txt":       "file2 contents",
+			},
+			wantManifest: &manifest.Manifest{
+				CreationTime:     clk.Now(),
+				ModificationTime: clk.Now(),
+				Inputs: []*manifest.Input{
+					{Name: mdl.S("emoji_suffix"), Value: mdl.S("🐈")},
+					{Name: mdl.S("ending_punctuation"), Value: mdl.S(".")},
+					{Name: mdl.S("name_to_greet"), Value: mdl.S("Bob")},
+				},
+				OutputFiles: []*manifest.OutputFile{
+					{File: mdl.S("dir1/file_in_dir.txt")},
+					{File: mdl.S("dir2/file2.txt")},
+					{File: mdl.S("file1.txt")},
+				},
 			},
 		},
 		{
@@ -522,6 +616,20 @@ emoji_suffix: '🐈'`,
 				"dir1/file_in_dir.txt": "file_in_dir contents",
 				"dir2/file2.txt":       "file2 contents",
 			},
+			wantManifest: &manifest.Manifest{
+				CreationTime:     clk.Now(),
+				ModificationTime: clk.Now(),
+				Inputs: []*manifest.Input{
+					{Name: mdl.S("emoji_suffix"), Value: mdl.S("🐈")},
+					{Name: mdl.S("ending_punctuation"), Value: mdl.S(".")},
+					{Name: mdl.S("name_to_greet"), Value: mdl.S("Bob")},
+				},
+				OutputFiles: []*manifest.OutputFile{
+					{File: mdl.S("dir1/file_in_dir.txt")},
+					{File: mdl.S("dir2/file2.txt")},
+					{File: mdl.S("file1.txt")},
+				},
+			},
 		},
 		{
 			name: "keep_temp_dirs_on_failure_if_flag",
@@ -564,6 +672,20 @@ emoji_suffix: '🐈'`,
 			},
 			wantBackupContents: map[string]string{
 				"file1.txt": "old contents",
+			},
+			wantManifest: &manifest.Manifest{
+				CreationTime:     clk.Now(),
+				ModificationTime: clk.Now(),
+				Inputs: []*manifest.Input{
+					{Name: mdl.S("emoji_suffix"), Value: mdl.S("🐈")},
+					{Name: mdl.S("ending_punctuation"), Value: mdl.S(".")},
+					{Name: mdl.S("name_to_greet"), Value: mdl.S("Bob")},
+				},
+				OutputFiles: []*manifest.OutputFile{
+					{File: mdl.S("dir1/file_in_dir.txt")},
+					{File: mdl.S("dir2/file2.txt")},
+					{File: mdl.S("file1.txt")},
+				},
 			},
 		},
 		{
@@ -616,6 +738,20 @@ emoji_suffix: '🐈'`,
 				"dir1/file_in_dir.txt": "file_in_dir contents",
 				"dir2/file2.txt":       "file2 contents",
 			},
+			wantManifest: &manifest.Manifest{
+				CreationTime:     clk.Now(),
+				ModificationTime: clk.Now(),
+				Inputs: []*manifest.Input{
+					{Name: mdl.S("emoji_suffix"), Value: mdl.S("🐈")},
+					{Name: mdl.S("ending_punctuation"), Value: mdl.S(".")},
+					{Name: mdl.S("name_to_greet"), Value: mdl.S("Bob")},
+				},
+				OutputFiles: []*manifest.OutputFile{
+					{File: mdl.S("dir1/file_in_dir.txt")},
+					{File: mdl.S("dir2/file2.txt")},
+					{File: mdl.S("file1.txt")},
+				},
+			},
 		},
 		{
 			name: "handles_unknown_inputs",
@@ -648,8 +784,7 @@ emoji_suffix: '🐈'`,
 			wantErr: `missing input(s): emoji_suffix, name_to_greet`,
 		},
 		{
-			name:         "destination_include_with_manifest",
-			flagManifest: true,
+			name: "destination_include_with_manifest",
 			templateContents: map[string]string{
 				"spec.yaml": `
 api_version: 'cli.abcxyz.dev/v1alpha1'
@@ -765,6 +900,24 @@ steps:
 			wantBackupContents: map[string]string{
 				"file_a.txt": "purple is my favorite color",
 			},
+			wantManifest: &manifest.Manifest{
+				CreationTime:     clk.Now(),
+				ModificationTime: clk.Now(),
+				OutputFiles: []*manifest.OutputFile{
+					{
+						File: mdl.S("file_a.txt"),
+						Patch: mdl.SP(`--- a/file_a.txt
++++ b/file_a.txt
+@@ -1 +1 @@
+-red is my favorite color
+\ No newline at end of file
++purple is my favorite color
+\ No newline at end of file
+`),
+					},
+					{File: mdl.S("file_b.txt")},
+				},
+			},
 		},
 		{
 			name: "with_default_ignore",
@@ -806,6 +959,27 @@ steps:
 			},
 			wantBackupContents: map[string]string{
 				"file_a.txt": "purple is my favorite color",
+			},
+			wantManifest: &manifest.Manifest{
+				CreationTime:     clk.Now(),
+				ModificationTime: clk.Now(),
+
+				OutputFiles: []*manifest.OutputFile{
+					{
+						File: mdl.S("dir/file_b.txt"),
+					},
+					{
+						File: mdl.S("file_a.txt"),
+						Patch: mdl.SP(`--- a/file_a.txt
++++ b/file_a.txt
+@@ -1 +1 @@
+-red is my favorite color
+\ No newline at end of file
++purple is my favorite color
+\ No newline at end of file
+`),
+					},
+				},
 			},
 		},
 		{
@@ -849,6 +1023,23 @@ steps:
 			wantBackupContents: map[string]string{
 				"file_a.txt": "purple is my favorite color",
 			},
+			wantManifest: &manifest.Manifest{
+				CreationTime:     clk.Now(),
+				ModificationTime: clk.Now(),
+				OutputFiles: []*manifest.OutputFile{
+					{
+						File: mdl.S("file_a.txt"),
+						Patch: mdl.SP(`--- a/file_a.txt
++++ b/file_a.txt
+@@ -1 +1 @@
+-red is my favorite color
+\ No newline at end of file
++purple is my favorite color
+\ No newline at end of file
+`),
+					},
+				},
+			},
 		},
 		{
 			name: "simple_skip",
@@ -868,6 +1059,10 @@ steps:
 `,
 			},
 			wantDestContents: map[string]string{},
+			wantManifest: &manifest.Manifest{
+				CreationTime:     clk.Now(),
+				ModificationTime: clk.Now(),
+			},
 		},
 		{
 			name: "glob_include",
@@ -908,6 +1103,18 @@ steps:
 				"dir2/something.json":        "json contents",
 				"python_files/include_me.py": "include_me contents",
 			},
+			wantManifest: &manifest.Manifest{
+				CreationTime:     clk.Now(),
+				ModificationTime: clk.Now(),
+				OutputFiles: []*manifest.OutputFile{
+					{File: mdl.S("dir1/something.md")},
+					{File: mdl.S("dir2/something.json")},
+					{File: mdl.S("file1.txt")},
+					{File: mdl.S("file2.txt")},
+					{File: mdl.S("file3.txt")},
+					{File: mdl.S("python_files/include_me.py")},
+				},
+			},
 		},
 		{
 			name: "for_each",
@@ -931,6 +1138,10 @@ steps:
 			},
 			wantStdout:       "Working on environment production\nWorking on environment dev\n",
 			wantDestContents: map[string]string{},
+			wantManifest: &manifest.Manifest{
+				CreationTime:     clk.Now(),
+				ModificationTime: clk.Now(),
+			},
 		},
 		{
 			name: "skip_input_validation",
@@ -955,6 +1166,13 @@ steps:
 			flagSkipInputValidation: true,
 			wantStdout:              "my_input is crocodile\n",
 			wantDestContents:        map[string]string{},
+			wantManifest: &manifest.Manifest{
+				CreationTime:     clk.Now(),
+				ModificationTime: clk.Now(),
+				Inputs: []*manifest.Input{
+					{Name: mdl.S("my_input"), Value: mdl.S("crocodile")},
+				},
+			},
 		},
 		{
 			name: "step_with_if",
@@ -983,6 +1201,13 @@ steps:
 			flagAcceptDefaults: true,
 			wantStdout:         "Hello\n",
 			wantDestContents:   map[string]string{},
+			wantManifest: &manifest.Manifest{
+				CreationTime:     clk.Now(),
+				ModificationTime: clk.Now(),
+				Inputs: []*manifest.Input{
+					{Name: mdl.S("my_input"), Value: mdl.S("true")},
+				},
+			},
 		},
 		{
 			name: "step_with_if_needs_v1beta1",
@@ -1038,6 +1263,20 @@ emoji_suffix: '🐈'`,
 				"file1.txt":            "my favorite color is red",
 				"dir1/file_in_dir.txt": "file_in_dir contents",
 				"dir2/file2.txt":       "file2 contents",
+			},
+			wantManifest: &manifest.Manifest{
+				CreationTime:     clk.Now(),
+				ModificationTime: clk.Now(),
+				Inputs: []*manifest.Input{
+					{Name: mdl.S("emoji_suffix"), Value: mdl.S("🐈")},
+					{Name: mdl.S("ending_punctuation"), Value: mdl.S(".")},
+					{Name: mdl.S("name_to_greet"), Value: mdl.S("Robert")},
+				},
+				OutputFiles: []*manifest.OutputFile{
+					{File: mdl.S("dir1/file_in_dir.txt")},
+					{File: mdl.S("dir2/file2.txt")},
+					{File: mdl.S("file1.txt")},
+				},
 			},
 		},
 		{
@@ -1104,6 +1343,13 @@ module "cloud_run" {
 }
 `, abctestutil.MinimalGitHeadSHA, abctestutil.MinimalGitHeadShortSHA, "v1.2.3"),
 			},
+			wantManifest: &manifest.Manifest{
+				CreationTime:     clk.Now(),
+				ModificationTime: clk.Now(),
+				OutputFiles: []*manifest.OutputFile{
+					{File: mdl.S("example.tf")},
+				},
+			},
 		},
 		{
 			name: "git_metadata_variables_are_empty_string_when_unavailable",
@@ -1124,6 +1370,13 @@ steps:
 			},
 			wantDestContents: map[string]string{
 				"example.txt": `"" "" ""`,
+			},
+			wantManifest: &manifest.Manifest{
+				CreationTime:     clk.Now(),
+				ModificationTime: clk.Now(),
+				OutputFiles: []*manifest.OutputFile{
+					{File: mdl.S("example.txt")},
+				},
 			},
 		},
 		{
@@ -1177,6 +1430,10 @@ steps:
 			},
 			wantStdout:       "/my/dest /my/source\n",
 			wantDestContents: map[string]string{},
+			wantManifest: &manifest.Manifest{
+				CreationTime:     clk.Now(),
+				ModificationTime: clk.Now(),
+			},
 		},
 		{
 			name:       "print_only_flags_are_not_in_scope_outside_of_print_actions",
@@ -1316,6 +1573,13 @@ steps:
 			wantDestContents: map[string]string{
 				"foo/.abc": "",
 			},
+			wantManifest: &manifest.Manifest{
+				CreationTime:     clk.Now(),
+				ModificationTime: clk.Now(),
+				OutputFiles: []*manifest.OutputFile{
+					{File: mdl.S("foo/.abc")},
+				},
+			},
 		},
 		{
 			name: "abc_is_not_reserved_as_subdir_name",
@@ -1335,6 +1599,13 @@ steps:
 			},
 			wantDestContents: map[string]string{
 				"foo/.abc/bar.txt": "",
+			},
+			wantManifest: &manifest.Manifest{
+				CreationTime:     clk.Now(),
+				ModificationTime: clk.Now(),
+				OutputFiles: []*manifest.OutputFile{
+					{File: mdl.S("foo/.abc/bar.txt")},
+				},
 			},
 		},
 		{
@@ -1358,6 +1629,10 @@ steps:
 			}),
 			wantStdout:       "rule validation passed\n",
 			wantDestContents: map[string]string{},
+			wantManifest: &manifest.Manifest{
+				CreationTime:     clk.Now(),
+				ModificationTime: clk.Now(),
+			},
 		},
 		{
 			name: "independent_rule_validation_invalid_rules",
@@ -1415,6 +1690,10 @@ steps:
 			},
 			wantStdout:       "git sha: ahl8foqboh8ktqzxnymuvdcg91hvim0cfszlcstl\ngit short sha: ahl8foq\ngit tag: v1.2.3\n",
 			wantDestContents: map[string]string{},
+			wantManifest: &manifest.Manifest{
+				CreationTime:     clk.Now(),
+				ModificationTime: clk.Now(),
+			},
 		},
 		{
 			name: "formatTime_not_in_scope_on_old_spec",
@@ -1443,6 +1722,10 @@ steps:
     message: 'The timestamp is {{formatTime ._now_ms "2006-01-02T15:04:05"}}'`,
 			},
 			wantStdout: "The timestamp is 2023-12-08T23:59:02\n",
+			wantManifest: &manifest.Manifest{
+				CreationTime:     clk.Now(),
+				ModificationTime: clk.Now(),
+			},
 		},
 		{
 			name: "_now_ms_not_in_scope_on_old_spec",
@@ -1471,6 +1754,10 @@ steps:
     message: 'The timestamp is {{ ._now_ms }}'`,
 			},
 			wantStdout: "The timestamp is 1702079942000\n",
+			wantManifest: &manifest.Manifest{
+				CreationTime:     clk.Now(),
+				ModificationTime: clk.Now(),
+			},
 		},
 		{
 			name: "flag_ignore_unknown_inputs",
@@ -1483,7 +1770,6 @@ steps:
 				"ending_punctuation": "!",
 			},
 			flagIgnoreUnknownInputs: true,
-			flagManifest:            true,
 			templateContents: map[string]string{
 				"myfile.txt":           "Some random stuff",
 				"spec.yaml":            specContents,
@@ -1567,7 +1853,6 @@ steps:
 				InputFiles:           inputFilePaths,
 				InputsFromFlags:      tc.flagInputs,
 				KeepTempDirs:         tc.flagKeepTempDirs,
-				Manifest:             tc.flagManifest,
 				BackfillManifestOnly: tc.flagBackfillManifestOnly,
 				OutDir:               outDir,
 				OverrideBuiltinVars:  tc.overrideBuiltinVars,

--- a/templates/common/upgrade/upgrade.go
+++ b/templates/common/upgrade/upgrade.go
@@ -425,7 +425,6 @@ func upgrade(ctx context.Context, p *Params, absManifestPath string) (_ *Manifes
 		IncludeFromDestExtraDir: reversedDir,
 		InputsFromFlags:         p.InputsFromFlags,
 		KeepTempDirs:            p.KeepTempDirs,
-		Manifest:                true,
 		OutDir:                  mergeDir,
 		Prompt:                  p.Prompt,
 		Prompter:                p.Prompter,

--- a/templates/common/upgrade/upgrade_test.go
+++ b/templates/common/upgrade/upgrade_test.go
@@ -1636,8 +1636,8 @@ yellow is my favorite color
 			assertManifest(ctx, t, "after upgrade", tc.wantManifestAfterUpgrade, manifestFullPath)
 
 			gotDestContentsAfter := abctestutil.LoadDir(t, destDir,
-				abctestutil.SkipGlob(".abc/manifest*"),
-				abctestutil.SkipGlob("*.patch.rej"), // rejected hunk files are asserted separately
+				abctestutil.SkipGlob(".abc/manifest*"), // manifests are asserted separately
+				abctestutil.SkipGlob("*.patch.rej"),    // rejected hunk files are asserted separately
 			)
 			if diff := cmp.Diff(gotDestContentsAfter, tc.wantDestContentsAfterUpgrade); diff != "" {
 				t.Errorf("installed directory contents after upgrading were not as expected (-got,+want): %s", diff)
@@ -2462,7 +2462,6 @@ func mustRender(tb testing.TB, ctx context.Context, clk clock.Clock, fakeDL *fak
 		DestDir:     destDir,
 		Downloader:  downloader,
 		FS:          &common.RealFS{},
-		Manifest:    true,
 		OutDir:      destDir,
 		TempDirBase: tempBase,
 	})


### PR DESCRIPTION
Going forward, we want render operations to default to producing a manifest, so they're upgradeable later. Therefore, in the Render() library API, we want to invert to sense of the Manifest bool to SkipManifest so that the default value of false does the desirable default behavior.

This is technically part of an exported API that shouldn't be changed, but since there's only one non-CLI user of this, and he's on our team, we'll allow it to change.

To be consistent with the above, the command line flag also changes from --manifest to --skip-manifest. This is also a backwards-incompatible change, but since the flag is documented as experimental, we'll allow it.

We also update a bunch of tests to assert on the produced manifests.