### PR TITLE
Reuse already-loaded manifest instead of re-reading

### DIFF
--- a/templates/common/upgrade/upgrade.go
+++ b/templates/common/upgrade/upgrade.go
@@ -329,7 +329,7 @@ type ActionTaken struct {
 //
 // Returns true if the upgrade occurred, or false if the upgrade was skipped
 // because we're already on the latest version of the template.
-func upgrade(ctx context.Context, p *Params, absManifestPath string) (_ *ManifestResult, rErr error) {
+func upgrade(ctx context.Context, p *Params, absManifestPath string, oldManifest *manifest.Manifest) (_ *ManifestResult, rErr error) {
 	logger := logging.FromContext(ctx).With("logger", "upgrade")
 
 	// For now, manifest files are always located in the .abc directory under
@@ -337,11 +337,6 @@ func upgrade(ctx context.Context, p *Params, absManifestPath string) (_ *Manifes
 	installedDir := filepath.Join(filepath.Dir(absManifestPath), "..")
 
 	if err := detectUnmergedConflicts(installedDir); err != nil {
-		return nil, err
-	}
-
-	oldManifest, err := loadManifest(ctx, p.FS, absManifestPath)
-	if err != nil {
 		return nil, err
 	}
 

--- a/templates/common/upgrade/upgradeall.go
+++ b/templates/common/upgrade/upgradeall.go
@@ -88,7 +88,7 @@ func UpgradeAll(ctx context.Context, p *Params) *Result {
 		return &Result{Err: err}
 	}
 
-	_, sorted, depGraph, err := manifestsToUpgrade(ctx, p)
+	manifests, sorted, depGraph, err := manifestsToUpgrade(ctx, p)
 	if err != nil {
 		return &Result{Err: err}
 	}
@@ -104,7 +104,8 @@ func UpgradeAll(ctx context.Context, p *Params) *Result {
 		}
 		logger.InfoContext(ctx, "beginning upgrade of manifest",
 			"manifest", absManifestPath)
-		result, err := upgrade(ctx, p, absManifestPath)
+		manifest := manifests[manifestPath]
+		result, err := upgrade(ctx, p, absManifestPath, manifest)
 		if err != nil {
 			out.Err = fmt.Errorf("when upgrading the manifest at %s:\n%w", absManifestPath, err)
 			break


### PR DESCRIPTION
Before this, we were unnecessarily re-reading the manifest from the filesystem. It's already loaded in UpgradeAll(), so now we just pass it to upgrade() instead of passing the path and re-parsing the manifest.