### PR TITLE
Fix package name v1beta4 -> v1beta6

### DIFF
--- a/templates/model/spec/v1beta6/spec.go
+++ b/templates/model/spec/v1beta6/spec.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 //nolint:wrapcheck // We don't want to excessively wrap errors, like "yaml error: yaml error: ..."
-package v1beta4
+package v1beta6
 
 import (
 	"errors"

--- a/templates/model/spec/v1beta6/spec_test.go
+++ b/templates/model/spec/v1beta6/spec_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package v1beta4
+package v1beta6
 
 import (
 	"strings"

--- a/templates/model/spec/v1beta6/upgrade.go
+++ b/templates/model/spec/v1beta6/upgrade.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package v1beta4
+package v1beta6
 
 import (
 	"context"


### PR DESCRIPTION
This was an oversight by me when I created the v1beta6 api_version. I
forgot to replace `package v1beta4` with `package v1beta6` in this
directory.