### PR TITLE
Fix runtime metrics timeout issue

### DIFF
--- a/cmd/abc/abc.go
+++ b/cmd/abc/abc.go
@@ -191,9 +191,8 @@ func realMain(ctx context.Context) error {
 	cleanup := metricswrap.WriteMetric(ctx, mClient, "runs", 1)
 	defer cleanup()
 
-	// TODO: This will cause a synchronous metrics call, may be way too slow.
+	// This will cause a synchronous metrics call.
 	defer func() {
-		// TODO: why did fixing this also fix other timeout issues?
 		runtimeCtx, closer := context.WithTimeout(ctx, runtimeMetricsTimeout)
 		defer closer()
 		cleanup := metricswrap.WriteMetric(runtimeCtx, mClient, "runtime_millis", time.Since(start).Milliseconds())

--- a/cmd/abc/abc.go
+++ b/cmd/abc/abc.go
@@ -191,10 +191,11 @@ func realMain(ctx context.Context) error {
 	cleanup := metricswrap.WriteMetric(ctx, mClient, "runs", 1)
 	defer cleanup()
 
-	runtimeCtx, closer := context.WithTimeout(ctx, runtimeMetricsTimeout)
-	defer closer()
 	// TODO: This will cause a synchronous metrics call, may be way too slow.
 	defer func() {
+		// TODO: why did fixing this also fix other timeout issues?
+		runtimeCtx, closer := context.WithTimeout(ctx, runtimeMetricsTimeout)
+		defer closer()
 		cleanup := metricswrap.WriteMetric(runtimeCtx, mClient, "runtime_millis", time.Since(start).Milliseconds())
 		defer cleanup()
 	}()


### PR DESCRIPTION
The deadline was being applied before the program ran, which caused it to time out almost every run.