### PR TITLE
fix: the manifest upgrade_channel field was sometimes omitted

### DIFF
--- a/templates/common/functional.go
+++ b/templates/common/functional.go
@@ -1,0 +1,28 @@
+// Copyright 2024 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+// FirstNonZero returns the first element of s that is not the zero value for
+// its type. It returns the zero value if all elements of s are zero or if s is
+// empty.
+func FirstNonZero[T comparable](s ...T) T {
+	var zero T
+	for _, e := range s {
+		if e != zero {
+			return e
+		}
+	}
+	return zero
+}

--- a/templates/common/templatesource/upgrade.go
+++ b/templates/common/templatesource/upgrade.go
@@ -80,8 +80,11 @@ type ForUpgradeParams struct {
 	// branch, or a SHA.
 	Version string
 
-	// The value of --upgrade-channel
-	FlagUpgradeChannel string
+	// Optional: the value of the UpgradeChannel to be returned in the
+	// DownloadMetadata of the returned Downloader. This can come from the
+	// --upgrade-channel or from the manifest being upgraded. Leave empty to
+	// autodetect the upgrade channel based on the Version field.
+	UpgradeChannel string
 }
 
 func remoteGitUpgradeDownloaderFactory(ctx context.Context, f *ForUpgradeParams) (Downloader, error) {
@@ -90,7 +93,7 @@ func remoteGitUpgradeDownloaderFactory(ctx context.Context, f *ForUpgradeParams)
 		input:              f.CanonicalLocation,
 		gitProtocol:        f.GitProtocol,
 		defaultVersion:     f.Version,
-		flagUpgradeChannel: f.FlagUpgradeChannel,
+		flagUpgradeChannel: f.UpgradeChannel,
 	})
 	if err != nil {
 		return nil, err

--- a/templates/common/templatesource/upgrade_test.go
+++ b/templates/common/templatesource/upgrade_test.go
@@ -185,12 +185,12 @@ func TestForUpgrade(t *testing.T) {
 			installedInDir := filepath.Join(tempDir, tc.installedInSubdir)
 
 			downloader, err := ForUpgrade(ctx, &ForUpgradeParams{
-				LocType:            tc.locType,
-				CanonicalLocation:  location,
-				InstalledDir:       installedInDir,
-				GitProtocol:        tc.gitProtocol,
-				Version:            tc.version,
-				FlagUpgradeChannel: tc.flagUpgradeChannel,
+				LocType:           tc.locType,
+				CanonicalLocation: location,
+				InstalledDir:      installedInDir,
+				GitProtocol:       tc.gitProtocol,
+				Version:           tc.version,
+				UpgradeChannel:    tc.flagUpgradeChannel,
 			})
 			if diff := testutil.DiffErrString(err, tc.wantErr); diff != "" {
 				t.Fatal(diff)


### PR DESCRIPTION
There was a bug in the case where we do `abc upgrade --version foo` to upgrade (or downgrade) to a specific version. In that case, the `upgrade_channel` field in the new manifest would be empty. The desired behavior is for the new manifest to have an upgrade_channel field equal to --upgrade-channel (if provided) or just inherit the upgrade_channel field from the old manifest.

The `FlagUpgradeChannel` struct field is renamed to `UpgradeChannel` because now it doesn't always come from a flag.