### PR TITLE
fix: go.mod file should be included in template output

### DIFF
--- a/examples/templates/render/hello_jupiter/spec.yaml
+++ b/examples/templates/render/hello_jupiter/spec.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: 'cli.abcxyz.dev/v1alpha1'
+apiVersion: 'cli.abcxyz.dev/v1beta6'
 kind: 'Template'
 
 desc:
@@ -22,7 +22,8 @@ steps:
   - desc: 'Include some files and directories'
     action: 'include'
     params:
-      paths: ['main.go']
+      paths: ['*']
+      skip: ['README.md']  # The README is about the template, not about the program that it outputs
   - desc: 'Replace "world" with "jupiter"'
     action: 'string_replace'
     params:

--- a/examples/templates/render/hello_jupiter/testdata/golden/example_test/data/go.mod
+++ b/examples/templates/render/hello_jupiter/testdata/golden/example_test/data/go.mod
@@ -1,0 +1,5 @@
+module github.com/abcxyz/abc/examples/templates/render/hello_jupiter
+
+go 1.22
+
+toolchain go1.22.1


### PR DESCRIPTION
The hello_jupiter file contained a go.mod file that was supposed to part of the template output, but it was never mentioned in the spec file and therefore was not actually used.

The fix is to include all files by wildcard. This requires updating the api_version to a version where wildcards are supported (v1beta6 is the latest).

We also ran `abc golden-test record` to update the recorded golden-test output with the new file.