### PR TITLE
Properly set current tag when multiple tags exist for same commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,3 +50,4 @@ jobs:
           args: 'release --clean'
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          GORELEASER_CURRENT_TAG: '${{ github.ref_type == "tag" && github.ref_name || "" }}'


### PR DESCRIPTION
GitHub will return lexigraphically the most recent tag if there are multiple for the same commit, which can break when doing a release after a prerelease (example: https://github.com/abcxyz/abc/actions/runs/10601630744). This hopefully will fix it.

Using feature from https://github.com/goreleaser/goreleaser/pull/1327