### PR TITLE
Return AlreadyUpToDate if the user inputs haven't changed

### DIFF
--- a/templates/common/render/render_test.go
+++ b/templates/common/render/render_test.go
@@ -105,6 +105,7 @@ steps:
 		flagBackfillManifestOnly   bool
 		flagUpgradeChannel         string
 		flagDebugStepDiffs         bool
+		flagNoopIfInputsMatch      map[string]string
 		overrideBuiltinVars        map[string]string
 		removeAllErr               error
 		wantScratchContents        map[string]string
@@ -112,6 +113,7 @@ steps:
 		wantDestContents           map[string]string
 		wantBackupContents         map[string]string
 		wantStdout                 string
+		wantNoopInputsMatched      bool
 		wantErr                    string
 
 		// manifests are part of the destination directory, but are compared
@@ -1761,6 +1763,67 @@ steps:
 				},
 			},
 		},
+		{
+			name: "noop_on_input_match",
+			flagInputs: map[string]string{
+				"name_to_greet":      "Alice",
+				"emoji_suffix":       "🐈",
+				"ending_punctuation": "!",
+			},
+			templateContents: map[string]string{
+				"myfile.txt":           "Some random stuff",
+				"spec.yaml":            specContents,
+				"file1.txt":            "my favorite color is blue",
+				"dir1/file_in_dir.txt": "file_in_dir contents",
+				"dir2/file2.txt":       "file2 contents",
+			},
+			flagNoopIfInputsMatch: map[string]string{
+				"name_to_greet":      "Alice",
+				"emoji_suffix":       "🐈",
+				"ending_punctuation": "!",
+			},
+			wantNoopInputsMatched: true,
+		},
+		{
+			name: "not_noop_on_input_mismatch",
+			flagInputs: map[string]string{
+				"name_to_greet":      "Alice",
+				"emoji_suffix":       "🐈",
+				"ending_punctuation": "!",
+			},
+			flagNoopIfInputsMatch: map[string]string{
+				"name_to_greet":      "Bob",
+				"emoji_suffix":       "🐈",
+				"ending_punctuation": "!",
+			},
+			templateContents: map[string]string{
+				"myfile.txt":           "Some random stuff",
+				"spec.yaml":            specContents,
+				"file1.txt":            "my favorite color is blue",
+				"dir1/file_in_dir.txt": "file_in_dir contents",
+				"dir2/file2.txt":       "file2 contents",
+			},
+			wantStdout: "Hello, Alice🐈!\n",
+			wantDestContents: map[string]string{
+				"file1.txt":            "my favorite color is red",
+				"dir1/file_in_dir.txt": "file_in_dir contents",
+				"dir2/file2.txt":       "file2 contents",
+			},
+			wantManifest: &manifest.Manifest{
+				CreationTime:     clk.Now(),
+				ModificationTime: clk.Now(),
+				Inputs: []*manifest.Input{
+					{Name: mdl.S("emoji_suffix"), Value: mdl.S("🐈")},
+					{Name: mdl.S("ending_punctuation"), Value: mdl.S("!")},
+					{Name: mdl.S("name_to_greet"), Value: mdl.S("Alice")},
+				},
+				OutputFiles: []*manifest.OutputFile{
+					{File: mdl.S("dir1/file_in_dir.txt")},
+					{File: mdl.S("dir2/file2.txt")},
+					{File: mdl.S("file1.txt")},
+				},
+			},
+		},
 	}
 
 	for _, tc := range cases {
@@ -1802,6 +1865,7 @@ steps:
 				InputFiles:          inputFilePaths,
 				InputsFromFlags:     tc.flagInputs,
 				KeepTempDirs:        tc.flagKeepTempDirs,
+				NoopIfInputsMatch:   tc.flagNoopIfInputsMatch,
 				OutDir:              outDir,
 				OverrideBuiltinVars: tc.overrideBuiltinVars,
 				SkipInputValidation: tc.flagSkipInputValidation,
@@ -1824,6 +1888,9 @@ steps:
 			}
 			if err == nil {
 				verifyManifest(ctx, t, result.ManifestPath != "", filepath.Join(outDir, result.ManifestPath), tc.wantManifest)
+				if result.NoopInputsMatched != tc.wantNoopInputsMatched {
+					t.Errorf("noopInputsMatched was %t but should be %t", result.NoopInputsMatched, tc.wantNoopInputsMatched)
+				}
 			}
 
 			if diff := cmp.Diff(stdoutBuf.String(), tc.wantStdout); diff != "" {
@@ -2165,8 +2232,6 @@ Enter value, or leave empty to accept default: `,
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-
-			// TODO rewrite to use framework
 
 			cmd := &cli.BaseCommand{}
 

--- a/templates/common/upgrade/upgrade.go
+++ b/templates/common/upgrade/upgrade.go
@@ -471,7 +471,7 @@ func upgrade(ctx context.Context, p *Params, absManifestPath string, oldManifest
 	}, nil
 }
 
-// Returns a map which, if it is equal to the resolve template inputs, will
+// Returns a map which, if it is equal to the resolved template inputs, will
 // abort the upgrade as a noop. This supports the optional feature where we
 // can cleanly bail out if there is no new template version and also the user's
 // template inputs are the same as before.

--- a/templates/common/upgrade/upgrade.go
+++ b/templates/common/upgrade/upgrade.go
@@ -364,20 +364,9 @@ func upgrade(ctx context.Context, p *Params, absManifestPath string, oldManifest
 		return nil, fmt.Errorf("failed downloading template: %w", err)
 	}
 
-	if !p.ContinueIfCurrent {
-		hashMatch, err := dirhash.Verify(oldManifest.TemplateDirhash.Val, templateDir)
-		if err != nil {
-			return nil, err //nolint:wrapcheck
-		}
-		if hashMatch {
-			// No need to upgrade. We already have the latest template version.
-			logger.InfoContext(ctx, "template installation is already up to date",
-				"manifest_path", absManifestPath)
-			return &ManifestResult{
-				Type:   AlreadyUpToDate,
-				DLMeta: dlMeta,
-			}, nil
-		}
+	noopIfInputsMatch, err := inputsForNoopCheck(ctx, p, templateDir, oldManifest)
+	if err != nil {
+		return nil, err
 	}
 
 	// The "merge directory" is yet another temp directory in addition to
@@ -426,6 +415,7 @@ func upgrade(ctx context.Context, p *Params, absManifestPath string, oldManifest
 		IncludeFromDestExtraDir: reversedDir,
 		InputsFromFlags:         p.InputsFromFlags,
 		KeepTempDirs:            p.KeepTempDirs,
+		NoopIfInputsMatch:       noopIfInputsMatch,
 		OutDir:                  mergeDir,
 		Prompt:                  p.Prompt,
 		Prompter:                p.Prompter,
@@ -438,6 +428,12 @@ func upgrade(ctx context.Context, p *Params, absManifestPath string, oldManifest
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed rendering template: %w", err)
+	}
+	if renderResult.NoopInputsMatched {
+		return &ManifestResult{
+			Type:   AlreadyUpToDate,
+			DLMeta: dlMeta,
+		}, nil
 	}
 
 	newManifest, _, err := loadManifest(ctx, p.FS, filepath.Join(mergeDir, renderResult.ManifestPath))
@@ -473,6 +469,35 @@ func upgrade(ctx context.Context, p *Params, absManifestPath string, oldManifest
 		NonConflicts:   nonConflicts,
 		Type:           resultType,
 	}, nil
+}
+
+// Returns a map which, if it is equal to the resolve template inputs, will
+// abort the upgrade as a noop. This supports the optional feature where we
+// can cleanly bail out if there is no new template version and also the user's
+// template inputs are the same as before.
+//
+// Returns nil if we don't want to do a noop, because --continue-if-current was
+// true or because there's a new version of the template.
+func inputsForNoopCheck(ctx context.Context, p *Params, templateDir string, oldManifest *manifest.Manifest) (map[string]string, error) {
+	logger := logging.FromContext(ctx).With("logger", "inputsForNoopCheck")
+	if p.ContinueIfCurrent {
+		return nil, nil
+	}
+
+	hashMatch, err := dirhash.Verify(oldManifest.TemplateDirhash.Val, templateDir)
+	if err != nil {
+		return nil, err //nolint:wrapcheck
+	}
+
+	if !hashMatch {
+		logger.InfoContext(ctx, "template dirhash did not match")
+		return nil, nil
+	}
+	logger.InfoContext(ctx, "template dirhash matched")
+
+	// We don't make the noop decision yet, but return a set of inputs that will
+	// conditional cause a noop depending on whether they match the new inputs.
+	return inputsToMap(oldManifest.Inputs), nil
 }
 
 func makeDownloader(ctx context.Context, p *Params, installedDir string, oldManifest *manifest.Manifest) (templatesource.Downloader, error) {


### PR DESCRIPTION
The old behavior was to noop in the case where the upstream template hasn't changed.

The new behavior is to noop in the case where the upstream template hasn't changed, AND the inputs to the template haven't changed. This includes all possible sources of inputs.

Of course this noop'ing can be overwritten with --continue-if-current to still force the upgrade operation to run.