### PR TITLE
Add the --manifest-filter flag to `upgrade` with CEL filtering

### DIFF
--- a/templates/commands/goldentest/test_funcs.go
+++ b/templates/commands/goldentest/test_funcs.go
@@ -151,7 +151,7 @@ func parseTestConfig(ctx context.Context, path string) (*goldentest.Test, error)
 	}
 	defer f.Close()
 
-	testI, err := decode.DecodeValidateUpgrade(ctx, f, path, decode.KindGoldenTest)
+	testI, _, err := decode.DecodeValidateUpgrade(ctx, f, path, decode.KindGoldenTest)
 	if err != nil {
 		return nil, fmt.Errorf("error reading golden test config file: %w", err)
 	}

--- a/templates/commands/render/render_test.go
+++ b/templates/commands/render/render_test.go
@@ -337,7 +337,7 @@ func loadManifest(ctx context.Context, path string) (*manifest.Manifest, error) 
 	}
 	defer f.Close()
 
-	manifestI, err := decode.DecodeValidateUpgrade(ctx, f, path, decode.KindManifest)
+	manifestI, _, err := decode.DecodeValidateUpgrade(ctx, f, path, decode.KindManifest)
 	if err != nil {
 		return nil, fmt.Errorf("error reading manifest file: %w", err)
 	}

--- a/templates/commands/upgrade/flags.go
+++ b/templates/commands/upgrade/flags.go
@@ -69,6 +69,10 @@ type Flags struct {
 	// See common/flags.KeepTempDirs().
 	KeepTempDirs bool
 
+	// An optional CEL expression which will be evaluated against each manifest
+	// that is found; only those where the expression is true will be upgraded.
+	ManifestFilter string
+
 	// The manifest to start with, when upgrading multiple manifests. This is
 	// used when a previous upgrade operation required manual intervention, and
 	// the manual intervention is done, and the user wants to resume.
@@ -114,6 +118,12 @@ func (f *Flags) Register(set *cli.FlagSet) {
 		Name:   "continue-if-current",
 		Target: &f.ContinueIfCurrent,
 		Usage:  "continue even if the template dirhash shows that the latest version of the template has already been installed; this is useful to force the manifest to be rewritten when used with --template-location",
+	})
+	u.StringVar(&cli.StringVar{
+		Name:    "manifest-filter",
+		Example: `template_location == "github.com/abcxyz/abc/examples/templates/render/hello_jupiter"`,
+		Target:  &f.ManifestFilter,
+		Usage:   "An optional CEL expression which will be evaluated against each manifest that is found; only those where the expression is true will be upgraded. If not set, the default is to upgrade every manifest that is found in the provided location",
 	})
 	u.BoolVar(flags.Verbose(&f.Verbose))
 

--- a/templates/commands/upgrade/upgrade.go
+++ b/templates/commands/upgrade/upgrade.go
@@ -145,6 +145,7 @@ func (c *Command) Run(ctx context.Context, args []string) error {
 		InputsFromFlags:      c.flags.Inputs,
 		KeepTempDirs:         c.flags.KeepTempDirs,
 		Location:             absLocation,
+		ManifestFilter:       c.flags.ManifestFilter,
 		Prompt:               c.flags.Prompt,
 		Prompter:             c,
 		SkipInputValidation:  c.flags.SkipInputValidation,

--- a/templates/common/cel.go
+++ b/templates/common/cel.go
@@ -304,7 +304,7 @@ func celCompile(ctx context.Context, scope *Scope, expr string) (cel.Program, er
 
 	ast, issues := env.Compile(expr)
 	if err := issues.Err(); err != nil {
-		if name, ok := isCELUndeclaredRef(err); ok {
+		if name, ok := IsCELUndeclaredRef(err); ok {
 			return nil, &errs.UnknownVarError{
 				VarName:       name,
 				AvailableVars: maps.Keys(scope.AllVars()),
@@ -330,7 +330,10 @@ func celCompile(ctx context.Context, scope *Scope, expr string) (cel.Program, er
 
 var celUndeclaredRefRE = regexp.MustCompile(`undeclared reference to '([^']+)'`)
 
-func isCELUndeclaredRef(err error) (string, bool) {
+// Detects whether the given error, which should come from the CEL Compile()
+// function, is an error indicating a reference to a nonexistent variable. This
+// can happen when, for example, the CEL expr was "x == 5" but x doesn't exist.
+func IsCELUndeclaredRef(err error) (string, bool) {
 	// The variable name that is the "undeclared reference" isn't available
 	// as a field of the error, so we're forced to parse the error message.
 	matches := celUndeclaredRefRE.FindStringSubmatch(err.Error())

--- a/templates/common/render/render_test.go
+++ b/templates/common/render/render_test.go
@@ -2227,7 +2227,7 @@ func mustLoadManifest(ctx context.Context, tb testing.TB, path string) *manifest
 	}
 	defer f.Close()
 
-	manifestI, err := decode.DecodeValidateUpgrade(ctx, f, path, decode.KindManifest)
+	manifestI, _, err := decode.DecodeValidateUpgrade(ctx, f, path, decode.KindManifest)
 	if err != nil {
 		tb.Fatalf("error reading manifest file: %v", err)
 	}

--- a/templates/common/specutil/spec.go
+++ b/templates/common/specutil/spec.go
@@ -124,7 +124,7 @@ func Load(ctx context.Context, fs common.FS, templateDir, source string) (*spec.
 	}
 	defer f.Close()
 
-	specI, err := decode.DecodeValidateUpgrade(ctx, f, SpecFileName, decode.KindTemplate)
+	specI, _, err := decode.DecodeValidateUpgrade(ctx, f, SpecFileName, decode.KindTemplate)
 	if err != nil {
 		return nil, fmt.Errorf("error reading template spec file: %w", err)
 	}

--- a/templates/common/upgrade/filter.go
+++ b/templates/common/upgrade/filter.go
@@ -1,0 +1,117 @@
+// Copyright 2024 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package upgrade
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"reflect"
+
+	"github.com/google/cel-go/cel"
+	"gopkg.in/yaml.v3"
+
+	manifest "github.com/abcxyz/abc/templates/model/manifest/v1alpha1"
+	"github.com/abcxyz/pkg/logging"
+)
+
+func filterManifests(ctx context.Context, filterCELExpr string, manifestsUnfiltered map[string]*manifest.Manifest) (map[string]*manifest.Manifest, error) {
+	logger := logging.FromContext(ctx).With("logger", "filterOneManifest")
+
+	out := maps.Clone(manifestsUnfiltered)
+	if len(filterCELExpr) == 0 {
+		return out, nil
+	}
+
+	for key, manifest := range manifestsUnfiltered {
+		ok, err := filterOneManifest(filterCELExpr, manifest)
+		if err != nil {
+			return nil, err
+		}
+		logger.InfoContext(ctx, "The CEL filter was successfully evaluated for a manifest",
+			"manifest_filename", key,
+			"result", ok)
+
+		if !ok {
+			delete(out, key)
+		}
+	}
+
+	return out, nil
+}
+
+// Returns true if the given CEL expression returns true when evaluated against
+// the given manifest.
+func filterOneManifest(filterCELExpr string, m *manifest.Manifest) (bool, error) {
+	// Alternative considered: there's another approach we could have taken to
+	// provide the values of the manifest fields to the CEL expression. We could
+	// have implemented the CEL ref.Val and ref.Type interfaces for the Manifest
+	// struct, using a lot of reflection code. This approach was deemed overly
+	// complex and bug-prone, since we'd be processing struct fields and tags
+	// using reflection, and there might be bugs where the field names and
+	// hierarchy in the CEL might differ subtly from the YAML. It would be a lot
+	// of code, all of which would be hard to maintain.
+	//
+	// The simpler, highly practical but less architecturally clean approach is
+	// to just round-trip the manifest struct through YAML marshaling and
+	// unmarshaling to get a map[string]any, then provide that map to CEL as the
+	// field values of the manifest. This is guaranteed to have exactly the
+	// right field names and hierarchy as YAML would have it, since it's
+	// produced by the YAML library.
+	buf, err := yaml.Marshal(m)
+	if err != nil {
+		return false, fmt.Errorf("internal error: failed marshaling Manifest while filtering: %w", err)
+	}
+	var asMap map[string]any
+	if err := yaml.Unmarshal(buf, &asMap); err != nil {
+		return false, fmt.Errorf("internal error: failed unmarshaling YAML back to map: %w", err)
+	}
+
+	celOpts := make([]cel.EnvOption, 0, len(asMap))
+	for name := range asMap {
+		celOpts = append(celOpts, cel.Variable(name, cel.DynType))
+	}
+	celEnv, err := cel.NewEnv(celOpts...)
+	if err != nil {
+		return false, fmt.Errorf("internal error: cel.NewEnv(): %w", err)
+	}
+
+	ast, issues := celEnv.Compile(filterCELExpr)
+	if err := issues.Err(); err != nil {
+		return false, fmt.Errorf("failed compiling CEL expression: %w", err)
+	}
+
+	prog, err := celEnv.Program(ast)
+	if err != nil {
+		return false, fmt.Errorf("failed constructing CEL program: %w", err)
+	}
+
+	celOut, _, err := prog.Eval(asMap)
+	if err != nil {
+		return false, fmt.Errorf("failed executing CEL expression: %w", err)
+	}
+
+	boolI, err := celOut.ConvertToNative(reflect.TypeOf(true))
+	if err != nil {
+		return false, fmt.Errorf("CEL filter evaluation did not return bool: %w", err)
+	}
+
+	result, ok := boolI.(bool)
+	if !ok {
+		return false, fmt.Errorf("internal error: CEL filter evaluation should return bool, got %T: %w", boolI, err)
+	}
+
+	return result, nil
+}

--- a/templates/common/upgrade/upgrade.go
+++ b/templates/common/upgrade/upgrade.go
@@ -440,7 +440,7 @@ func upgrade(ctx context.Context, p *Params, absManifestPath string, oldManifest
 		return nil, fmt.Errorf("failed rendering template: %w", err)
 	}
 
-	newManifest, err := loadManifest(ctx, p.FS, filepath.Join(mergeDir, renderResult.ManifestPath))
+	newManifest, _, err := loadManifest(ctx, p.FS, filepath.Join(mergeDir, renderResult.ManifestPath))
 	if err != nil {
 		return nil, err
 	}
@@ -624,24 +624,24 @@ func mergeManifest(old, newManifest *manifest.Manifest) *manifest.WithHeader {
 }
 
 // loadManifest reads and unmarshals the manifest at the given path.
-func loadManifest(ctx context.Context, fs common.FS, path string) (*manifest.Manifest, error) {
+func loadManifest(ctx context.Context, fs common.FS, path string) (*manifest.Manifest, []byte, error) {
 	f, err := fs.Open(path)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open manifest file at %q: %w", path, err)
+		return nil, nil, fmt.Errorf("failed to open manifest file at %q: %w", path, err)
 	}
 	defer f.Close()
 
-	manifestI, err := decode.DecodeValidateUpgrade(ctx, f, path, decode.KindManifest)
+	manifestI, buf, err := decode.DecodeValidateUpgrade(ctx, f, path, decode.KindManifest)
 	if err != nil {
-		return nil, fmt.Errorf("error reading manifest file: %w", err)
+		return nil, nil, fmt.Errorf("error reading manifest file: %w", err)
 	}
 
 	out, ok := manifestI.(*manifest.Manifest)
 	if !ok {
-		return nil, fmt.Errorf("internal error: manifest file did not decode to *manifest.Manifest")
+		return nil, nil, fmt.Errorf("internal error: manifest file did not decode to *manifest.Manifest")
 	}
 
-	return out, nil
+	return out, buf, nil
 }
 
 // inputsToMap takes the list of input values (e.g. "service_account" was "my-service-account")

--- a/templates/common/upgrade/upgrade.go
+++ b/templates/common/upgrade/upgrade.go
@@ -111,6 +111,12 @@ type Params struct {
 	// that single template will be upgraded.
 	Location string
 
+	// A CEL expression to filter the manifests found. If this is set, then it
+	// will be executed against each manifest YAML model, and the manifest will
+	// upgraded IFF the expression returns true. If unset, then no filtering
+	// will be done and every manifest found under Location will be upgraded.
+	ManifestFilter string
+
 	// The value of --prompt.
 	Prompt   bool
 	Prompter input.Prompter

--- a/templates/common/upgrade/upgrade_test.go
+++ b/templates/common/upgrade/upgrade_test.go
@@ -1783,7 +1783,7 @@ yellow is my favorite color
 			if tc.fakeInitialRenderDownloader != nil {
 				tc.fakeInitialRenderDownloader.sourceDir = templateDir // inject per-testcase value that's not known when the testcase is created
 			}
-			renderResult := mustRender(t, ctx, clk, tc.fakeInitialRenderDownloader, tempBase, templateDir, destDir)
+			renderResult := mustRender(t, ctx, clk, tc.fakeInitialRenderDownloader, tempBase, templateDir, destDir, nil)
 
 			manifestFullPath := filepath.Join(destDir, renderResult.ManifestPath)
 
@@ -1940,7 +1940,7 @@ func TestUpgrade_NonCanonical(t *testing.T) {
 	abctestutil.WriteAll(t, templateDir, origTemplateDirContents)
 	clk := clock.NewMock()
 	clk.Set(time.Date(2024, 3, 1, 4, 5, 6, 7, time.UTC))
-	mustRender(t, ctx, clk, nil, tempBase, templateDir, destDir)
+	mustRender(t, ctx, clk, nil, tempBase, templateDir, destDir, nil)
 
 	clk.Add(time.Second)
 	params := &Params{
@@ -2031,7 +2031,7 @@ steps:
 	ctx := context.Background()
 	clk := clock.NewMock()
 	clk.Set(renderTime1)
-	renderResult1 := mustRender(t, ctx, clk, nil, tempBase, templateDir, destDir1)
+	renderResult1 := mustRender(t, ctx, clk, nil, tempBase, templateDir, destDir1, nil)
 
 	wantManifestBeforeUpgrade := &manifest.Manifest{
 		CreationTime:     renderTime1,
@@ -2056,7 +2056,7 @@ steps:
 	assertManifest(ctx, t, "before upgrade", wantManifestBeforeUpgrade, manifestFullPath)
 
 	clk.Add(time.Second)
-	mustRender(t, ctx, clk, nil, tempBase, templateDir, destDir2) // don't bother checking the manifest for the second render; it's the same as the first one
+	mustRender(t, ctx, clk, nil, tempBase, templateDir, destDir2, nil) // don't bother checking the manifest for the second render; it's the same as the first one
 
 	// Simulate the user making some edits to the included-from-destination file
 	// after the render operation but before the upgrade
@@ -2321,80 +2321,174 @@ func TestDetectUnmergedConflicts(t *testing.T) {
 }
 
 // TODO(upgrade): add tests:
-//   - upgrade multiple with already-resolved
 //   - upgrade template-that-outputs-template
+
 func TestUpgradeAll_MultipleTemplates(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
-	clk := clock.NewMock()
+	specFile := `api_version: 'cli.abcxyz.dev/v1beta6'
+kind: 'Template'
+desc: 'my template'
+inputs:
+  - name: "my_input"
+    desc: "An arbitrary input"
+steps:
+  - desc: 'include .'
+    action: 'include'
+    params:
+      paths: ['.']
+`
 
-	tempBase := t.TempDir()
-
-	// Make the temp dir into a git repo so template locations will be treated
-	// as canonical.
-	abctestutil.WriteAll(t, tempBase, abctestutil.WithGitRepoAt("", nil))
-
-	template1Files := map[string]string{
-		"spec.yaml":  includeDotSpec,
-		"myfile.txt": "my old template1 file contents",
+	cases := []struct {
+		name               string
+		flagManifestFilter string
+		wantNumSuccesses   int
+		wantDestContents   map[string]string
+		wantErr            string
+	}{
+		{
+			name:             "no_filter",
+			wantNumSuccesses: 2,
+			wantDestContents: map[string]string{
+				"destDir1/myfile.txt": "my new template1 file contents",
+				"destDir2/myfile.txt": "my new template2 file contents",
+			},
+		},
+		{
+			name:               "filter_by_location_type",
+			flagManifestFilter: `location_type == "local_git"`,
+			wantNumSuccesses:   2,
+			wantDestContents: map[string]string{
+				"destDir1/myfile.txt": "my new template1 file contents",
+				"destDir2/myfile.txt": "my new template2 file contents",
+			},
+		},
+		{
+			name:               "filter_by_template_location",
+			flagManifestFilter: `template_location == "../../templateDir1"`,
+			wantNumSuccesses:   1,
+			wantDestContents: map[string]string{
+				"destDir1/myfile.txt": "my new template1 file contents",
+				"destDir2/myfile.txt": "my old template2 file contents",
+			},
+		},
+		{
+			name:               "filter_by_input_value",
+			flagManifestFilter: `inputs.exists(item, item.name == "my_input" && item.value == "template_1_input")`,
+			wantNumSuccesses:   1,
+			wantDestContents: map[string]string{
+				"destDir1/myfile.txt": "my new template1 file contents",
+				"destDir2/myfile.txt": "my old template2 file contents",
+			},
+		},
+		{
+			name:               "filter_by_output_file",
+			flagManifestFilter: `output_files.exists(item, item.file == "myfile.txt")`,
+			wantNumSuccesses:   2,
+			wantDestContents: map[string]string{
+				"destDir1/myfile.txt": "my new template1 file contents",
+				"destDir2/myfile.txt": "my new template2 file contents",
+			},
+		},
+		{
+			name:               "filter_matches_none",
+			flagManifestFilter: `1 == 0`,
+			wantNumSuccesses:   0,
+			wantDestContents: map[string]string{
+				"destDir1/myfile.txt": "my old template1 file contents",
+				"destDir2/myfile.txt": "my old template2 file contents",
+			},
+		},
+		{
+			name:               "filter_returns_non_boolean",
+			flagManifestFilter: `"string_which_should_be_bool"`,
+			wantErr:            "CEL filter evaluation did not return bool",
+		},
 	}
-	template2Files := map[string]string{
-		"spec.yaml":  includeDotSpec,
-		"myfile.txt": "my old template2 file contents",
-	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	templateDir1 := filepath.Join(tempBase, "templateDir1")
-	templateDir2 := filepath.Join(tempBase, "templateDir2")
-	destBase := filepath.Join(tempBase, "dest")
-	destDir1 := filepath.Join(destBase, "destDir1")
-	destDir2 := filepath.Join(destBase, "destDir2")
-	abctestutil.WriteAll(t, templateDir1, template1Files)
-	abctestutil.WriteAll(t, templateDir2, template2Files)
-	mustRender(t, ctx, clk, nil, tempBase, templateDir1, destDir1)
-	mustRender(t, ctx, clk, nil, tempBase, templateDir2, destDir2)
+			ctx := context.Background()
+			clk := clock.NewMock()
 
-	upgradedTemplate1Files := map[string]string{
-		"spec.yaml":  includeDotSpec,
-		"myfile.txt": "my new template1 file contents",
-	}
-	upgradedTemplate2Files := map[string]string{
-		"spec.yaml":  includeDotSpec,
-		"myfile.txt": "my new template2 file contents",
-	}
+			tempBase := t.TempDir()
 
-	abctestutil.WriteAll(t, templateDir1, upgradedTemplate1Files)
-	abctestutil.WriteAll(t, templateDir2, upgradedTemplate2Files)
+			// Make the temp dir into a git repo so template locations will be treated
+			// as canonical.
+			abctestutil.WriteAll(t, tempBase, abctestutil.WithGitRepoAt("", nil))
 
-	allResult := UpgradeAll(ctx, &Params{
-		Clock:    clk,
-		CWD:      tempBase,
-		FS:       &common.RealFS{},
-		Location: tempBase,
-		Stdout:   os.Stdout,
-	})
+			template1Files := map[string]string{
+				"spec.yaml":  specFile,
+				"myfile.txt": "my old template1 file contents",
+			}
+			template2Files := map[string]string{
+				"spec.yaml":  specFile,
+				"myfile.txt": "my old template2 file contents",
+			}
 
-	if allResult.Err != nil {
-		t.Fatal(allResult.Err)
-	}
+			templateDir1 := filepath.Join(tempBase, "templateDir1")
+			templateDir2 := filepath.Join(tempBase, "templateDir2")
+			destBase := filepath.Join(tempBase, "dest")
+			destDir1 := filepath.Join(destBase, "destDir1")
+			destDir2 := filepath.Join(destBase, "destDir2")
+			abctestutil.WriteAll(t, templateDir1, template1Files)
+			abctestutil.WriteAll(t, templateDir2, template2Files)
+			template1Inputs := map[string]string{
+				"my_input": "template_1_input",
+			}
+			template2Inputs := map[string]string{
+				"my_input": "template_2_input",
+			}
+			mustRender(t, ctx, clk, nil, tempBase, templateDir1, destDir1, template1Inputs)
+			mustRender(t, ctx, clk, nil, tempBase, templateDir2, destDir2, template2Inputs)
 
-	if len(allResult.Results) != 2 {
-		t.Errorf("got %d results, expected exactly 2", len(allResult.Results))
-	}
-	for _, result := range allResult.Results {
-		if result.Type != Success {
-			t.Fatalf("got upgrade result %q, expected %q", result.Type, Success)
-		}
-	}
+			upgradedTemplate1Files := map[string]string{
+				"spec.yaml":  specFile,
+				"myfile.txt": "my new template1 file contents",
+			}
+			upgradedTemplate2Files := map[string]string{
+				"spec.yaml":  specFile,
+				"myfile.txt": "my new template2 file contents",
+			}
 
-	wantDestContents := map[string]string{
-		"destDir1/myfile.txt": "my new template1 file contents",
-		"destDir2/myfile.txt": "my new template2 file contents",
-	}
-	opt := abctestutil.SkipGlob("*/.abc/manifest*") // manifests are too unpredictable, don't assert their contents
-	gotDestContents := abctestutil.LoadDir(t, destBase, opt)
-	if diff := cmp.Diff(gotDestContents, wantDestContents); diff != "" {
-		t.Errorf("dest contents were not as expected (-got,+want):\n%s", diff)
+			abctestutil.WriteAll(t, templateDir1, upgradedTemplate1Files)
+			abctestutil.WriteAll(t, templateDir2, upgradedTemplate2Files)
+
+			allResult := UpgradeAll(ctx, &Params{
+				Clock:          clk,
+				CWD:            tempBase,
+				FS:             &common.RealFS{},
+				Location:       tempBase,
+				ManifestFilter: tc.flagManifestFilter,
+				Stdout:         os.Stdout,
+			})
+			if diff := testutil.DiffErrString(allResult.Err, tc.wantErr); diff != "" {
+				t.Fatal(diff)
+			}
+			if tc.wantErr != "" {
+				return
+			}
+
+			if allResult.Err != nil {
+				t.Fatal(allResult.Err)
+			}
+
+			if len(allResult.Results) != tc.wantNumSuccesses {
+				t.Fatalf("got %d results, expected exactly %d", len(allResult.Results), tc.wantNumSuccesses)
+			}
+			for _, result := range allResult.Results {
+				if result.Type != Success {
+					t.Fatalf("got upgrade result %q, expected %q", result.Type, Success)
+				}
+			}
+
+			opt := abctestutil.SkipGlob("*/.abc/manifest*") // manifests are too unpredictable, don't assert their contents
+			gotDestContents := abctestutil.LoadDir(t, destBase, opt)
+			if diff := cmp.Diff(gotDestContents, tc.wantDestContents); diff != "" {
+				t.Errorf("dest contents were not as expected (-got,+want):\n%s", diff)
+			}
+		})
 	}
 }
 
@@ -2426,8 +2520,8 @@ func TestUpgradeAll_MultipleTemplatesWithResumedConflict(t *testing.T) {
 	destDir2 := filepath.Join(destBase, "destDir2")
 	abctestutil.WriteAll(t, templateDir1, template1Files)
 	abctestutil.WriteAll(t, templateDir2, template2Files)
-	mustRender(t, ctx, clk, nil, tempBase, templateDir1, destDir1)
-	mustRender(t, ctx, clk, nil, tempBase, templateDir2, destDir2)
+	mustRender(t, ctx, clk, nil, tempBase, templateDir1, destDir1, nil)
+	mustRender(t, ctx, clk, nil, tempBase, templateDir2, destDir2, nil)
 
 	abctestutil.OverwriteJoin(t, destDir1, "myfile.txt", "my local edits")
 
@@ -2540,9 +2634,9 @@ func TestUpgradeAll_Dependency(t *testing.T) {
 	destDirC := filepath.Join(destBase, "destDirC")
 	abctestutil.WriteAll(t, templateDir1, template1Files)
 	abctestutil.WriteAll(t, templateDir2, template2Files)
-	mustRender(t, ctx, clk, nil, tempBase, templateDir1, destDirA)
-	mustRender(t, ctx, clk, nil, tempBase, templateDir2, destDirB)
-	mustRender(t, ctx, clk, nil, tempBase, destDirA+"/inner", destDirC)
+	mustRender(t, ctx, clk, nil, tempBase, templateDir1, destDirA, nil)
+	mustRender(t, ctx, clk, nil, tempBase, templateDir2, destDirB, nil)
+	mustRender(t, ctx, clk, nil, tempBase, destDirA+"/inner", destDirC, nil)
 
 	wantRendered := map[string]string{
 		"destDirA/outer_output_file.txt": "my old outer output file",
@@ -2674,7 +2768,7 @@ func assertManifest(ctx context.Context, tb testing.TB, whereAreWe string, want 
 	}
 }
 
-func mustRender(tb testing.TB, ctx context.Context, clk clock.Clock, fakeDL *fakeDownloader, tempBase, templateDir, destDir string) *render.Result {
+func mustRender(tb testing.TB, ctx context.Context, clk clock.Clock, fakeDL *fakeDownloader, tempBase, templateDir, destDir string, inputs map[string]string) *render.Result {
 	tb.Helper()
 
 	var downloader templatesource.Downloader = fakeDL
@@ -2690,13 +2784,14 @@ func mustRender(tb testing.TB, ctx context.Context, clk clock.Clock, fakeDL *fak
 	}
 
 	result, err := render.Render(ctx, &render.Params{
-		Clock:       clk,
-		Cwd:         tempBase,
-		DestDir:     destDir,
-		Downloader:  downloader,
-		FS:          &common.RealFS{},
-		OutDir:      destDir,
-		TempDirBase: tempBase,
+		Clock:           clk,
+		Cwd:             tempBase,
+		DestDir:         destDir,
+		Downloader:      downloader,
+		InputsFromFlags: inputs,
+		FS:              &common.RealFS{},
+		OutDir:          destDir,
+		TempDirBase:     tempBase,
 	})
 	if err != nil {
 		tb.Fatal(err)

--- a/templates/common/upgrade/upgrade_test.go
+++ b/templates/common/upgrade/upgrade_test.go
@@ -2404,6 +2404,14 @@ steps:
 			flagManifestFilter: `"string_which_should_be_bool"`,
 			wantErr:            "CEL filter evaluation did not return bool",
 		},
+		{
+			name:               "nonexistent_field_skips_manifest",
+			flagManifestFilter: `nonexistent == "lol"`,
+			wantDestContents: map[string]string{
+				"destDir1/myfile.txt": "my old template1 file contents",
+				"destDir2/myfile.txt": "my old template2 file contents",
+			},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/templates/common/upgrade/upgrade_test.go
+++ b/templates/common/upgrade/upgrade_test.go
@@ -2739,7 +2739,7 @@ func mustIndexFunc[T any](t *testing.T, s []T, f func(T) bool) int {
 func assertManifest(ctx context.Context, tb testing.TB, whereAreWe string, want *manifest.Manifest, path string) {
 	tb.Helper()
 
-	got, err := loadManifest(ctx, &common.RealFS{}, path)
+	got, _, err := loadManifest(ctx, &common.RealFS{}, path)
 	if err != nil {
 		tb.Fatal(err)
 	}

--- a/templates/common/upgrade/upgradeall.go
+++ b/templates/common/upgrade/upgradeall.go
@@ -161,7 +161,10 @@ func manifestsToUpgrade(ctx context.Context, p *Params) (map[string]*manifest.Ma
 		return nil, nil, nil, err
 	}
 
-	manifestsFiltered := filterManifests(p, manifestsUnfiltered)
+	manifestsFiltered, err := filterManifests(ctx, p.ManifestFilter, manifestsUnfiltered)
+	if err != nil {
+		return nil, nil, nil, err
+	}
 
 	sorted, depGraph, err := depOrder(p.TemplateLocation, manifestsFiltered)
 	if err != nil {
@@ -193,15 +196,6 @@ func loadManifests(ctx context.Context, cwd, startFrom string, paths []string) (
 		out[p] = manifest
 	}
 	return out, nil
-}
-
-func filterManifests(p *Params, manifestsUnfiltered map[string]*manifest.Manifest) map[string]*manifest.Manifest {
-	out := maps.Clone(manifestsUnfiltered)
-	_ = p
-
-	// TODO(drevell): add filtering logic in next PR
-
-	return out
 }
 
 func overallResult(results []*ManifestResult) ResultType {

--- a/templates/model/decode/decode_test.go
+++ b/templates/model/decode/decode_test.go
@@ -344,7 +344,7 @@ builtin_vars:
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, gotVersion, err := Decode(strings.NewReader(tc.fileContents), "file.yaml", tc.requireKind, tc.isReleaseBuild)
+			got, gotVersion, _, err := Decode(strings.NewReader(tc.fileContents), "file.yaml", tc.requireKind, tc.isReleaseBuild)
 			if diff := testutil.DiffErrString(err, tc.wantErr); diff != "" {
 				t.Fatal(diff)
 			}
@@ -509,7 +509,7 @@ steps:
 
 			ctx := context.Background()
 			rd := strings.NewReader(tc.fileContents)
-			vu, err := DecodeValidateUpgrade(ctx, rd, "file.yaml", "")
+			vu, _, err := DecodeValidateUpgrade(ctx, rd, "file.yaml", "")
 			if diff := testutil.DiffErrString(err, tc.wantErr); diff != "" {
 				t.Fatal(diff)
 			}


### PR DESCRIPTION
To support users with lots of template installations, we add the `abc upgrade --manifest-filter` flag. This will limit upgrades to only those template installations whose manifest passes the filter. The filter is provided by the user as a CEL expression.

The CEL expression has access to the fields of the manifest YAML file under the same field names as they appear in the manifest.

Example: upgrade all installations of the template `github.com/foo/bar`:

	abc upgrade --manifest-filter='template_location ==
	"github.com/foo/bar"'

Example: upgrade all installations whose `deployment_name` input has the value `foo`:

	abc upgrade --manifest-filter='inputs.exists(item, item.name == "deployment_name" && item.value == "foo")'

Example: upgrade all installations that touched the file `a/b/c.txt` (relative to the template's destination directory):

	abc upgrade --manifest-filter='output_files.exists(item, item.file == "a/b/c.txt"'